### PR TITLE
Fix for calling PieChartData(xVals: nil, dataSet: dataSet) giving the…

### DIFF
--- a/Charts/Classes/Data/ChartData.swift
+++ b/Charts/Classes/Data/ChartData.swift
@@ -127,7 +127,7 @@ public class ChartData: NSObject
         
         for (var i = 0; i < dataSets.count; i++)
         {
-            if (dataSets[i].yVals.count > _xVals.count)
+            if (_xVals.count != 0 && dataSets[i].yVals.count > _xVals.count)
             {
                 println("One or more of the DataSet Entry arrays are longer than the x-values array of this Data object.")
                 return


### PR DESCRIPTION
… following warning:

"One or more of the DataSet Entry arrays are longer than the x-values array of this Data object."

Cause is that when xVals is used, if it's nil then it is set to an empty array. Later on when it is used, the warning is emitted because `dataSets[i].yVals.count > _xVals.count`