### PR TITLE
Added support for setting a custom width that is wider than the longe…

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1514,6 +1514,33 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// returns true if autoScaleMinMax is enabled, false if no
     /// :default: false
     public var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled; }
+    
+    
+    /// Sets a custom width to the specified y axis.
+    public func setXAxisWidth(which: ChartYAxis.AxisDependency, width: CGFloat)
+    {
+        if (which == .Left)
+        {
+            _leftAxis.setCustomWidth(width);
+        }
+        else
+        {
+            _rightAxis.setCustomWidth(width);
+        }
+    }
+
+    /// Returns the width of the specified y axis.
+    public func getXAxisWidth(which: ChartYAxis.AxisDependency) -> CGFloat
+    {
+        if (which == .Left)
+        {
+            return _leftAxis.requiredSize().width;
+        }
+        else
+        {
+            return _rightAxis.requiredSize().width;
+        }
+    }
 }
 
 /// Default formatter that calculates the position of the filled line.

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -89,6 +89,9 @@ public class ChartYAxis: ChartAxisBase
     /// the side this axis object represents
     private var _axisDependency = AxisDependency.Left
     
+    /// the width the axis should take
+    private var _customWidth = CGFloat(0);
+    
     public override init()
     {
         super.init();
@@ -158,6 +161,7 @@ public class ChartYAxis: ChartAxisBase
         var size = label.sizeWithAttributes([NSFontAttributeName: labelFont]);
         size.width += xOffset * 2.0;
         size.height += yOffset * 2.0;
+        size.width = max(_customWidth, size.width);
         return size;
     }
 
@@ -202,6 +206,12 @@ public class ChartYAxis: ChartAxisBase
         }
     }
 
+    /// Sets a custom width to the axis that can be bigger than the requried size of the longest label. Note: narrower axis widths are not supported.
+    public func setCustomWidth(width: CGFloat)
+    {
+        _customWidth = width;
+    }
+    
     public var isInverted: Bool { return inverted; }
     
     public var isStartAtZeroEnabled: Bool { return startAtZeroEnabled; }


### PR DESCRIPTION
This adds support to set a custom width to an y axis as described in #92 .
Note that this only works with values that are greater than the longest label width. 
It takes the max from the longest label and the custom width.

What do we need this for? If you've got several charts that share the same x values vertically stacked in a view, setting a common y axis width based on the widest y axis not only looks nicer, it also allows you to get away with a single x axis (that is, in case the chart ranges are kept in sync of course).