### PR TITLE
fix radar chart negative value rendering bug if startAtZeroEnabled is false for issue #166

### DIFF
--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -96,7 +96,17 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             }
             else
             {
-                var first = ceil(Double(yMin) / interval) * interval
+                var rawValue = Double(yMin) / interval
+                var first: Double;
+                // if raw value negative, we need to use floor rather than ceil
+                if (rawValue < 0)
+                {
+                    first = floor(rawValue) * interval
+                }
+                else
+                {
+                    first = ceil(Double(yMin) / interval) * interval
+                }
                 
                 if (first == 0.0)
                 { // Fix for IEEE negative zero case (Where value == -0.0, and 0.0 == -0.0)
@@ -132,6 +142,8 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         }
         
         _yAxis.axisMaximum = _yAxis.entries[_yAxis.entryCount - 1]
+        // set axisMinimum to be the minimum value.
+        _yAxis.axisMinimum = _yAxis.entries[0]
         _yAxis.axisRange = abs(_yAxis.axisMaximum - _yAxis.axisMinimum)
     }
     


### PR DESCRIPTION
For issue #166
we have to check if Double(yMin) / interval will be -1<x<0, if this is the case, ceil(x) would be 0. but I think we need it to be -1.

negative values using ceil is not correct, I think. This will lead the minimum value is larger than the data values, like if I have -0.5 , 1 , it calculate as [0,1], not [-1,1]. (ceil(-0.5) = 0)

In order to render the negative values correctly,

 _yAxis.axisMinimum = _yAxis.entries[0];

is the key.

I have been thinking about different ways to fix. But I was suddenly realized the whole reason is the axisMinimum is not changed while the entries have been modified. Add this line solved my problem, and other radar charts remain good on my side. So I think this should be the correct way to fix it.

@danielgindi you must double check here, because I am not sure if you missed to set it, or you intend not to set _yAxis.axisMinimum.
