### PR TITLE
try to fix bar chart + Horizontal Bar chart wrong render + highlight position bug for issue #214 and #242.

### DIFF
--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -55,17 +55,7 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
         // extend xDelta to make space for multiple datasets (if ther are one)
         _deltaX *= CGFloat(_data.dataSetCount)
         
-        var maxEntry = 0
-        
-        for (var i = 0, count = barData.dataSetCount; i < count; i++)
-        {
-            var set = barData.getDataSetByIndex(i)
-            
-            if (maxEntry < set!.entryCount)
-            {
-                maxEntry = set!.entryCount
-            }
-        }
+        var maxEntry = barData.xValCount
         
         var groupSpace = barData.groupSpace
         _deltaX += CGFloat(maxEntry) * groupSpace

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -467,9 +467,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         {
             var bd = _data as! BarChartData
             var space = bd.groupSpace
-            var j = _data.getDataSetByIndex(dataSetIndex)!.entryIndex(entry: entry, isEqual: true)
             
-            var x = CGFloat(j * (_data.dataSetCount - 1) + dataSetIndex) + space * CGFloat(j) + space / 2.0
+            var x = CGFloat(entry.xIndex * (_data.dataSetCount - 1) + dataSetIndex) + space * CGFloat(entry.xIndex) + space / 2.0
             
             xPos += x
             

--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -92,8 +92,8 @@ public class BarChartRenderer: ChartDataRendererBase
             var e = entries[j]
             
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + j * dataSetOffset) + CGFloat(index)
-                + groupSpace * CGFloat(j) + groupSpaceHalf
+            var x = CGFloat(e.xIndex + e.xIndex * dataSetOffset) + CGFloat(index)
+                + groupSpace * CGFloat(e.xIndex) + groupSpaceHalf
             var vals = e.values
             
             if (!containsStacks || vals == nil)

--- a/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
+++ b/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
@@ -51,8 +51,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
             var e = entries[j]
             
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + j * dataSetOffset) + CGFloat(index)
-                + groupSpace * CGFloat(j) + groupSpaceHalf
+            var x = CGFloat(e.xIndex + e.xIndex * dataSetOffset) + CGFloat(index)
+                + groupSpace * CGFloat(e.xIndex) + groupSpaceHalf
             let values = e.values
             
             if (!containsStacks || values == nil)

--- a/Charts/Classes/Utils/ChartTransformer.swift
+++ b/Charts/Classes/Utils/ChartTransformer.swift
@@ -142,7 +142,7 @@ public class ChartTransformer: NSObject
             var e = entries[j]
 
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + (j * (setCount - 1)) + dataSet) + space * CGFloat(j) + space / 2.0
+            var x = CGFloat(e.xIndex + (e.xIndex * (setCount - 1)) + dataSet) + space * CGFloat(e.xIndex) + space / 2.0
             var y = e.value
             
             valuePoints.append(CGPoint(x: x, y: CGFloat(y) * phaseY))
@@ -167,7 +167,7 @@ public class ChartTransformer: NSObject
             var e = entries[j]
 
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + (j * (setCount - 1)) + dataSet) + space * CGFloat(j) + space / 2.0
+            var x = CGFloat(e.xIndex + (e.xIndex * (setCount - 1)) + dataSet) + space * CGFloat(e.xIndex) + space / 2.0
             var y = e.value
             
             valuePoints.append(CGPoint(x: CGFloat(y) * phaseY, y: x))


### PR DESCRIPTION
Alright, I managed to squash commits and merge v2.1.2 and #221. I will paste old message from #221 below.

Try to fix wrong position bug. use entry.xIndex instead of j of dataSet.entryCount to calculate the offset and position. Issue #214 + #242

The idea is, because not every xIndex will have a dataEntry, if the data is invalid (nil/nan/null), the entryCount will be less than xValsCount.

For example, xVals: [0,1,2,3,4,5,6,7,8,9,10], if there are two dataSets, like below:
xIndex:0 value:100, xIndex:10 value:200
xIndex:0 value:1000, xIndex:10 value:2000

Current logic will use entryCount instead of xValsCount to calculate the matrix and position, which will lead to shorter xPosition value on xAxis. issue #214 has the screenshot.

What I changed is I always use xValsCount and actual xIndex value to calculate.

@danielgindi There might be something I missed if I am not correct. On the other hand, if you think I am right, I would also miss places to apply the new logic, because while I am testing, I found I missed to change getMarkerPosition. There could be more.

merge from upstream master (+3 squashed commits)

Squashed commits:
[c861fea] add fix for horizontal bar chart
[2f75778] apply the same logic for getMarkerPosition
[baca6dd] try to fix wrong position bug. use entry.xIndex instead of j of dataSet.entryCount to calculate the offset and position