### PR TITLE
Add 'init' to PieChartData to be used from Swift

### DIFF
--- a/Charts/Classes/Data/PieChartData.swift
+++ b/Charts/Classes/Data/PieChartData.swift
@@ -20,7 +20,17 @@ public class PieChartData: ChartData
         super.init();
         
     }
-    
+
+    public override init(xVals: [String]?, dataSets: [ChartDataSet]?)
+    {
+        super.init(xVals: xVals, dataSets: dataSets)
+    }
+
+    public convenience init(xVals: [String]?, dataSet: ChartDataSet?)
+    {
+        self.init(xVals: xVals, dataSets: dataSet === nil ? nil : [dataSet!]);
+    }
+
     var dataSet: PieChartDataSet?
     {
         get


### PR DESCRIPTION
Hey!

We're trying to use your great library from Swift and while we're copying your sample code, we're running into problems because init methods are not inherited in Swift. Since your sample code uses ObjC, maybe that's why it works on ObjC but it doesn't in Swift

You can use this Swift code [https://gist.github.com/jmnavarro/659d29cb3434a0854ae8] (copied from PieCharViewController from your sample) to see why it's necessary

Thanks!
