### PR TITLE
The line charts have started to properly display balloon markers

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1314,10 +1314,9 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     {
         var vals = [ChartSelectionDetail]();
 
-        var pt = CGPoint();
-
         for (var i = 0, count = _data.dataSetCount; i < count; i++)
         {
+            var pt = CGPoint();
             var dataSet = _data.getDataSetByIndex(i);
             if (dataSet === nil || !dataSet.isHighlightEnabled)
             {


### PR DESCRIPTION
I would like to display several sequential data sets on the same line chart (two data sets are sequential if the last element of the 1st set is also the first element of the 2nd one e.g. [1,2,3] and [3,4,5]); unfortunately, set up so, the line chart stops properly display balloon markers (they appear only over some points of the plot). The attached commit fixes the described issue.