### PR TITLE
Offset adjustment when drawLabels on the x axis is disabled.

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -374,11 +374,11 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             {
                 offsetRight += rightAxis.requiredSize().width;
             }
-            
-            var xlabelheight = xAxis.labelHeight * 2.0;
-        
-            if (xAxis.isEnabled)
+
+            if (xAxis.isEnabled && xAxis.isDrawLabelsEnabled)
             {
+                var xlabelheight = xAxis.labelHeight * 2.0;
+                
                 // offsets for x-labels
                 if (xAxis.labelPosition == .Bottom)
                 {


### PR DESCRIPTION
As I said in issue #92 the x axis offset doesn't adjust when you disable x axis labels. With this change you can have the x grid without labels but the chart area still fills the entire viewport.