### PR TITLE
Added a podspec

### DIFF
--- a/Charts.podspec
+++ b/Charts.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name = "Charts"
+  s.version = "2.0.9"
+  s.summary = "ios-charts is a powerful & easy to use chart library for iOS"
+  s.homepage = "https://github.com/danielgindi/ios-charts"
+  s.license = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
+  s.authors = "Daniel Cohen Gindi", "Philipp Jahoda"
+  s.ios.deployment_target = "8.0"
+  s.source = { :git => "https://github.com/danielgindi/ios-charts.git", :tag => "v2.0.9" }
+  s.source_files = "Classes", "Charts/Classes/**/*.swift"
+  s.frameworks = "Foundation", "UIKit", "CoreGraphics"
+end


### PR DESCRIPTION
I've added a podspec since I will be using this with cocoapods. I have not pushed it to the repo that manages pods just yet since the current specification is not complete. Cocoapods requires that a version be tagged in order to work properly and be able to distinguish between versions. I have done this in my own fork and used my fork as the source for the pod but I'd like it to point to the original source.

Once you tag a version, I will update this line: `s.source = { :git => "https://github.com/petester42/ios-charts.git", :tag => "0.0.1" }` to point to here and then you can merge.

I also tried making sure carthage support works but the way the current project is setup makes it so that the schemes are not there when running carthage.