### PR TITLE
add NaN check to allow non-digits handling for radar chart

### DIFF
--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 import CoreGraphics
-import UIKit.UIGestureRecognizer
+import UIKit
 
 /// Base class of PieChartView and RadarChartView.
 public class PieRadarChartViewBase: ChartViewBase
@@ -751,6 +751,11 @@ public class PieRadarChartViewBase: ChartViewBase
                     if (self.isKindOfClass(RadarChartView))
                     {
                         dataSetIndex = ChartUtils.closestDataSetIndex(valsAtIndex, value: Double(distance / (self as! RadarChartView).factor), axis: nil);
+                    }
+                    
+                    if (dataSetIndex < 0)
+                    {
+                        return;
                     }
                     
                     var h = ChartHighlight(xIndex: index, dataSetIndex: dataSetIndex);

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -111,11 +111,11 @@ public class ChartDataSet: NSObject
         for (var i = start + 1; i <= endValue; i++)
         {
             let e = _yVals[i];
-            if (e.value < _yMin)
+            if (!e.value.isNaN && e.value < _yMin)
             {
                 _yMin = e.value;
             }
-            if (e.value > _yMax)
+            if (!e.value.isNaN && e.value > _yMax)
             {
                 _yMax = e.value;
             }

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -105,10 +105,10 @@ public class ChartDataSet: NSObject
         _lastStart = start;
         _lastEnd = endValue;
         
-        _yMin = yVals[start].value;
-        _yMax = yVals[start].value;
+        _yMin = DBL_MAX;
+        _yMax = DBL_MIN;
         
-        for (var i = start + 1; i <= endValue; i++)
+        for (var i = start; i <= endValue; i++)
         {
             let e = _yVals[i];
             if (!e.value.isNaN && e.value < _yMin)

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -54,6 +54,12 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             interval = floor(10 * intervalMagnitude);
         }
         
+        // clean old values
+        if (_yAxis.entries.count > 0)
+        {
+            _yAxis.entries.removeAll(keepCapacity: false);
+        }
+        
         // if the labels should only show min and max
         if (_yAxis.isShowOnlyMinMaxEnabled)
         {

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -70,6 +70,11 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         else
         {
             var first = ceil(Double(yMin) / interval) * interval;
+            if (first.isSignMinus)
+            {
+                first = -first;
+            }
+            
             var last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval);
             
             var f: Double;

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -59,6 +59,8 @@ public class RadarChartRenderer: ChartDataRendererBase
         var entries = dataSet.yVals;
         
         var path = CGPathCreateMutable();
+        
+        var hasMovedToPoint = false;
 
         for (var j = 0; j < entries.count; j++)
         {
@@ -71,9 +73,10 @@ public class RadarChartRenderer: ChartDataRendererBase
                 continue
             }
             
-            if (j == 0)
+            if (!hasMovedToPoint)
             {
                 CGPathMoveToPoint(path, nil, p.x, p.y);
+                hasMovedToPoint = true;
             }
             else
             {

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -66,6 +66,11 @@ public class RadarChartRenderer: ChartDataRendererBase
             
             var p = ChartUtils.getPosition(center: center, dist: CGFloat(e.value - _chart.chartYMin) * factor, angle: sliceangle * CGFloat(j) + _chart.rotationAngle);
             
+            if (p.x.isNaN || p.y.isNaN)
+            {
+                continue
+            }
+            
             if (j == 0)
             {
                 CGPathMoveToPoint(path, nil, p.x, p.y);
@@ -272,6 +277,11 @@ public class RadarChartRenderer: ChartDataRendererBase
 
             var p = ChartUtils.getPosition(center: center, dist: CGFloat(y) * factor,
                 angle: sliceangle * CGFloat(j) + _chart.rotationAngle);
+            
+            if (p.x.isNaN || p.y.isNaN)
+            {
+                continue;
+            }
             
             _lineSegments[0] = CGPoint(x: p.x, y: 0.0)
             _lineSegments[1] = CGPoint(x: p.x, y: viewPortHandler.chartHeight)


### PR DESCRIPTION
The background is that not every data in every dataSet is valid number in real life.

add NaN check to allow non-digits handleing. if a CGPoint contains NaN, simply ignore it, this will ignore current point and continue the path with next valid point.

This is helpful, where dataSet 1 contains invalid data but dataSet 2 has valid data. People can have a chance to insert NaN if user found the data is nil/null/NSNotFound/ifinity/DOUBLE_MAX.... any number that cannot be drawn on screen or even exists in real life, and still get the chart.

for example, 

xValues: [1,2,3,4,5]
dataSet 1: [5,6,NaN,8,9]
dataSet 2: [11,12,13,14,15]

With NaN support, the radar chart will connect dataSet 1 values: 5-6-8-9 as a web, and dataSet 2 as 11-12-13-14-15 as another web.

**Attention:**
I only add the code for radar chart, since I am more familiar with it and gives the demo. If it is a valid scenario, you can expand it to other charts accordingly.