### PR TITLE
renderExtras is inside the chart contentRect, so renderExtras should be clipped

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -216,11 +216,11 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         {
             renderer?.drawHighlighted(context: context, indices: _indicesToHightlight)
         }
-
-        // Removes clipping rectangle
-        CGContextRestoreGState(context)
         
         renderer!.drawExtras(context: context)
+        
+        // Removes clipping rectangle
+        CGContextRestoreGState(context)
         
         _xAxisRenderer.renderAxisLabels(context: context)
         _leftYAxisRenderer.renderAxisLabels(context: context)


### PR DESCRIPTION
When I tried to add something more in renderExtras, it will draw outside of the chart contentRect. I think renderExtras should also be clipped. How do you think?