### PR TITLE
Candle chart - make the shadow same color as an increasing/decreasing candle color #122

### DIFF
--- a/Charts/Classes/Data/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/CandleChartDataSet.swift
@@ -28,6 +28,9 @@ public class CandleChartDataSet: BarLineScatterCandleChartDataSet
     /// the color of the shadow line
     public var shadowColor: UIColor?
     
+    /// use candle color for the shadow
+    public var makeShadowSameColorAsCandle = false
+    
     /// color for open <= close
     public var decreasingColor: UIColor?
     

--- a/Charts/Classes/Renderers/CandleStickChartRenderer.swift
+++ b/Charts/Classes/Renderers/CandleStickChartRenderer.swift
@@ -101,7 +101,20 @@ public class CandleStickChartRenderer: ChartDataRendererBase
             
             // draw the shadow
             
-            CGContextSetStrokeColorWithColor(context, (dataSet.shadowColor ?? dataSet.colorAt(j)).CGColor);
+            var shadowColor = dataSet.shadowColor ?? dataSet.colorAt(j);
+            if (dataSet.makeShadowSameColorAsCandle)
+            {
+                if (e.open > e.close)
+                {
+                    shadowColor = dataSet.decreasingColor ?? dataSet.colorAt(j);
+                }
+                else if (e.open < e.close)
+                {
+                    shadowColor = dataSet.increasingColor ?? dataSet.colorAt(j);
+                }
+            }
+            
+            CGContextSetStrokeColorWithColor(context, shadowColor.CGColor);
 
             CGContextStrokeLineSegments(context, _shadowPoints, 2);
             
@@ -115,7 +128,12 @@ public class CandleStickChartRenderer: ChartDataRendererBase
             trans.rectValueToPixel(&_bodyRect);
             
             // draw body differently for increasing and decreasing entry
-            if (e.open >= e.close)
+            
+            if (e.open == e.close) {
+                CGContextSetStrokeColorWithColor(context, shadowColor.CGColor);
+                CGContextStrokeRect(context, _bodyRect);
+            }
+            else if (e.open > e.close)
             {
                 
                 var color = dataSet.decreasingColor ?? dataSet.colorAt(j);


### PR DESCRIPTION
I'm developing a financial app, it is customary to color the candle shadow the same color as the candle itself. e.g. green/red for increasing/decreasing.

On top of that it is customary to draw a horizontal line when the candle height is zero, I've added this feature as well   