### PR TITLE
AutoScaling yAxis during panning / zooming

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -24,6 +24,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     private var _pinchZoomEnabled = false
     private var _doubleTapToZoomEnabled = true
     private var _dragEnabled = true
+    private var _autoScaleMinMaxEnabled = false;
     
     private var _scaleXEnabled = true
     private var _scaleYEnabled = true
@@ -153,6 +154,12 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         _leftYAxisRenderer?.renderAxisLine(context: context);
         _rightYAxisRenderer?.renderAxisLine(context: context);
 
+        if (_autoScaleMinMaxEnabled)
+        {
+            calcMinMax();
+            calculateOffsets();
+        }
+        
         // make sure the graph values and grid cannot be drawn outside the content-rect
         CGContextSaveGState(context);
 
@@ -256,6 +263,11 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     internal override func calcMinMax()
     {
+        if (_autoScaleMinMaxEnabled)
+        {
+            _data.calcMinMax(start: lowestVisibleXIndex, end: highestVisibleXIndex);
+        }
+        
         var minLeft = _data.getYMin(.Left);
         var maxLeft = _data.getYMax(.Left);
         var minRight = _data.getYMin(.Right);
@@ -864,7 +876,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
     /// Zooms in or out by the given scale factor. x and y are the coordinates
     /// (in pixels) of the zoom center.
-    /// 
+    ///
     /// :param: scaleX if < 1f --> zoom out, if > 1f --> zoom in
     /// :param: scaleY if < 1f --> zoom out, if > 1f --> zoom in
     /// :param: x
@@ -1470,6 +1482,27 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     {
         return _leftAxis.isInverted || _rightAxis.isInverted;
     }
+    
+    /// flat that indicates if auto scaling on the y axis is enabled.
+    /// if yes, the y axis automatically adjusts to the min and max y values of the current x axis range
+    public var autoScaleMinMaxEnabled: Bool
+        {
+        get
+        {
+            return _autoScaleMinMaxEnabled;
+        }
+        set
+        {
+            if (_autoScaleMinMaxEnabled != newValue)
+            {
+                _autoScaleMinMaxEnabled = newValue;
+            }
+        }
+    }
+    
+    /// returns true if autoScaleMinMax is enabled, false if no
+    /// :default: false
+    public var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled; }
 }
 
 /// Default formatter that calculates the position of the filled line.

--- a/Charts/Classes/Data/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/CandleChartDataSet.swift
@@ -45,7 +45,7 @@ public class CandleChartDataSet: BarLineScatterCandleChartDataSet
         super.init(yVals: yVals, label: label);
     }
     
-    internal override func calcMinMax()
+    internal override func calcMinMax(#start: Int, end: Int)
     {
         if (yVals.count == 0)
         {
@@ -53,19 +53,33 @@ public class CandleChartDataSet: BarLineScatterCandleChartDataSet
         }
         
         var entries = yVals as! [CandleChartDataEntry];
-
-        _yMin = entries[0].low;
-        _yMax = entries[0].high;
-
-        for (var i = 0; i < entries.count; i++)
+        
+        var endValue : Int;
+        
+        if end == 0
+        {
+            endValue = entries.count - 1;
+        }
+        else
+        {
+            endValue = end;
+        }
+        
+        _lastStart = start;
+        _lastEnd = end;
+        
+        _yMin = entries[start].low;
+        _yMax = entries[start].high;
+        
+        for (var i = 0; i <= endValue; i++)
         {
             var e = entries[i];
-
+            
             if (e.low < _yMin)
             {
                 _yMin = e.low;
             }
-
+            
             if (e.high > _yMax)
             {
                 _yMax = e.high;

--- a/Charts/Classes/Data/ChartData.swift
+++ b/Charts/Classes/Data/ChartData.swift
@@ -25,6 +25,8 @@ public class ChartData: NSObject
     internal var _rightAxisMin = Float(0.0)
     private var _yValueSum = Float(0.0)
     private var _yValCount = Int(0)
+    internal var _lastStart = Int(0);
+    internal var _lastEnd = Int(0);
     
     /// the average length (in characters) across all x-value strings
     private var _xValAverageLength = Float(0.0)
@@ -69,7 +71,7 @@ public class ChartData: NSObject
     {
         checkIsLegal(dataSets);
         
-        calcMinMax();
+        calcMinMax(start: _lastStart, end: _lastEnd);
         calcYValueSum();
         calcYValueCount();
         
@@ -120,8 +122,9 @@ public class ChartData: NSObject
     }
     
     /// calc minimum and maximum y value over all datasets
-    internal func calcMinMax()
+    internal func calcMinMax(#start: Int, end: Int)
     {
+        
         if (_dataSets == nil || _dataSets.count < 1)
         {
             _yMax = 0.0;
@@ -129,12 +132,17 @@ public class ChartData: NSObject
         }
         else
         {
+            _lastStart = start;
+            _lastEnd = end;
+            
             // calculate absolute min and max
             _yMin = _dataSets[0].yMin;
             _yMax = _dataSets[0].yMax;
             
             for (var i = 0; i < _dataSets.count; i++)
             {
+                _dataSets[i].calcMinMax(start: start, end: end);
+                
                 if (_dataSets[i].yMin < _yMin)
                 {
                     _yMin = _dataSets[i].yMin;
@@ -552,7 +560,7 @@ public class ChartData: NSObject
         _yValCount -= d.entryCount;
         _yValueSum -= d.yValueSum;
         
-        calcMinMax();
+        calcMinMax(start: _lastStart, end: _lastEnd);
         
         return true;
     }
@@ -629,7 +637,7 @@ public class ChartData: NSObject
             _yValCount -= 1;
             _yValueSum -= val;
             
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
         }
         
         return removed;

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -83,10 +83,24 @@ public class ChartDataSet: NSObject
             return;
         }
         
-        _yMin = yVals[0].value;
-        _yMax = yVals[0].value;
+        var endValue : Int;
         
-        for var i = 0; i < _yVals.count; i++
+        if end == 0
+        {
+            endValue = _yVals.count - 1;
+        }
+        else
+        {
+            endValue = end;
+        }
+        
+        _lastStart = start;
+        _lastEnd = endValue;
+        
+        _yMin = yVals[start].value;
+        _yMax = yVals[start].value;
+        
+        for var i = start; i <= endValue; i++
         {
             let e = _yVals[i];
             if (e.value < _yMin)

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -22,6 +22,8 @@ public class ChartDataSet: NSObject
     internal var _yMax = Float(0.0)
     internal var _yMin = Float(0.0)
     internal var _yValueSum = Float(0.0)
+    internal var _lastStart = 0;
+    internal var _lastEnd = 0;
     public var label = "DataSet"
     public var visible = true;
     public var drawValuesEnabled = true;
@@ -58,7 +60,7 @@ public class ChartDataSet: NSObject
         // default color
         colors.append(UIColor(red: 140.0/255.0, green: 234.0/255.0, blue: 255.0/255.0, alpha: 1.0));
         
-        self.calcMinMax();
+        self.calcMinMax(start: _lastStart, end: _lastEnd);
         self.calcYValueSum();
     }
     
@@ -70,11 +72,11 @@ public class ChartDataSet: NSObject
     /// Use this method to tell the data set that the underlying data has changed
     public func notifyDataSetChanged()
     {
-        calcMinMax();
+        calcMinMax(start: _lastStart, end: _lastEnd);
         calcYValueSum();
     }
     
-    internal func calcMinMax()
+    internal func calcMinMax(#start : Int, end: Int)
     {
         if _yVals!.count == 0
         {
@@ -291,7 +293,7 @@ public class ChartDataSet: NSObject
         if (removed)
         {
             _yValueSum -= entry.value;
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
         }
         
         return removed;
@@ -305,7 +307,7 @@ public class ChartDataSet: NSObject
             var e = _yVals.removeAtIndex(index);
             
             _yValueSum -= e.value;
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
             
             return true;
         }
@@ -348,8 +350,8 @@ public class ChartDataSet: NSObject
         return drawValuesEnabled;
     }
     
-    /// Checks if this DataSet contains the specified Entry. 
-    /// :returns: true if contains the entry, false if not. 
+    /// Checks if this DataSet contains the specified Entry.
+    /// :returns: true if contains the entry, false if not.
     public func contains(e: ChartDataEntry) -> Bool
     {
         for entry in _yVals
@@ -367,6 +369,8 @@ public class ChartDataSet: NSObject
     public func clear()
     {
         _yVals.removeAll(keepCapacity: true);
+        _lastStart = 0;
+        _lastEnd = 0;
         notifyDataSetChanged();
     }
 

--- a/Charts/Classes/Data/CombinedChartData.swift
+++ b/Charts/Classes/Data/CombinedChartData.swift
@@ -47,7 +47,7 @@ public class CombinedChartData: BarLineScatterCandleChartData
             
             checkIsLegal(newValue.dataSets);
             
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
             calcYValueSum();
             calcYValueCount();
             
@@ -71,7 +71,7 @@ public class CombinedChartData: BarLineScatterCandleChartData
             
             checkIsLegal(newValue.dataSets);
             
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
             calcYValueSum();
             calcYValueCount();
             
@@ -95,7 +95,7 @@ public class CombinedChartData: BarLineScatterCandleChartData
             
             checkIsLegal(newValue.dataSets);
             
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
             calcYValueSum();
             calcYValueCount();
         
@@ -119,7 +119,7 @@ public class CombinedChartData: BarLineScatterCandleChartData
             
             checkIsLegal(newValue.dataSets);
             
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
             calcYValueSum();
             calcYValueCount();
             
@@ -143,7 +143,7 @@ public class CombinedChartData: BarLineScatterCandleChartData
             
             checkIsLegal(newValue.dataSets);
             
-            calcMinMax();
+            calcMinMax(start: _lastStart, end: _lastEnd);
             calcYValueSum();
             calcYValueCount();
             


### PR DESCRIPTION
This adds the auto scaling we've talked about in #89 . There is an issue that I haven't been able to solve yet, though. Sometimes during panning, the chart is kind of stuck in a re-drawing cycle which. I've got no idea why this is happening, but maybe you've got an idea, so please don't merge this as it is.

With autoscaling enabled, the drawRect method runs about 10% slower for the datasets of the ChartsDemo application. In our finance chart with 250 candles, this slow down isn't noticeable on an actual device.