### PR TITLE
Add missing UIKit

### DIFF
--- a/Charts/Classes/Components/ChartXAxis.swift
+++ b/Charts/Classes/Components/ChartXAxis.swift
@@ -13,6 +13,7 @@
 //
 
 import Foundation
+import UIKit
 
 public class ChartXAxis: ChartAxisBase
 {


### PR DESCRIPTION
Importing this class into an iOS 7 project raised an error for unresolved
identifier `CGFloat`.

This pull request fixes [the bug](https://github.com/danielgindi/ios-charts/issues/19).