### PR TITLE
#1 add missing modules while compiling swift project files into Objective-C for iOS 7; #2 fix ChartYAxisRendererRadarChart bug

### DIFF
--- a/Charts/Classes/Data/BubbleChartData.swift
+++ b/Charts/Classes/Data/BubbleChartData.swift
@@ -8,6 +8,8 @@
 //
 //  https://github.com/danielgindi/ios-charts
 //
+import Foundation
+import CoreGraphics.CGBase
 
 public class BubbleChartData: BarLineScatterCandleChartData
 {

--- a/Charts/Classes/Data/BubbleChartDataEntry.swift
+++ b/Charts/Classes/Data/BubbleChartDataEntry.swift
@@ -10,6 +10,7 @@
 //
 
 import Foundation
+import CoreGraphics.CGBase
 
 public class BubbleChartDataEntry: ChartDataEntry
 {

--- a/Charts/Classes/Data/BubbleChartDataSet.swift
+++ b/Charts/Classes/Data/BubbleChartDataSet.swift
@@ -10,7 +10,8 @@
 //
 
 import Foundation
-import CoreGraphics;
+import CoreGraphics
+import UIKit.UIColor
 
 public class BubbleChartDataSet: BarLineScatterCandleChartDataSet
 {

--- a/Charts/Classes/Renderers/BubbleChartRenderer.swift
+++ b/Charts/Classes/Renderers/BubbleChartRenderer.swift
@@ -10,6 +10,8 @@
 //
 
 import Foundation
+import CoreGraphics
+import UIKit.UIColor
 
 @objc
 public protocol BubbleChartRendererDelegate

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -131,14 +131,14 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
     
     public override func renderLimitLines(#context: CGContext)
     {
-        CGContextSaveGState(context);
-        
         var limitLines = _yAxis.limitLines;
         
         if (limitLines.count == 0)
         {
             return;
         }
+        
+        CGContextSaveGState(context);
         
         var sliceangle = _chart.sliceAngle;
         
@@ -184,6 +184,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             CGContextStrokePath(context);
         }
+
         CGContextRestoreGState(context);
     }
 }

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -131,6 +131,8 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
     
     public override func renderLimitLines(#context: CGContext)
     {
+        CGContextSaveGState(context);
+        
         var limitLines = _yAxis.limitLines;
         
         if (limitLines.count == 0)
@@ -182,5 +184,6 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             CGContextStrokePath(context);
         }
+        CGContextRestoreGState(context);
     }
 }


### PR DESCRIPTION
add missing modules regards to issue https://github.com/danielgindi/ios-charts/issues/133