### PR TITLE
fix radar chart negative value rendering bug if startAtZeroEnabled is false for issue #166

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -216,11 +216,11 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         {
             renderer?.drawHighlighted(context: context, indices: _indicesToHightlight);
         }
-
-        // Removes clipping rectangle
-        CGContextRestoreGState(context);
         
         renderer!.drawExtras(context: context);
+        
+        // Removes clipping rectangle
+        CGContextRestoreGState(context);
         
         _xAxisRenderer.renderAxisLabels(context: context);
         _leftYAxisRenderer.renderAxisLabels(context: context);

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -230,6 +230,11 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             pt.x = fixedPosition
             pt.y += offset
             
+            if (pt.y > viewPortHandler.contentRect.height)
+            {
+                continue
+            }
+            
             ChartUtils.drawText(context: context, text: text, point: pt, align: textAlign, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -150,7 +150,11 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         var labelFont = _yAxis.labelFont
         var labelTextColor = _yAxis.labelTextColor
         
-        for (var i = 0; i < _yAxis.entryCount; i++)
+        var labelWidth = _yAxis.requiredSize().width
+        
+        var modulus = Int(ceil((CGFloat(_yAxis.entryCount) * labelWidth) / (viewPortHandler.contentWidth * viewPortHandler.touchMatrix.a)))
+        
+        for (var i = 0; i < _yAxis.entryCount; i += modulus)
         {
             var text = _yAxis.getFormattedLabel(i)
             

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -159,6 +159,11 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
                 return
             }
             
+            if (positions[i].x < viewPortHandler.contentRect.origin.x)
+            {
+                continue
+            }
+            
             ChartUtils.drawText(context: context, text: text, point: CGPoint(x: positions[i].x, y: fixedPosition - offset), align: .Center, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -69,7 +69,20 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         }
         else
         {
-            var first = ceil(Double(yMin) / interval) * interval;
+            var rawValue = Double(yMin) / interval;
+            
+            var first: Double;
+            
+            // if raw value is like -0.35, ceil it will be 0, so use -1 instead
+            if (rawValue > -1 && rawValue < 0)
+            {
+                first = -interval;
+            }
+            else
+            {
+                first = ceil(Double(yMin) / interval) * interval;
+            }
+            
             if (first == 0.0 && first.isSignMinus)
             {
                 first = -first;
@@ -103,6 +116,8 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         }
         
         _yAxis.axisMaximum = _yAxis.entries[_yAxis.entryCount - 1];
+        // set axisMinimum to be the minimum value.
+        _yAxis.axisMinimum = _yAxis.entries[0];
         _yAxis.axisRange = abs(_yAxis.axisMaximum - _yAxis.axisMinimum);
     }
     

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -73,10 +73,10 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             var first: Double;
             
-            // if raw value is like -0.35, ceil it will be 0, so use -1 instead
-            if (rawValue > -1 && rawValue < 0)
+            // if raw value negative, we need to minus 1.
+            if (rawValue < 0)
             {
-                first = -interval;
+                first = floor(rawValue) * interval;
             }
             else
             {


### PR DESCRIPTION
For issue #166 
we have to check if Double(yMin) / interval will be  -1<x<0, if this is the case, ceil(x) would be 0. but I think we need it to be -1.

In order to render the negative values correctly, 
```swift
 _yAxis.axisMinimum = _yAxis.entries[0];
```
is the key. 

I have been thinking about different ways to fix. But I was suddenly realized the whole reason is the axisMinimum is not changed while the entries have been modified. Add this line solved my problem, and other radar charts remain good on my side. So I think this should be the correct way to fix it.

@danielgindi you must double check here, because I am not sure if you missed to set it, or you intend not to set _yAxis.axisMinimum.