### PR TITLE
when the point of label out of viewPortHandler.contentRect, we should not draw the label

### DIFF
--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -230,6 +230,12 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             pt.x = fixedPosition
             pt.y += offset
             
+            if (pt.y < viewPortHandler.contentRect.origin.y ||
+                pt.y > viewPortHandler.contentRect.height + viewPortHandler.contentRect.origin.y)
+            {
+                continue
+            }
+            
             ChartUtils.drawText(context: context, text: text, point: pt, align: textAlign, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -159,6 +159,12 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
                 return
             }
             
+            if (positions[i].x < viewPortHandler.contentRect.origin.x ||
+                positions[i].x > viewPortHandler.contentRect.size.width + viewPortHandler.contentRect.origin.x)
+            {
+                continue
+            }
+            
             ChartUtils.drawText(context: context, text: text, point: CGPoint(x: positions[i].x, y: fixedPosition - offset), align: .Center, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }


### PR DESCRIPTION
when the point of label out of viewPortHandler.contentRect, we should not draw the label

1.for bar chart, if the label point is out of contentRect vertically, ignore it and continue
2.for horizontal bar chart, if the label point is out of contentRect horizontally, ignore it and continue 