### PR TITLE
Swift 2.0 XCode 7 beta 5 -  "self.dynamicType.allocWithZone(zone)"  cannot complie

### DIFF
--- a/Charts/Charts.xcodeproj/project.pbxproj
+++ b/Charts/Charts.xcodeproj/project.pbxproj
@@ -417,7 +417,8 @@
 		5BA8EC371A9D14DC00CE82E1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = dcg;
 				TargetAttributes = {
 					5BA8EC3F1A9D14DC00CE82E1 = {
@@ -565,6 +566,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -639,6 +641,7 @@
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -655,6 +658,7 @@
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};

--- a/Charts/Charts.xcodeproj/xcshareddata/xcschemes/Charts.xcscheme
+++ b/Charts/Charts.xcodeproj/xcshareddata/xcschemes/Charts.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -52,6 +52,8 @@
             ReferencedContainer = "container:Charts.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -61,6 +63,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Charts/Classes/Animation/ChartAnimator.swift
+++ b/Charts/Classes/Animation/ChartAnimator.swift
@@ -146,7 +146,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingX: an easing function for the animation on the x axis
@@ -179,7 +179,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOptionX: the easing function for the animation on the x axis
@@ -190,7 +190,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
@@ -200,7 +200,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
@@ -210,7 +210,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval)
@@ -219,7 +219,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easing: an easing function for the animation
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
@@ -228,7 +228,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easingOption: the easing function for the animation
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
@@ -237,7 +237,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval)
     {
@@ -245,7 +245,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
     public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
@@ -254,7 +254,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
     public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
@@ -263,7 +263,7 @@ public class ChartAnimator: NSObject
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     public func animate(yAxisDuration yAxisDuration: NSTimeInterval)
     {

--- a/Charts/Classes/Animation/ChartAnimator.swift
+++ b/Charts/Classes/Animation/ChartAnimator.swift
@@ -85,10 +85,10 @@ public class ChartAnimator: NSObject
     
     private func updateAnimationPhases(currentTime: NSTimeInterval)
     {
-        var elapsedTime: NSTimeInterval = currentTime - _startTime
+        let elapsedTime: NSTimeInterval = currentTime - _startTime
         if (_enabledX)
         {
-            var duration: NSTimeInterval = _xDuration
+            let duration: NSTimeInterval = _xDuration
             var elapsed: NSTimeInterval = elapsedTime
             if (elapsed > duration)
             {
@@ -106,7 +106,7 @@ public class ChartAnimator: NSObject
         }
         if (_enabledY)
         {
-            var duration: NSTimeInterval = _yDuration
+            let duration: NSTimeInterval = _yDuration
             var elapsed: NSTimeInterval = elapsedTime
             if (elapsed > duration)
             {
@@ -126,7 +126,7 @@ public class ChartAnimator: NSObject
     
     @objc private func animationLoop()
     {
-        var currentTime: NSTimeInterval = CACurrentMediaTime()
+        let currentTime: NSTimeInterval = CACurrentMediaTime()
         
         updateAnimationPhases(currentTime)
         
@@ -147,11 +147,11 @@ public class ChartAnimator: NSObject
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingX an easing function for the animation on the x axis
-    /// :param: easingY an easing function for the animation on the y axis
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingX: an easing function for the animation on the x axis
+    /// - parameter easingY: an easing function for the animation on the y axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
     {
         stop()
         
@@ -180,92 +180,92 @@ public class ChartAnimator: NSObject
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingOptionX the easing function for the animation on the x axis
-    /// :param: easingOptionY the easing function for the animation on the y axis
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingOptionX: the easing function for the animation on the x axis
+    /// - parameter easingOptionY: the easing function for the animation on the y axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easingFunctionFromOption(easingOptionX), easingY: easingFunctionFromOption(easingOptionY))
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easing an easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easing: an easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easing, easingY: easing)
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingOption the easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingOption: the easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOption: .EaseInOutSine)
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: easing an easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter easing: an easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: 0.0, easing: easing)
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: easingOption the easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter easingOption: the easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: 0.0, easing: easingFunctionFromOption(easingOption))
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    public func animate(#xAxisDuration: NSTimeInterval)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: 0.0, easingOption: .EaseInOutSine)
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easing an easing function for the animation
-    public func animate(#yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easing: an easing function for the animation
+    public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
     {
         animate(xAxisDuration: 0.0, yAxisDuration: yAxisDuration, easing: easing)
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingOption the easing function for the animation
-    public func animate(#yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingOption: the easing function for the animation
+    public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: 0.0, yAxisDuration: yAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: yAxisDuration duration for animating the y axis
-    public func animate(#yAxisDuration: NSTimeInterval)
+    /// - parameter yAxisDuration: duration for animating the y axis
+    public func animate(yAxisDuration yAxisDuration: NSTimeInterval)
     {
         animate(xAxisDuration: 0.0, yAxisDuration: yAxisDuration, easingOption: .EaseInOutSine)
     }

--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -22,7 +22,7 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
     
     /// if set to true, all values are drawn above their bars, instead of below their top
     private var _drawValueAboveBarEnabled = true
-    
+
     /// if set to true, a grey area is darawn behind each bar that indicates the maximum value
     private var _drawBarShadowEnabled = false
     
@@ -47,7 +47,7 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
             return
         }
         
-        var barData = _data as! BarChartData
+        let barData = _data as! BarChartData
         
         // increase deltax by 1 because the bars have a width of 1
         _deltaX += 0.5
@@ -55,7 +55,7 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
         // extend xDelta to make space for multiple datasets (if ther are one)
         _deltaX *= CGFloat(_data.dataSetCount)
         
-        var groupSpace = barData.groupSpace
+        let groupSpace = barData.groupSpace
         _deltaX += CGFloat(barData.xValCount) * groupSpace
         _chartXMax = Double(_deltaX) - _chartXMin
     }
@@ -65,34 +65,34 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
     {
         if (_dataNotSet || _data === nil)
         {
-            println("Can't select by touch. No data set.")
+            print("Can't select by touch. No data set.", appendNewline: true)
             return nil
         }
         
         return _highlighter?.getHighlight(x: Double(pt.x), y: Double(pt.y))
     }
-    
+        
     /// Returns the bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
     public func getBarBounds(e: BarChartDataEntry) -> CGRect!
     {
-        var set = _data.getDataSetForEntry(e) as! BarChartDataSet!
+        let set = _data.getDataSetForEntry(e) as! BarChartDataSet!
         
         if (set === nil)
         {
             return nil
         }
         
-        var barspace = set.barSpace
-        var y = CGFloat(e.value)
-        var x = CGFloat(e.xIndex)
+        let barspace = set.barSpace
+        let y = CGFloat(e.value)
+        let x = CGFloat(e.xIndex)
         
-        var barWidth: CGFloat = 0.5
+        let barWidth: CGFloat = 0.5
         
-        var spaceHalf = barspace / 2.0
-        var left = x - barWidth + spaceHalf
-        var right = x + barWidth - spaceHalf
-        var top = y >= 0.0 ? y : 0.0
-        var bottom = y <= 0.0 ? y : 0.0
+        let spaceHalf = barspace / 2.0
+        let left = x - barWidth + spaceHalf
+        let right = x + barWidth - spaceHalf
+        let top = y >= 0.0 ? y : 0.0
+        let bottom = y <= 0.0 ? y : 0.0
         
         var bounds = CGRect(x: left, y: top, width: right - left, height: bottom - top)
         
@@ -103,8 +103,8 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
     
     public override var lowestVisibleXIndex: Int
     {
-        var step = CGFloat(_data.dataSetCount)
-        var div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
+        let step = CGFloat(_data.dataSetCount)
+        let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentLeft, y: _viewPortHandler.contentBottom)
         getTransformer(ChartYAxis.AxisDependency.Left).pixelToValue(&pt)
@@ -114,8 +114,8 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
 
     public override var highestVisibleXIndex: Int
     {
-        var step = CGFloat(_data.dataSetCount)
-        var div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
+        let step = CGFloat(_data.dataSetCount)
+        let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentRight, y: _viewPortHandler.contentBottom)
         getTransformer(ChartYAxis.AxisDependency.Left).pixelToValue(&pt)

--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -60,7 +60,7 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
         _chartXMax = Double(_deltaX) - _chartXMin
     }
     
-    /// Returns the Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the BarChart.
+    /// - returns: the Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the BarChart.
     public override func getHighlightByTouchPoint(pt: CGPoint) -> ChartHighlight?
     {
         if (_dataNotSet || _data === nil)
@@ -72,7 +72,7 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
         return _highlighter?.getHighlight(x: Double(pt.x), y: Double(pt.y))
     }
         
-    /// Returns the bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
+    /// - returns: the bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
     public func getBarBounds(e: BarChartDataEntry) -> CGRect!
     {
         let set = _data.getDataSetForEntry(e) as! BarChartDataSet!
@@ -158,13 +158,13 @@ public class BarChartView: BarLineChartViewBase, BarChartRendererDelegate
         }
     }
     
-    /// returns true if drawing the highlighting arrow is enabled, false if not
+    /// - returns: true if drawing the highlighting arrow is enabled, false if not
     public var isDrawHighlightArrowEnabled: Bool { return drawHighlightArrowEnabled; }
     
-    /// returns true if drawing values above bars is enabled, false if not
+    /// - returns: true if drawing values above bars is enabled, false if not
     public var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled; }
     
-    /// returns true if drawing shadows (maxvalue) for each bar is enabled, false if not
+    /// - returns: true if drawing shadows (maxvalue) for each bar is enabled, false if not
     public var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled; }
     
     // MARK: - BarChartRendererDelegate

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -289,8 +289,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         var minRight = _data.getYMin(.Right)
         var maxRight = _data.getYMax(.Right)
         
-        var leftRange = abs(maxLeft - (_leftAxis.isStartAtZeroEnabled ? 0.0 : minLeft))
-        var rightRange = abs(maxRight - (_rightAxis.isStartAtZeroEnabled ? 0.0 : minRight))
+        let leftRange = abs(maxLeft - (_leftAxis.isStartAtZeroEnabled ? 0.0 : minLeft))
+        let rightRange = abs(maxRight - (_rightAxis.isStartAtZeroEnabled ? 0.0 : minRight))
         
         // in case all values are equal
         if (leftRange == 0.0)
@@ -311,10 +311,10 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             }
         }
         
-        var topSpaceLeft = leftRange * Double(_leftAxis.spaceTop)
-        var topSpaceRight = rightRange * Double(_rightAxis.spaceTop)
-        var bottomSpaceLeft = leftRange * Double(_leftAxis.spaceBottom)
-        var bottomSpaceRight = rightRange * Double(_rightAxis.spaceBottom)
+        let topSpaceLeft = leftRange * Double(_leftAxis.spaceTop)
+        let topSpaceRight = rightRange * Double(_rightAxis.spaceTop)
+        let bottomSpaceLeft = leftRange * Double(_leftAxis.spaceBottom)
+        let bottomSpaceRight = rightRange * Double(_rightAxis.spaceBottom)
         
         _chartXMax = Double(_data.xVals.count - 1)
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
@@ -383,7 +383,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                     || _legend.position == .BelowChartRight
                     || _legend.position == .BelowChartCenter)
                 {
-                    var yOffset = _legend.textHeightMax; // It's possible that we do not need this offset anymore as it is available through the extraOffsets
+                    let yOffset = _legend.textHeightMax; // It's possible that we do not need this offset anymore as it is available through the extraOffsets
                     offsetBottom += min(_legend.neededHeight + yOffset, _viewPortHandler.chartHeight * _legend.maxSizePercent)
                 }
             }
@@ -401,7 +401,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
             if (xAxis.isEnabled && xAxis.isDrawLabelsEnabled)
             {
-                var xlabelheight = xAxis.labelHeight * 2.0
+                let xlabelheight = xAxis.labelHeight * 2.0
                 
                 // offsets for x-labels
                 if (xAxis.labelPosition == .Bottom)
@@ -424,7 +424,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             offsetBottom += self.extraBottomOffset
             offsetLeft += self.extraLeftOffset
             
-            var minOffset = CGFloat(10.0)
+            let minOffset = CGFloat(10.0)
             
             _viewPortHandler.restrainViewPort(
                 offsetLeft: max(minOffset, offsetLeft),
@@ -457,7 +457,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    public override func getMarkerPosition(#entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
+    public override func getMarkerPosition(entry entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
     {
         let dataSetIndex = highlight.dataSetIndex
         var xPos = CGFloat(entry.xIndex)
@@ -465,10 +465,10 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         
         if (self.isKindOfClass(BarChartView))
         {
-            var bd = _data as! BarChartData
-            var space = bd.groupSpace
+            let bd = _data as! BarChartData
+            let space = bd.groupSpace
             
-            var x = CGFloat(entry.xIndex * (_data.dataSetCount - 1) + dataSetIndex) + space * CGFloat(entry.xIndex) + space / 2.0
+            let x = CGFloat(entry.xIndex * (_data.dataSetCount - 1) + dataSetIndex) + space * CGFloat(entry.xIndex) + space / 2.0
             
             xPos += x
             
@@ -477,7 +477,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                 if barEntry.values != nil && highlight.range !== nil
                 {
                     yPos = highlight.range!.to
-                }
+        }
             }
         }
         
@@ -490,7 +490,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
     
     /// draws the grid background
-    internal func drawGridBackground(#context: CGContext)
+    internal func drawGridBackground(context context: CGContext)
     {
         if (drawGridBackgroundEnabled || drawBordersEnabled)
         {
@@ -563,7 +563,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         
         if (recognizer.state == UIGestureRecognizerState.Ended)
         {
-            var h = getHighlightByTouchPoint(recognizer.locationInView(self))
+            let h = getHighlightByTouchPoint(recognizer.locationInView(self))
             
             if (h === nil || h!.isEqual(self.lastHighlighted))
             {
@@ -622,8 +622,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                 }
                 else
                 {
-                    var x = abs(recognizer.locationInView(self).x - recognizer.locationOfTouch(1, inView: self).x)
-                    var y = abs(recognizer.locationInView(self).y - recognizer.locationOfTouch(1, inView: self).y)
+                    let x = abs(recognizer.locationInView(self).x - recognizer.locationOfTouch(1, inView: self).x)
+                    let y = abs(recognizer.locationInView(self).y - recognizer.locationOfTouch(1, inView: self).y)
                     
                     if (x > y)
                     {
@@ -650,8 +650,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
         else if (recognizer.state == UIGestureRecognizerState.Changed)
         {
-            var isZoomingOut = (recognizer.scale < 1)
-            var canZoomMoreX = isZoomingOut ? _viewPortHandler.canZoomOutMoreX : _viewPortHandler.canZoomInMoreX
+            let isZoomingOut = (recognizer.scale < 1)
+            let canZoomMoreX = isZoomingOut ? _viewPortHandler.canZoomOutMoreX : _viewPortHandler.canZoomInMoreX
             
             if (_isScaling)
             {
@@ -669,8 +669,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                         location.y = -(_viewPortHandler.chartHeight - location.y - _viewPortHandler.offsetBottom)
                     }
                     
-                    var scaleX = (_gestureScaleAxis == .Both || _gestureScaleAxis == .X) && _scaleXEnabled ? recognizer.scale : 1.0
-                    var scaleY = (_gestureScaleAxis == .Both || _gestureScaleAxis == .Y) && _scaleYEnabled ? recognizer.scale : 1.0
+                    let scaleX = (_gestureScaleAxis == .Both || _gestureScaleAxis == .X) && _scaleXEnabled ? recognizer.scale : 1.0
+                    let scaleY = (_gestureScaleAxis == .Both || _gestureScaleAxis == .Y) && _scaleYEnabled ? recognizer.scale : 1.0
                     
                     var matrix = CGAffineTransformMakeTranslation(location.x, location.y)
                     matrix = CGAffineTransformScale(matrix, scaleX, scaleY)
@@ -704,7 +704,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                 
                 _closestDataSetToTouch = getDataSetByTouchPoint(recognizer.locationOfTouch(0, inView: self))
                 
-                var translation = recognizer.translationInView(self)
+                let translation = recognizer.translationInView(self)
                 
                 if (!performPanChange(translation: translation))
                 {
@@ -731,8 +731,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         {
             if (_isDragging)
             {
-                var originalTranslation = recognizer.translationInView(self)
-                var translation = CGPoint(x: originalTranslation.x - _lastPanPoint.x, y: originalTranslation.y - _lastPanPoint.y)
+                let originalTranslation = recognizer.translationInView(self)
+                let translation = CGPoint(x: originalTranslation.x - _lastPanPoint.x, y: originalTranslation.y - _lastPanPoint.y)
                 
                 performPanChange(translation: translation)
                 
@@ -740,7 +740,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             }
             else if (isHighlightPerDragEnabled)
             {
-                var h = getHighlightByTouchPoint(recognizer.locationInView(self))
+                let h = getHighlightByTouchPoint(recognizer.locationInView(self))
                 
                 let lastHighlighted = self.lastHighlighted
                 
@@ -779,7 +779,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    private func performPanChange(var #translation: CGPoint) -> Bool
+    private func performPanChange(var translation translation: CGPoint) -> Bool
     {
         if (isAnyAxisInverted && _closestDataSetToTouch !== nil
             && getAxis(_closestDataSetToTouch.axisDependency).isInverted)
@@ -794,7 +794,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             }
         }
         
-        var originalMatrix = _viewPortHandler.touchMatrix
+        let originalMatrix = _viewPortHandler.touchMatrix
         
         var matrix = CGAffineTransformMakeTranslation(translation.x, translation.y)
         matrix = CGAffineTransformConcat(originalMatrix, matrix)
@@ -821,14 +821,14 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     @objc private func decelerationLoop()
     {
-        var currentTime = CACurrentMediaTime()
+        let currentTime = CACurrentMediaTime()
         
         _decelerationVelocity.x *= self.dragDecelerationFrictionCoef
         _decelerationVelocity.y *= self.dragDecelerationFrictionCoef
         
-        var timeInterval = CGFloat(currentTime - _decelerationLastTime)
+        let timeInterval = CGFloat(currentTime - _decelerationLastTime)
         
-        var distance = CGPoint(
+        let distance = CGPoint(
             x: _decelerationVelocity.x * timeInterval,
             y: _decelerationVelocity.y * timeInterval
         )
@@ -909,7 +909,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             
             if (foundScrollView !== nil)
             {
-                for scrollRecognizer in foundScrollView!.gestureRecognizers as! [UIGestureRecognizer]
+                for scrollRecognizer in foundScrollView!.gestureRecognizers!
                 {
                     if (scrollRecognizer.isKindOfClass(UIPanGestureRecognizer))
                     {
@@ -935,7 +935,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// Zooms in by 1.4, into the charts center. center.
     public func zoomIn()
     {
-        var matrix = _viewPortHandler.zoomIn(x: self.bounds.size.width / 2.0, y: -(self.bounds.size.height / 2.0))
+        let matrix = _viewPortHandler.zoomIn(x: self.bounds.size.width / 2.0, y: -(self.bounds.size.height / 2.0))
         _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
         
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
@@ -946,7 +946,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// Zooms out by 0.7, from the charts center. center.
     public func zoomOut()
     {
-        var matrix = _viewPortHandler.zoomOut(x: self.bounds.size.width / 2.0, y: -(self.bounds.size.height / 2.0))
+        let matrix = _viewPortHandler.zoomOut(x: self.bounds.size.width / 2.0, y: -(self.bounds.size.height / 2.0))
         _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
         
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
@@ -957,13 +957,13 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// Zooms in or out by the given scale factor. x and y are the coordinates
     /// (in pixels) of the zoom center.
     ///
-    /// :param: scaleX if < 1 --> zoom out, if > 1 --> zoom in
-    /// :param: scaleY if < 1 --> zoom out, if > 1 --> zoom in
-    /// :param: x
-    /// :param: y
+    /// - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
+    /// - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
+    /// - parameter x:
+    /// - parameter y:
     public func zoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat)
     {
-        var matrix = _viewPortHandler.zoom(scaleX: scaleX, scaleY: scaleY, x: x, y: -y)
+        let matrix = _viewPortHandler.zoom(scaleX: scaleX, scaleY: scaleY, x: x, y: -y)
         _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
         
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
@@ -974,7 +974,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// Resets all zooming and dragging and makes the chart fit exactly it's bounds.
     public func fitScreen()
     {
-        var matrix = _viewPortHandler.fitScreen()
+        let matrix = _viewPortHandler.fitScreen()
         _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
         
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
@@ -993,7 +993,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// If this is e.g. set to 10, no more than 10 values on the x-axis can be viewed at once without scrolling.
     public func setVisibleXRangeMaximum(maxXRange: CGFloat)
     {
-        var xScale = _deltaX / maxXRange
+        let xScale = _deltaX / maxXRange
         _viewPortHandler.setMinimumScaleX(xScale)
     }
     
@@ -1001,27 +1001,27 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// If this is e.g. set to 10, no more than 10 values on the x-axis can be viewed at once without scrolling.
     public func setVisibleXRangeMinimum(minXRange: CGFloat)
     {
-        var xScale = _deltaX / minXRange
+        let xScale = _deltaX / minXRange
         _viewPortHandler.setMaximumScaleX(xScale)
     }
 
     /// Limits the maximum and minimum value count that can be visible by pinching and zooming.
     /// e.g. minRange=10, maxRange=100 no less than 10 values and no more that 100 values can be viewed
     /// at once without scrolling
-    public func setVisibleXRange(#minXRange: CGFloat, maxXRange: CGFloat)
+    public func setVisibleXRange(minXRange minXRange: CGFloat, maxXRange: CGFloat)
     {
-        var maxScale = _deltaX / minXRange
-        var minScale = _deltaX / maxXRange
+        let maxScale = _deltaX / minXRange
+        let minScale = _deltaX / maxXRange
         _viewPortHandler.setMinMaxScaleX(minScaleX: minScale, maxScaleX: maxScale)
     }
     
     /// Sets the size of the area (range on the y-axis) that should be maximum visible at once.
     /// 
-    /// :param: yRange
-    /// :param: axis - the axis for which this limit should apply
+    /// - parameter yRange:
+    /// - parameter axis: - the axis for which this limit should apply
     public func setVisibleYRangeMaximum(maxYRange: CGFloat, axis: ChartYAxis.AxisDependency)
     {
-        var yScale = getDeltaY(axis) / maxYRange
+        let yScale = getDeltaY(axis) / maxYRange
         _viewPortHandler.setMinimumScaleY(yScale)
     }
 
@@ -1043,13 +1043,13 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
     /// Centers the viewport to the specified y-value on the y-axis.
     /// 
-    /// :param: yValue
-    /// :param: axis - which axis should be used as a reference for the y-axis
+    /// - parameter yValue:
+    /// - parameter axis: - which axis should be used as a reference for the y-axis
     public func moveViewToY(yValue: CGFloat, axis: ChartYAxis.AxisDependency)
     {
         if (_viewPortHandler.hasChartDimens)
         {
-            var valsInView = getDeltaY(axis) / _viewPortHandler.scaleY
+            let valsInView = getDeltaY(axis) / _viewPortHandler.scaleY
             
             var pt = CGPoint(x: 0.0, y: yValue + valsInView / 2.0)
             
@@ -1064,14 +1064,14 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
     /// This will move the left side of the current viewport to the specified x-index on the x-axis, and center the viewport to the specified y-value on the y-axis.
     /// 
-    /// :param: xIndex
-    /// :param: yValue
-    /// :param: axis - which axis should be used as a reference for the y-axis
-    public func moveViewTo(#xIndex: Int, yValue: CGFloat, axis: ChartYAxis.AxisDependency)
+    /// - parameter xIndex:
+    /// - parameter yValue:
+    /// - parameter axis: - which axis should be used as a reference for the y-axis
+    public func moveViewTo(xIndex xIndex: Int, yValue: CGFloat, axis: ChartYAxis.AxisDependency)
     {
         if (_viewPortHandler.hasChartDimens)
         {
-            var valsInView = getDeltaY(axis) / _viewPortHandler.scaleY
+            let valsInView = getDeltaY(axis) / _viewPortHandler.scaleY
             
             var pt = CGPoint(x: CGFloat(xIndex), y: yValue + valsInView / 2.0)
             
@@ -1086,15 +1086,15 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     /// This will move the center of the current viewport to the specified x-index and y-value.
     ///
-    /// :param: xIndex
-    /// :param: yValue
-    /// :param: axis - which axis should be used as a reference for the y-axis
-    public func centerViewTo(#xIndex: Int, yValue: CGFloat, axis: ChartYAxis.AxisDependency)
+    /// - parameter xIndex:
+    /// - parameter yValue:
+    /// - parameter axis: - which axis should be used as a reference for the y-axis
+    public func centerViewTo(xIndex xIndex: Int, yValue: CGFloat, axis: ChartYAxis.AxisDependency)
     {
         if (_viewPortHandler.hasChartDimens)
         {
-            var valsInView = getDeltaY(axis) / _viewPortHandler.scaleY
-            var xsInView = CGFloat(xAxis.values.count) / _viewPortHandler.scaleX
+            let valsInView = getDeltaY(axis) / _viewPortHandler.scaleY
+            let xsInView = CGFloat(xAxis.values.count) / _viewPortHandler.scaleX
             
             var pt = CGPoint(x: CGFloat(xIndex) - xsInView / 2.0, y: yValue + valsInView / 2.0)
             
@@ -1109,7 +1109,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
     /// Sets custom offsets for the current ViewPort (the offsets on the sides of the actual chart window). Setting this will prevent the chart from automatically calculating it's offsets. Use resetViewPortOffsets() to undo this.
     /// ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING, else use setExtraOffsets(...).
-    public func setViewPortOffsets(#left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
+    public func setViewPortOffsets(left left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         _customViewPortEnabled = true
         
@@ -1258,7 +1258,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    /// :returns: true if zooming via double-tap is enabled false if not.
+    /// - returns: true if zooming via double-tap is enabled false if not.
     /// :default: true
     public var isDoubleTapToZoomEnabled: Bool
     {
@@ -1276,14 +1276,14 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return highlightPerDragEnabled
     }
     
-    /// :returns: true if drawing the grid background is enabled, false if not.
+    /// - returns: true if drawing the grid background is enabled, false if not.
     /// :default: true
     public var isDrawGridBackgroundEnabled: Bool
     {
         return drawGridBackgroundEnabled
     }
     
-    /// :returns: true if drawing the borders rectangle is enabled, false if not.
+    /// - returns: true if drawing the borders rectangle is enabled, false if not.
     /// :default: false
     public var isDrawBordersEnabled: Bool
     {
@@ -1295,10 +1295,10 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     {
         if (_dataNotSet || _data === nil)
         {
-            println("Can't select by touch. No data set.")
+            print("Can't select by touch. No data set.", appendNewline: true)
             return nil
         }
-        
+
         return _highlighter?.getHighlight(x: Double(pt.x), y: Double(pt.y))
     }
 
@@ -1306,7 +1306,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// (encapsulated in a PointD). This method transforms pixel coordinates to
     /// coordinates / values in the chart. This is the opposite method to
     /// getPixelsForValues(...).
-    public func getValueByTouchPoint(var #pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGPoint
+    public func getValueByTouchPoint(var pt pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGPoint
     {
         getTransformer(axis).pixelToValue(&pt)
 
@@ -1326,7 +1326,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
     /// returns the y-value at the given touch position (must not necessarily be
     /// a value contained in one of the datasets)
-    public func getYValueByTouchPoint(#pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGFloat
+    public func getYValueByTouchPoint(pt pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGFloat
     {
         return getValueByTouchPoint(pt: pt, axis: axis).y
     }
@@ -1334,7 +1334,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// returns the Entry object displayed at the touched position of the chart
     public func getEntryByTouchPoint(pt: CGPoint) -> ChartDataEntry!
     {
-        var h = getHighlightByTouchPoint(pt)
+        let h = getHighlightByTouchPoint(pt)
         if (h !== nil)
         {
             return _data!.getEntryForHighlight(h!)
@@ -1345,7 +1345,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     ///returns the DataSet object displayed at the touched position of the chart
     public func getDataSetByTouchPoint(pt: CGPoint) -> BarLineScatterCandleChartDataSet!
     {
-        var h = getHighlightByTouchPoint(pt)
+        let h = getHighlightByTouchPoint(pt)
         if (h !== nil)
         {
             return _data.getDataSetByIndex(h!.dataSetIndex) as! BarLineScatterCandleChartDataSet!
@@ -1460,12 +1460,12 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         _viewPortHandler.setDragOffsetY(offset)
     }
 
-    /// :returns: true if both drag offsets (x and y) are zero or smaller.
+    /// - returns: true if both drag offsets (x and y) are zero or smaller.
     public var hasNoDragOffset: Bool { return _viewPortHandler.hasNoDragOffset; }
 
     /// The X axis renderer. This is a read-write property so you can set your own custom renderer here.
     /// :default: An instance of ChartXAxisRenderer
-    /// :returns: The current set X axis renderer
+    /// - returns: The current set X axis renderer
     public var xAxisRenderer: ChartXAxisRenderer
     {
         get { return _xAxisRenderer }
@@ -1474,7 +1474,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     /// The left Y axis renderer. This is a read-write property so you can set your own custom renderer here.
     /// :default: An instance of ChartYAxisRenderer
-    /// :returns: The current set left Y axis renderer
+    /// - returns: The current set left Y axis renderer
     public var leftYAxisRenderer: ChartYAxisRenderer
     {
         get { return _leftYAxisRenderer }
@@ -1483,7 +1483,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     /// The right Y axis renderer. This is a read-write property so you can set your own custom renderer here.
     /// :default: An instance of ChartYAxisRenderer
-    /// :returns: The current set right Y axis renderer
+    /// - returns: The current set right Y axis renderer
     public var rightYAxisRenderer: ChartYAxisRenderer
     {
         get { return _rightYAxisRenderer }
@@ -1597,7 +1597,7 @@ internal class BarLineChartFillFormatter: NSObject, ChartFillFormatter
         _chart = chart
     }
     
-    internal func getFillLinePosition(#dataSet: LineChartDataSet, data: LineChartData, chartMaxY: Double, chartMinY: Double) -> CGFloat
+    internal func getFillLinePosition(dataSet dataSet: LineChartDataSet, data: LineChartData, chartMaxY: Double, chartMinY: Double) -> CGFloat
     {
         var fillMin = CGFloat(0.0)
         

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -74,7 +74,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         super.init(frame: frame)
     }
     
-    public required init(coder aDecoder: NSCoder)
+    public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -517,7 +517,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    /// Returns the Transformer class that contains all matrices and is
+    /// - returns: the Transformer class that contains all matrices and is
     /// responsible for transforming values into pixels on the screen and
     /// backwards.
     public func getTransformer(which: ChartYAxis.AxisDependency) -> ChartTransformer
@@ -1136,7 +1136,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
 
     // MARK: - Accessors
 
-    /// Returns the delta-y value (y-value range) of the specified axis.
+    /// - returns: the delta-y value (y-value range) of the specified axis.
     public func getDeltaY(axis: ChartYAxis.AxisDependency) -> CGFloat
     {
         if (axis == .Left)
@@ -1149,7 +1149,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// Returns the position (in pixels) the provided Entry has inside the chart view
+    /// - returns: the position (in pixels) the provided Entry has inside the chart view
     public func getPosition(e: ChartDataEntry, axis: ChartYAxis.AxisDependency) -> CGPoint
     {
         var vals = CGPoint(x: CGFloat(e.xIndex), y: CGFloat(e.value))
@@ -1258,8 +1258,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
+    /// default: true
     /// - returns: true if zooming via double-tap is enabled false if not.
-    /// :default: true
     public var isDoubleTapToZoomEnabled: Bool
     {
         return doubleTapToZoomEnabled
@@ -1270,27 +1270,28 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     /// If set to true, highlighting per dragging over a fully zoomed out chart is enabled
     /// You might want to disable this when using inside a UIScrollView
-    /// :default: true
+    /// 
+    /// default: true
     public var isHighlightPerDragEnabled: Bool
     {
         return highlightPerDragEnabled
     }
     
+    /// default: true
     /// - returns: true if drawing the grid background is enabled, false if not.
-    /// :default: true
     public var isDrawGridBackgroundEnabled: Bool
     {
         return drawGridBackgroundEnabled
     }
     
+    /// default: false
     /// - returns: true if drawing the borders rectangle is enabled, false if not.
-    /// :default: false
     public var isDrawBordersEnabled: Bool
     {
         return drawBordersEnabled
     }
     
-    /// Returns the Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the Line-, Scatter-, or CandleStick-Chart.
+    /// - returns: the Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the Line-, Scatter-, or CandleStick-Chart.
     public func getHighlightByTouchPoint(pt: CGPoint) -> ChartHighlight?
     {
         if (_dataNotSet || _data === nil)
@@ -1302,7 +1303,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return _highlighter?.getHighlight(x: Double(pt.x), y: Double(pt.y))
     }
 
-    /// Returns the x and y values in the chart at the given touch point
+    /// - returns: the x and y values in the chart at the given touch point
     /// (encapsulated in a PointD). This method transforms pixel coordinates to
     /// coordinates / values in the chart. This is the opposite method to
     /// getPixelsForValues(...).
@@ -1324,14 +1325,14 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return pt
     }
 
-    /// returns the y-value at the given touch position (must not necessarily be
+    /// - returns: the y-value at the given touch position (must not necessarily be
     /// a value contained in one of the datasets)
     public func getYValueByTouchPoint(pt pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGFloat
     {
         return getValueByTouchPoint(pt: pt, axis: axis).y
     }
     
-    /// returns the Entry object displayed at the touched position of the chart
+    /// - returns: the Entry object displayed at the touched position of the chart
     public func getEntryByTouchPoint(pt: CGPoint) -> ChartDataEntry!
     {
         let h = getHighlightByTouchPoint(pt)
@@ -1342,7 +1343,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return nil
     }
     
-    ///returns the DataSet object displayed at the touched position of the chart
+    /// - returns: the DataSet object displayed at the touched position of the chart
     public func getDataSetByTouchPoint(pt: CGPoint) -> BarLineScatterCandleChartDataSet!
     {
         let h = getHighlightByTouchPoint(pt)
@@ -1353,7 +1354,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return nil
     }
     
-    /// Returns the lowest x-index (value on the x-axis) that is still visible on he chart.
+    /// - returns: the lowest x-index (value on the x-axis) that is still visible on he chart.
     public var lowestVisibleXIndex: Int
     {
         var pt = CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentBottom)
@@ -1361,7 +1362,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return (pt.x <= 0.0) ? 0 : Int(pt.x + 1.0)
     }
 
-    /// Returns the highest x-index (value on the x-axis) that is still visible on the chart.
+    /// - returns: the highest x-index (value on the x-axis) that is still visible on the chart.
     public var highestVisibleXIndex: Int
     {
         var pt = CGPoint(x: viewPortHandler.contentRight, y: viewPortHandler.contentBottom)
@@ -1369,7 +1370,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return (Int(pt.x) >= _data.xValCount) ? _data.xValCount - 1 : Int(pt.x)
     }
 
-    /// returns the current x-scale factor
+    /// - returns: the current x-scale factor
     public var scaleX: CGFloat
     {
         if (_viewPortHandler === nil)
@@ -1379,7 +1380,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return _viewPortHandler.scaleX
     }
 
-    /// returns the current y-scale factor
+    /// - returns: the current y-scale factor
     public var scaleY: CGFloat
     {
         if (_viewPortHandler === nil)
@@ -1392,18 +1393,18 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     /// if the chart is fully zoomed out, return true
     public var isFullyZoomedOut: Bool { return _viewPortHandler.isFullyZoomedOut; }
 
-    /// Returns the left y-axis object. In the horizontal bar-chart, this is the
+    /// - returns: the left y-axis object. In the horizontal bar-chart, this is the
     /// top axis.
     public var leftAxis: ChartYAxis
     {
         return _leftAxis
     }
 
-    /// Returns the right y-axis object. In the horizontal bar-chart, this is the
+    /// - returns: the right y-axis object. In the horizontal bar-chart, this is the
     /// bottom axis.
     public var rightAxis: ChartYAxis { return _rightAxis; }
 
-    /// Returns the y-axis object to the corresponding AxisDependency. In the
+    /// - returns: the y-axis object to the corresponding AxisDependency. In the
     /// horizontal bar-chart, LEFT == top, RIGHT == BOTTOM
     public func getAxis(axis: ChartYAxis.AxisDependency) -> ChartYAxis
     {
@@ -1417,7 +1418,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// Returns the object representing all x-labels, this method can be used to
+    /// - returns: the object representing all x-labels, this method can be used to
     /// acquire the XAxis object and modify it (e.g. change the position of the
     /// labels)
     public var xAxis: ChartXAxis
@@ -1442,8 +1443,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// returns true if pinch-zoom is enabled, false if not
-    /// :default: false
+    /// default: false
+    /// - returns: true if pinch-zoom is enabled, false if not
     public var isPinchZoomEnabled: Bool { return pinchZoomEnabled; }
 
     /// Set an offset in dp that allows the user to drag the chart over it's
@@ -1500,7 +1501,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         return min(leftAxis.axisMinimum, rightAxis.axisMinimum)
     }
     
-    /// Returns true if either the left or the right or both axes are inverted.
+    /// - returns: true if either the left or the right or both axes are inverted.
     public var isAnyAxisInverted: Bool
     {
         return _leftAxis.isInverted || _rightAxis.isInverted
@@ -1514,8 +1515,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         set { _autoScaleMinMaxEnabled = newValue; }
     }
     
-    /// returns true if auto scaling on the y axis is enabled.
-    /// :default: false
+    /// default: false
+    /// - returns: true if auto scaling on the y axis is enabled.
     public var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled; }
     
     /// Sets a minimum width to the specified y axis.
@@ -1531,8 +1532,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    /// Returns the (custom) minimum width of the specified Y axis.
-    /// :default 0.0
+    /// default: 0.0
+    /// - returns: the (custom) minimum width of the specified Y axis.
     public func getYAxisMinWidth(which: ChartYAxis.AxisDependency) -> CGFloat
     {
         if (which == .Left)
@@ -1558,9 +1559,10 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    /// Returns the (custom) maximum width of the specified Y axis.
     /// Zero (0.0) means there's no maximum width
-    /// :default 0.0 (no maximum specified)
+    ///
+    /// default: 0.0 (no maximum specified)
+    /// - returns: the (custom) maximum width of the specified Y axis.
     public func getYAxisMaxWidth(which: ChartYAxis.AxisDependency) -> CGFloat
     {
         if (which == .Left)
@@ -1573,7 +1575,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// Returns the width of the specified y axis.
+    /// - returns the width of the specified y axis.
     public func getYAxisWidth(which: ChartYAxis.AxisDependency) -> CGFloat
     {
         if (which == .Left)

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1107,8 +1107,8 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// Sets custom offsets for the current ViewPort (the offsets on the sides of the actual chart window). Setting this will prevent the chart from automatically calculating it's offsets. Use resetViewPortOffsets() to undo this.
-    /// ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING, else use setExtraOffsets(...).
+    /// Sets custom offsets for the current `ChartViewPort` (the offsets on the sides of the actual chart window). Setting this will prevent the chart from automatically calculating it's offsets. Use `resetViewPortOffsets()` to undo this.
+    /// ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING, else use `setExtraOffsets(...)`.
     public func setViewPortOffsets(left left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         _customViewPortEnabled = true
@@ -1127,7 +1127,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// Resets all custom offsets set via setViewPortOffsets(...) method. Allows the chart to again calculate all offsets automatically.
+    /// Resets all custom offsets set via `setViewPortOffsets(...)` method. Allows the chart to again calculate all offsets automatically.
     public func resetViewPortOffsets()
     {
         _customViewPortEnabled = false
@@ -1160,7 +1160,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
 
     /// the number of maximum visible drawn values on the chart
-    /// only active when setDrawValues() is enabled
+    /// only active when `setDrawValues()` is enabled
     public var maxVisibleValueCount: Int
     {
         get
@@ -1258,7 +1258,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    /// default: true
+    /// **default**: true
     /// - returns: true if zooming via double-tap is enabled false if not.
     public var isDoubleTapToZoomEnabled: Bool
     {
@@ -1269,22 +1269,22 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     public var highlightPerDragEnabled = true
     
     /// If set to true, highlighting per dragging over a fully zoomed out chart is enabled
-    /// You might want to disable this when using inside a UIScrollView
+    /// You might want to disable this when using inside a `UIScrollView`
     /// 
-    /// default: true
+    /// **default**: true
     public var isHighlightPerDragEnabled: Bool
     {
         return highlightPerDragEnabled
     }
     
-    /// default: true
+    /// **default**: true
     /// - returns: true if drawing the grid background is enabled, false if not.
     public var isDrawGridBackgroundEnabled: Bool
     {
         return drawGridBackgroundEnabled
     }
     
-    /// default: false
+    /// **default**: false
     /// - returns: true if drawing the borders rectangle is enabled, false if not.
     public var isDrawBordersEnabled: Bool
     {
@@ -1304,9 +1304,9 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
 
     /// - returns: the x and y values in the chart at the given touch point
-    /// (encapsulated in a PointD). This method transforms pixel coordinates to
+    /// (encapsulated in a `CGPoint`). This method transforms pixel coordinates to
     /// coordinates / values in the chart. This is the opposite method to
-    /// getPixelsForValues(...).
+    /// `getPixelsForValues(...)`.
     public func getValueByTouchPoint(var pt pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGPoint
     {
         getTransformer(axis).pixelToValue(&pt)
@@ -1315,7 +1315,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
 
     /// Transforms the given chart values into pixels. This is the opposite
-    /// method to getValueByTouchPoint(...).
+    /// method to `getValueByTouchPoint(...)`.
     public func getPixelForValue(x: Double, y: Double, axis: ChartYAxis.AxisDependency) -> CGPoint
     {
         var pt = CGPoint(x: CGFloat(x), y: CGFloat(y))
@@ -1443,7 +1443,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
 
-    /// default: false
+    /// **default**: false
     /// - returns: true if pinch-zoom is enabled, false if not
     public var isPinchZoomEnabled: Bool { return pinchZoomEnabled; }
 
@@ -1465,7 +1465,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     public var hasNoDragOffset: Bool { return _viewPortHandler.hasNoDragOffset; }
 
     /// The X axis renderer. This is a read-write property so you can set your own custom renderer here.
-    /// :default: An instance of ChartXAxisRenderer
+    /// **default**: An instance of ChartXAxisRenderer
     /// - returns: The current set X axis renderer
     public var xAxisRenderer: ChartXAxisRenderer
     {
@@ -1474,7 +1474,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
     
     /// The left Y axis renderer. This is a read-write property so you can set your own custom renderer here.
-    /// :default: An instance of ChartYAxisRenderer
+    /// **default**: An instance of ChartYAxisRenderer
     /// - returns: The current set left Y axis renderer
     public var leftYAxisRenderer: ChartYAxisRenderer
     {
@@ -1483,7 +1483,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
     
     /// The right Y axis renderer. This is a read-write property so you can set your own custom renderer here.
-    /// :default: An instance of ChartYAxisRenderer
+    /// **default**: An instance of ChartYAxisRenderer
     /// - returns: The current set right Y axis renderer
     public var rightYAxisRenderer: ChartYAxisRenderer
     {
@@ -1515,7 +1515,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         set { _autoScaleMinMaxEnabled = newValue; }
     }
     
-    /// default: false
+    /// **default**: false
     /// - returns: true if auto scaling on the y axis is enabled.
     public var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled; }
     
@@ -1532,7 +1532,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         }
     }
     
-    /// default: 0.0
+    /// **default**: 0.0
     /// - returns: the (custom) minimum width of the specified Y axis.
     public func getYAxisMinWidth(which: ChartYAxis.AxisDependency) -> CGFloat
     {
@@ -1561,7 +1561,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     
     /// Zero (0.0) means there's no maximum width
     ///
-    /// default: 0.0 (no maximum specified)
+    /// **default**: 0.0 (no maximum specified)
     /// - returns: the (custom) maximum width of the specified Y axis.
     public func getYAxisMaxWidth(which: ChartYAxis.AxisDependency) -> CGFloat
     {

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -74,7 +74,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         super.init(frame: frame)
     }
     
-    public required init?(coder aDecoder: NSCoder)
+    public required init(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -145,7 +145,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         initialize()
     }
     
-    public required init?(coder aDecoder: NSCoder)
+    public required init(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
         initialize()
@@ -830,7 +830,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     internal typealias VoidClosureType = () -> ()
     internal var _sizeChangeEventActions = [VoidClosureType]()
     
-    override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String: AnyObject]?, context: UnsafeMutablePointer<Void>)
+    public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [NSObject : AnyObject]?, context: UnsafeMutablePointer<Void>)
     {
         if (keyPath == "bounds" || keyPath == "frame")
         {

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -451,7 +451,6 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         {
             let highlight = _indicesToHightlight[i]
             let xIndex = highlight.xIndex
-            let dataSetIndex = highlight.dataSetIndex
 
             if (xIndex <= Int(_deltaX) && xIndex <= Int(_deltaX * _animator.phaseX))
             {
@@ -830,7 +829,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     internal typealias VoidClosureType = () -> ()
     internal var _sizeChangeEventActions = [VoidClosureType]()
     
-    public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [NSObject : AnyObject]?, context: UnsafeMutablePointer<Void>)
+    public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>)
     {
         if (keyPath == "bounds" || keyPath == "frame")
         {

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -145,7 +145,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         initialize()
     }
     
-    public required init(coder aDecoder: NSCoder)
+    public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
         initialize()
@@ -830,7 +830,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     internal typealias VoidClosureType = () -> ()
     internal var _sizeChangeEventActions = [VoidClosureType]()
     
-    override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [NSObject: AnyObject]?, context: UnsafeMutablePointer<Void>)
+    override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String: AnyObject]?, context: UnsafeMutablePointer<Void>)
     {
         if (keyPath == "bounds" || keyPath == "frame")
         {

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -20,8 +20,8 @@ import UIKit
 public protocol ChartViewDelegate
 {
     /// Called when a value has been selected inside the chart.
-    /// :entry: The selected Entry.
-    /// :dataSetIndex: The index in the datasets array of the data object the Entrys DataSet is in.
+    /// - parameter entry: The selected Entry.
+    /// - parameter dataSetIndex: The index in the datasets array of the data object the Entrys DataSet is in.
     optional func chartValueSelected(chartView: ChartViewBase, entry: ChartDataEntry, dataSetIndex: Int, highlight: ChartHighlight)
     
     // Called when nothing has been selected or an "un-select" has been made.
@@ -225,7 +225,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         setNeedsDisplay()
     }
     
-    /// Returns true if the chart is empty (meaning it's data object is either null or contains no entries).
+    /// - returns: true if the chart is empty (meaning it's data object is either null or contains no entries).
     public func isEmpty() -> Bool
     {
         if (_data == nil)
@@ -345,15 +345,14 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     // MARK: - Highlighting
     
-    /// Returns the array of currently highlighted values. This might be null or empty if nothing is highlighted.
+    /// - returns: the array of currently highlighted values. This might be null or empty if nothing is highlighted.
     public var highlighted: [ChartHighlight]
     {
         return _indicesToHightlight
     }
     
-    /// Returns true if there are values to highlight,
-    /// false if there are no values to highlight.
     /// Checks if the highlight array is null, has a length of zero or if the first object is null.
+    /// - returns: true if there are values to highlight, false if there are no values to highlight.
     public func valuesToHighlight() -> Bool
     {
         return _indicesToHightlight.count > 0
@@ -487,7 +486,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         }
     }
     
-    /// Returns the actual position in pixels of the MarkerView for the given Entry in the given DataSet.
+    /// - returns: the actual position in pixels of the MarkerView for the given Entry in the given DataSet.
     public func getMarkerPosition(entry entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
     {
         fatalError("getMarkerPosition() cannot be called on ChartViewBase")
@@ -495,7 +494,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     // MARK: - Animation
     
-    /// Returns the animator responsible for animating chart values.
+    /// - returns: the animator responsible for animating chart values.
     public var animator: ChartAnimator!
     {
         return _animator
@@ -606,19 +605,19 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     // MARK: - Accessors
 
-    /// returns the total value (sum) of all y-values across all DataSets
+    /// - returns: the total value (sum) of all y-values across all DataSets
     public var yValueSum: Double
     {
         return _data.yValueSum
     }
 
-    /// returns the current y-max value across all DataSets
+    /// - returns: the current y-max value across all DataSets
     public var chartYMax: Double
     {
         return _data.yMax
     }
 
-    /// returns the current y-min value across all DataSets
+    /// - returns: the current y-min value across all DataSets
     public var chartYMin: Double
     {
         return _data.yMin
@@ -634,13 +633,13 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         return _chartXMin
     }
     
-    /// returns the average value of all values the chart holds
+    /// - returns: the average value of all values the chart holds
     public func getAverage() -> Double
     {
         return yValueSum / Double(_data.yValCount)
     }
     
-    /// returns the average value for a specific DataSet (with a specific label) in the chart
+    /// - returns: the average value for a specific DataSet (with a specific label) in the chart
     public func getAverage(dataSetLabel dataSetLabel: String) -> Double
     {
         let ds = _data.getDataSetByLabel(dataSetLabel, ignorecase: true)
@@ -652,39 +651,39 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         return ds!.yValueSum / Double(ds!.entryCount)
     }
     
-    /// returns the total number of values the chart holds (across all DataSets)
+    /// - returns: the total number of values the chart holds (across all DataSets)
     public var getValueCount: Int
     {
         return _data.yValCount
     }
     
-    /// Returns the center point of the chart (the whole View) in pixels.
-    /// Note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)
+    /// *Note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)*
+    /// - returns: the center point of the chart (the whole View) in pixels.
     public var midPoint: CGPoint
     {
         let bounds = self.bounds
         return CGPoint(x: bounds.origin.x + bounds.size.width / 2.0, y: bounds.origin.y + bounds.size.height / 2.0)
     }
     
-    /// Returns the center of the chart taking offsets under consideration. (returns the center of the content rectangle)
+    /// - returns: the center of the chart taking offsets under consideration. (returns the center of the content rectangle)
     public var centerOffsets: CGPoint
     {
         return _viewPortHandler.contentCenter
     }
     
-    /// Returns the Legend object of the chart. This method can be used to get an instance of the legend in order to customize the automatically generated Legend.
+    /// - returns: the Legend object of the chart. This method can be used to get an instance of the legend in order to customize the automatically generated Legend.
     public var legend: ChartLegend
     {
         return _legend
     }
     
-    /// Returns the renderer object responsible for rendering / drawing the Legend.
+    /// - returns: the renderer object responsible for rendering / drawing the Legend.
     public var legendRenderer: ChartLegendRenderer!
     {
         return _legendRenderer
     }
     
-    /// Returns the rectangle that defines the borders of the chart-value surface (into which the actual values are drawn).
+    /// - returns: the rectangle that defines the borders of the chart-value surface (into which the actual values are drawn).
     public var contentRect: CGRect
     {
         return _viewPortHandler.contentRect
@@ -713,7 +712,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         }
     }
     
-    /// returns the x-value at the given index
+    /// - returns: the x-value at the given index
     public func getXValue(index: Int) -> String!
     {
         if (_data == nil || _data.xValCount <= index)
@@ -744,20 +743,20 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         return vals
     }
     
-    /// returns the percentage the given value has of the total y-value sum
+    /// - returns: the percentage the given value has of the total y-value sum
     public func percentOfTotal(val: Double) -> Double
     {
         return val / _data.yValueSum * 100.0
     }
     
-    /// Returns the ViewPortHandler of the chart that is responsible for the
+    /// - returns: the ViewPortHandler of the chart that is responsible for the
     /// content area of the chart and its offsets and dimensions.
     public var viewPortHandler: ChartViewPortHandler!
     {
         return _viewPortHandler
     }
     
-    /// Returns the bitmap that represents the chart.
+    /// - returns: the bitmap that represents the chart.
     public func getChartImage(transparent transparent: Bool) -> UIImage
     {
         UIGraphicsBeginImageContextWithOptions(bounds.size, opaque || !transparent, UIScreen.mainScreen().scale)
@@ -798,9 +797,9 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// the SD card chart is saved as a PNG image, example:
     /// saveToPath("myfilename", "foldername1/foldername2")
     ///
-    /// :filePath: path to the image to save
-    /// :format: the format to save
-    /// :compressionQuality: compression quality for lossless formats (JPEG)
+    /// - parameter filePath: path to the image to save
+    /// - parameter format: the format to save
+    /// - parameter compressionQuality: compression quality for lossless formats (JPEG)
     ///
     /// - returns: true if the image was saved successfully
     public func saveToPath(path: String, format: ImageFormat, compressionQuality: Double) -> Bool
@@ -878,8 +877,8 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// if true, value highlightning is enabled
     public var isHighlightEnabled: Bool { return highlightEnabled }
     
+    /// default: true
     /// - returns: true if chart continues to scroll after touch up, false if not.
-    /// :default: true
     public var isDragDecelerationEnabled: Bool
         {
             return dragDecelerationEnabled
@@ -887,7 +886,8 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     /// Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
     /// 1 is an invalid value, and will be converted to 0.999 automatically.
-    /// :default: true
+    /// 
+    /// default: true
     public var dragDecelerationFrictionCoef: CGFloat
     {
         get

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -501,7 +501,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingX: an easing function for the animation on the x axis
@@ -512,7 +512,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOptionX: the easing function for the animation on the x axis
@@ -523,7 +523,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
@@ -533,7 +533,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
@@ -543,7 +543,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval)
@@ -552,7 +552,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easing: an easing function for the animation
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
@@ -561,7 +561,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easingOption: the easing function for the animation
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
@@ -570,7 +570,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     public func animate(xAxisDuration xAxisDuration: NSTimeInterval)
     {
@@ -578,7 +578,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
     public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
@@ -587,7 +587,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
     public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
@@ -596,7 +596,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
+    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     public func animate(yAxisDuration yAxisDuration: NSTimeInterval)
     {
@@ -877,7 +877,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// if true, value highlightning is enabled
     public var isHighlightEnabled: Bool { return highlightEnabled }
     
-    /// default: true
+    /// **default**: true
     /// - returns: true if chart continues to scroll after touch up, false if not.
     public var isDragDecelerationEnabled: Bool
         {
@@ -887,7 +887,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
     /// 1 is an invalid value, and will be converted to 0.999 automatically.
     /// 
-    /// default: true
+    /// **default**: true
     public var dragDecelerationFrictionCoef: CGFloat
     {
         get

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -145,7 +145,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         initialize()
     }
     
-    public required init(coder aDecoder: NSCoder)
+    public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
         initialize()

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -128,7 +128,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// An extra offset to be appended to the viewport's left
     public var extraLeftOffset: CGFloat = 0.0
     
-    public func setExtraOffsets(#left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
+    public func setExtraOffsets(left left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         extraLeftOffset = left
         extraTopOffset = top
@@ -192,7 +192,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         {
             if (newValue == nil || newValue?.yValCount == 0)
             {
-                println("Charts: data argument is nil on setData()")
+                print("Charts: data argument is nil on setData()", appendNewline: true)
                 return
             }
             
@@ -265,15 +265,15 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// calculates the required number of digits for the values that might be drawn in the chart (if enabled), and creates the default value formatter
-    internal func calculateFormatter(#min: Double, max: Double)
+    internal func calculateFormatter(min min: Double, max: Double)
     {
         // check if a custom formatter is set or not
         var reference = Double(0.0)
         
         if (_data == nil || _data.xValCount < 2)
         {
-            var absMin = fabs(min)
-            var absMax = fabs(max)
+            let absMin = fabs(min)
+            let absMax = fabs(max)
             reference = absMin > absMax ? absMin : absMax
         }
         else
@@ -281,7 +281,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
             reference = fabs(max - min)
         }
         
-        var digits = ChartUtils.decimals(reference)
+        let digits = ChartUtils.decimals(reference)
     
         _defaultValueFormatter.maximumFractionDigits = digits
         _defaultValueFormatter.minimumFractionDigits = digits
@@ -301,9 +301,9 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
             
             ChartUtils.drawText(context: context, text: noDataText, point: CGPoint(x: frame.width / 2.0, y: frame.height / 2.0), align: .Center, attributes: [NSFontAttributeName: infoFont, NSForegroundColorAttributeName: infoTextColor])
             
-            if (noDataTextDescription != nil && count(noDataTextDescription!) > 0)
+            if (noDataTextDescription != nil && (noDataTextDescription!).characters.count > 0)
             {   
-                var textOffset = -infoFont.lineHeight / 2.0
+                let textOffset = -infoFont.lineHeight / 2.0
                 
                 ChartUtils.drawText(context: context, text: noDataTextDescription!, point: CGPoint(x: frame.width / 2.0, y: frame.height / 2.0 + textOffset), align: .Center, attributes: [NSFontAttributeName: infoFont, NSForegroundColorAttributeName: infoTextColor])
             }
@@ -319,7 +319,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// draws the description text in the bottom right corner of the chart
-    internal func drawDescription(#context: CGContext)
+    internal func drawDescription(context context: CGContext)
     {
         if (descriptionText.lengthOfBytesUsingEncoding(NSUTF16StringEncoding) == 0)
         {
@@ -328,7 +328,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         
         let frame = self.bounds
         
-        var attrs = [NSObject: AnyObject]()
+        var attrs = [String : AnyObject]()
         
         var font = descriptionFont
         
@@ -339,7 +339,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         
         attrs[NSFontAttributeName] = font
         attrs[NSForegroundColorAttributeName] = descriptionTextColor
-        
+
         ChartUtils.drawText(context: context, text: descriptionText, point: CGPoint(x: frame.width - _viewPortHandler.offsetRight - 10.0, y: frame.height - _viewPortHandler.offsetBottom - 10.0 - font!.lineHeight), align: .Right, attributes: attrs)
     }
     
@@ -379,7 +379,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     /// Highlights the value at the given x-index in the given DataSet. 
     /// Provide -1 as the x-index to undo all highlighting.
-    public func highlightValue(#xIndex: Int, dataSetIndex: Int, callDelegate: Bool)
+    public func highlightValue(xIndex xIndex: Int, dataSetIndex: Int, callDelegate: Bool)
     {
         if (xIndex < 0 || dataSetIndex < 0 || xIndex >= _data.xValCount || dataSetIndex >= _data.dataSetCount)
         {
@@ -392,7 +392,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
 
     /// Highlights the value selected by touch gesture.
-    public func highlightValue(#highlight: ChartHighlight?, callDelegate: Bool)
+    public func highlightValue(highlight highlight: ChartHighlight?, callDelegate: Bool)
     {
         var entry: ChartDataEntry?
         var h = highlight
@@ -440,7 +440,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     // MARK: - Markers
 
     /// draws all MarkerViews on the highlighted positions
-    internal func drawMarkers(#context: CGContext)
+    internal func drawMarkers(context context: CGContext)
     {
         // if there is no marker view or drawing marker is disabled
         if (marker === nil || !drawMarkers || !valuesToHighlight())
@@ -462,7 +462,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
                     continue
                 }
                 
-                var pos = getMarkerPosition(entry: e!, highlight: highlight)
+                let pos = getMarkerPosition(entry: e!, highlight: highlight)
 
                 // check bounds
                 if (!_viewPortHandler.isInBounds(x: pos.x, y: pos.y))
@@ -488,7 +488,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Returns the actual position in pixels of the MarkerView for the given Entry in the given DataSet.
-    public func getMarkerPosition(#entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
+    public func getMarkerPosition(entry entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
     {
         fatalError("getMarkerPosition() cannot be called on ChartViewBase")
     }
@@ -503,103 +503,103 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingX an easing function for the animation on the x axis
-    /// :param: easingY an easing function for the animation on the y axis
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingX: an easing function for the animation on the x axis
+    /// - parameter easingY: an easing function for the animation on the y axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easingX, easingY: easingY)
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingOptionX the easing function for the animation on the x axis
-    /// :param: easingOptionY the easing function for the animation on the y axis
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingOptionX: the easing function for the animation on the x axis
+    /// - parameter easingOptionY: the easing function for the animation on the y axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOptionX: easingOptionX, easingOptionY: easingOptionY)
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easing an easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easing: an easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easing: easing)
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingOption the easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingOption: the easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOption: easingOption)
     }
     
     /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: yAxisDuration duration for animating the y axis
-    public func animate(#xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter yAxisDuration: duration for animating the y axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, yAxisDuration: NSTimeInterval)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration)
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: easing an easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter easing: an easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, easing: easing)
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    /// :param: easingOption the easing function for the animation
-    public func animate(#xAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    /// - parameter easingOption: the easing function for the animation
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, easingOption: easingOption)
     }
     
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: xAxisDuration duration for animating the x axis
-    public func animate(#xAxisDuration: NSTimeInterval)
+    /// - parameter xAxisDuration: duration for animating the x axis
+    public func animate(xAxisDuration xAxisDuration: NSTimeInterval)
     {
         _animator.animate(xAxisDuration: xAxisDuration)
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easing an easing function for the animation
-    public func animate(#yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easing: an easing function for the animation
+    public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(yAxisDuration: yAxisDuration, easing: easing)
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: yAxisDuration duration for animating the y axis
-    /// :param: easingOption the easing function for the animation
-    public func animate(#yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
+    /// - parameter yAxisDuration: duration for animating the y axis
+    /// - parameter easingOption: the easing function for the animation
+    public func animate(yAxisDuration yAxisDuration: NSTimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(yAxisDuration: yAxisDuration, easingOption: easingOption)
     }
     
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If animate(...) is called, no further calling of invalidate() is necessary to refresh the chart.
-    /// :param: yAxisDuration duration for animating the y axis
-    public func animate(#yAxisDuration: NSTimeInterval)
+    /// - parameter yAxisDuration: duration for animating the y axis
+    public func animate(yAxisDuration yAxisDuration: NSTimeInterval)
     {
         _animator.animate(yAxisDuration: yAxisDuration)
     }
@@ -641,9 +641,9 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// returns the average value for a specific DataSet (with a specific label) in the chart
-    public func getAverage(#dataSetLabel: String) -> Double
+    public func getAverage(dataSetLabel dataSetLabel: String) -> Double
     {
-        var ds = _data.getDataSetByLabel(dataSetLabel, ignorecase: true)
+        let ds = _data.getDataSetByLabel(dataSetLabel, ignorecase: true)
         if (ds == nil)
         {
             return 0.0
@@ -662,7 +662,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// Note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)
     public var midPoint: CGPoint
     {
-        var bounds = self.bounds
+        let bounds = self.bounds
         return CGPoint(x: bounds.origin.x + bounds.size.width / 2.0, y: bounds.origin.y + bounds.size.height / 2.0)
     }
     
@@ -733,8 +733,8 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         
         for (var i = 0, count = _data.dataSetCount; i < count; i++)
         {
-            var set = _data.getDataSetByIndex(i)
-            var e = set.entryForXIndex(xIndex)
+            let set = _data.getDataSetByIndex(i)
+            let e = set.entryForXIndex(xIndex)
             if (e !== nil)
             {
                 vals.append(e!)
@@ -758,12 +758,12 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// Returns the bitmap that represents the chart.
-    public func getChartImage(#transparent: Bool) -> UIImage
+    public func getChartImage(transparent transparent: Bool) -> UIImage
     {
         UIGraphicsBeginImageContextWithOptions(bounds.size, opaque || !transparent, UIScreen.mainScreen().scale)
         
-        var context = UIGraphicsGetCurrentContext()
-        var rect = CGRect(origin: CGPoint(x: 0, y: 0), size: bounds.size)
+        let context = UIGraphicsGetCurrentContext()
+        let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: bounds.size)
         
         if (opaque || !transparent)
         {
@@ -780,7 +780,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         
         layer.renderInContext(UIGraphicsGetCurrentContext())
         
-        var image = UIGraphicsGetImageFromCurrentImageContext()
+        let image = UIGraphicsGetImageFromCurrentImageContext()
         
         UIGraphicsEndImageContext()
         
@@ -802,10 +802,10 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// :format: the format to save
     /// :compressionQuality: compression quality for lossless formats (JPEG)
     ///
-    /// :returns: true if the image was saved successfully
+    /// - returns: true if the image was saved successfully
     public func saveToPath(path: String, format: ImageFormat, compressionQuality: Double) -> Bool
     {
-        var image = getChartImage(transparent: format != .JPEG)
+        let image = getChartImage(transparent: format != .JPEG)
 
         var imageData: NSData!
         switch (format)
@@ -831,11 +831,11 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     internal typealias VoidClosureType = () -> ()
     internal var _sizeChangeEventActions = [VoidClosureType]()
     
-    override public func observeValueForKeyPath(keyPath: String, ofObject object: AnyObject, change: [NSObject: AnyObject], context: UnsafeMutablePointer<Void>)
+    override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [NSObject: AnyObject]?, context: UnsafeMutablePointer<Void>)
     {
         if (keyPath == "bounds" || keyPath == "frame")
         {
-            var bounds = self.bounds
+            let bounds = self.bounds
             
             if (_viewPortHandler !== nil &&
                 (bounds.size.width != _viewPortHandler.chartWidth ||
@@ -878,7 +878,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     /// if true, value highlightning is enabled
     public var isHighlightEnabled: Bool { return highlightEnabled }
     
-    /// :returns: true if chart continues to scroll after touch up, false if not.
+    /// - returns: true if chart continues to scroll after touch up, false if not.
     /// :default: true
     public var isDragDecelerationEnabled: Bool
         {
@@ -924,7 +924,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     
     // MARK: - Touches
     
-    public override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
         if (!_interceptTouchEvents)
         {
@@ -932,7 +932,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         }
     }
     
-    public override func touchesMoved(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
         if (!_interceptTouchEvents)
         {
@@ -940,7 +940,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         }
     }
     
-    public override func touchesEnded(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
         if (!_interceptTouchEvents)
         {
@@ -948,7 +948,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
         }
     }
     
-    public override func touchesCancelled(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesCancelled(touches: Set<UITouch>?, withEvent event: UIEvent?)
     {
         if (!_interceptTouchEvents)
         {

--- a/Charts/Classes/Charts/CombinedChartView.swift
+++ b/Charts/Classes/Charts/CombinedChartView.swift
@@ -189,13 +189,13 @@ public class CombinedChartView: BarLineChartViewBase
         set { (renderer as! CombinedChartRenderer!).drawBarShadowEnabled = newValue; }
     }
     
-    /// returns true if drawing the highlighting arrow is enabled, false if not
+    /// - returns: true if drawing the highlighting arrow is enabled, false if not
     public var isDrawHighlightArrowEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawHighlightArrowEnabled; }
     
-    /// returns true if drawing values above bars is enabled, false if not
+    /// - returns: true if drawing values above bars is enabled, false if not
     public var isDrawValueAboveBarEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled; }
     
-    /// returns true if drawing shadows (maxvalue) for each bar is enabled, false if not
+    /// - returns: true if drawing shadows (maxvalue) for each bar is enabled, false if not
     public var isDrawBarShadowEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawBarShadowEnabled; }
     
     /// the order in which the provided data objects should be drawn.

--- a/Charts/Classes/Charts/HorizontalBarChartView.swift
+++ b/Charts/Classes/Charts/HorizontalBarChartView.swift
@@ -56,7 +56,7 @@ public class HorizontalBarChartView: BarChartView
                 || _legend.position == .BelowChartRight
                 || _legend.position == .BelowChartCenter)
             {
-                var yOffset = _legend.textHeightMax * 2.0; // It's possible that we do not need this offset anymore as it is available through the extraOffsets
+                let yOffset = _legend.textHeightMax * 2.0; // It's possible that we do not need this offset anymore as it is available through the extraOffsets
                 offsetBottom += min(_legend.neededHeight + yOffset, _viewPortHandler.chartHeight * _legend.maxSizePercent)
             }
         }
@@ -72,7 +72,7 @@ public class HorizontalBarChartView: BarChartView
             offsetBottom += _rightAxis.getRequiredHeightSpace()
         }
         
-        var xlabelwidth = _xAxis.labelWidth
+        let xlabelwidth = _xAxis.labelWidth
         
         if (_xAxis.isEnabled)
         {
@@ -97,7 +97,7 @@ public class HorizontalBarChartView: BarChartView
         offsetBottom += self.extraBottomOffset
         offsetLeft += self.extraLeftOffset
         
-        var minOffset: CGFloat = 10.0
+        let minOffset: CGFloat = 10.0
         
         _viewPortHandler.restrainViewPort(
             offsetLeft: max(minOffset, offsetLeft),
@@ -127,22 +127,22 @@ public class HorizontalBarChartView: BarChartView
     
     public override func getBarBounds(e: BarChartDataEntry) -> CGRect!
     {
-        var set = _data.getDataSetForEntry(e) as! BarChartDataSet!
+        let set = _data.getDataSetForEntry(e) as! BarChartDataSet!
         
         if (set === nil)
         {
             return nil
         }
         
-        var barspace = set.barSpace
-        var y = CGFloat(e.value)
-        var x = CGFloat(e.xIndex)
+        let barspace = set.barSpace
+        let y = CGFloat(e.value)
+        let x = CGFloat(e.xIndex)
         
-        var spaceHalf = barspace / 2.0
-        var top = x - 0.5 + spaceHalf
-        var bottom = x + 0.5 - spaceHalf
-        var left = y >= 0.0 ? y : 0.0
-        var right = y <= 0.0 ? y : 0.0
+        let spaceHalf = barspace / 2.0
+        let top = x - 0.5 + spaceHalf
+        let bottom = x + 0.5 - spaceHalf
+        let left = y >= 0.0 ? y : 0.0
+        let right = y <= 0.0 ? y : 0.0
         
         var bounds = CGRect(x: left, y: top, width: right - left, height: bottom - top)
         
@@ -164,7 +164,7 @@ public class HorizontalBarChartView: BarChartView
     {
         if (_dataNotSet || _data === nil)
         {
-            println("Can't select by touch. No data set.")
+            print("Can't select by touch. No data set.", appendNewline: true)
             return nil
         }
         
@@ -173,8 +173,8 @@ public class HorizontalBarChartView: BarChartView
     
     public override var lowestVisibleXIndex: Int
     {
-        var step = CGFloat(_data.dataSetCount)
-        var div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
+        let step = CGFloat(_data.dataSetCount)
+        let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentLeft, y: _viewPortHandler.contentBottom)
         getTransformer(ChartYAxis.AxisDependency.Left).pixelToValue(&pt)
@@ -184,8 +184,8 @@ public class HorizontalBarChartView: BarChartView
     
     public override var highestVisibleXIndex: Int
     {
-        var step = CGFloat(_data.dataSetCount)
-        var div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
+        let step = CGFloat(_data.dataSetCount)
+        let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentLeft, y: _viewPortHandler.contentTop)
         getTransformer(ChartYAxis.AxisDependency.Left).pixelToValue(&pt)

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -216,7 +216,7 @@ public class PieChartView: PieRadarChartViewBase
     
     /// Sets the color for the hole that is drawn in the center of the PieChart (if enabled).
     /// 
-    /// *NOTE: Use holeTransparent with holeColor = nil to make the hole transparent.*
+    /// *Note: Use holeTransparent with holeColor = nil to make the hole transparent.*
     public var holeColor: UIColor?
     {
         get
@@ -367,7 +367,7 @@ public class PieChartView: PieRadarChartViewBase
     
     /// the radius of the hole in the center of the piechart in percent of the maximum radius (max = the radius of the whole chart)
     /// 
-    /// default: 0.5 (50%) (half the pie)
+    /// **default**: 0.5 (50%) (half the pie)
     public var holeRadiusPercent: CGFloat
     {
         get
@@ -383,7 +383,7 @@ public class PieChartView: PieRadarChartViewBase
     
     /// the radius of the transparent circle that is drawn next to the hole in the piechart in percent of the maximum radius (max = the radius of the whole chart)
     /// 
-    /// default: 0.55 (55%) -> means 5% larger than the center-hole by default
+    /// **default**: 0.55 (55%) -> means 5% larger than the center-hole by default
     public var transparentCircleRadiusPercent: CGFloat
     {
         get

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -31,7 +31,7 @@ public class PieChartView: PieRadarChartViewBase
         super.init(frame: frame)
     }
     
-    public required init(coder aDecoder: NSCoder)
+    public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -183,7 +183,7 @@ public class PieChartView: PieRadarChartViewBase
         return -1; // return -1 if no index found
     }
     
-    /// Returns the index of the DataSet this x-index belongs to.
+    /// - returns: the index of the DataSet this x-index belongs to.
     public func dataSetIndexForIndex(xIndex: Int) -> Int
     {
         var dataSets = _data.dataSets
@@ -199,7 +199,7 @@ public class PieChartView: PieRadarChartViewBase
         return -1
     }
     
-    /// returns an integer array of all the different angles the chart slices
+    /// - returns: an integer array of all the different angles the chart slices
     /// have the angles in the returned array determine how much space (of 360°)
     /// each slice takes
     public var drawAngles: [CGFloat]
@@ -207,7 +207,7 @@ public class PieChartView: PieRadarChartViewBase
         return _drawAngles
     }
 
-    /// returns the absolute angles of the different chart slices (where the
+    /// - returns: the absolute angles of the different chart slices (where the
     /// slices end)
     public var absoluteAngles: [CGFloat]
     {
@@ -215,7 +215,8 @@ public class PieChartView: PieRadarChartViewBase
     }
     
     /// Sets the color for the hole that is drawn in the center of the PieChart (if enabled).
-    /// NOTE: Use holeTransparent with holeColor = nil to make the hole transparent.
+    /// 
+    /// *NOTE: Use holeTransparent with holeColor = nil to make the hole transparent.*
     public var holeColor: UIColor?
     {
         get
@@ -243,7 +244,7 @@ public class PieChartView: PieRadarChartViewBase
         }
     }
     
-    /// Returns true if the hole in the center of the PieChart is transparent, false if not.
+    /// - returns: true if the hole in the center of the PieChart is transparent, false if not.
     public var isHoleTransparent: Bool 
     {
         return (renderer as! PieChartRenderer).holeTransparent
@@ -324,13 +325,13 @@ public class PieChartView: PieRadarChartViewBase
         return _circleBox.width / 2.0
     }
     
-    /// returns the circlebox, the boundingbox of the pie-chart slices
+    /// - returns: the circlebox, the boundingbox of the pie-chart slices
     public var circleBox: CGRect
     {
         return _circleBox
     }
     
-    /// returns the center of the circlebox
+    /// - returns: the center of the circlebox
     public var centerCircleBox: CGPoint
     {
         return CGPoint(x: _circleBox.midX, y: _circleBox.midY)
@@ -365,7 +366,8 @@ public class PieChartView: PieRadarChartViewBase
     }
     
     /// the radius of the hole in the center of the piechart in percent of the maximum radius (max = the radius of the whole chart)
-    /// :default: 0.5 (50%) (half the pie)
+    /// 
+    /// default: 0.5 (50%) (half the pie)
     public var holeRadiusPercent: CGFloat
     {
         get
@@ -380,7 +382,8 @@ public class PieChartView: PieRadarChartViewBase
     }
     
     /// the radius of the transparent circle that is drawn next to the hole in the piechart in percent of the maximum radius (max = the radius of the whole chart)
-    /// :default: 0.55 (55%) -> means 5% larger than the center-hole by default
+    /// 
+    /// default: 0.55 (55%) -> means 5% larger than the center-hole by default
     public var transparentCircleRadiusPercent: CGFloat
     {
         get

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -80,9 +80,9 @@ public class PieChartView: PieRadarChartViewBase
             return
         }
         
-        var radius = diameter / 2.0
+        let radius = diameter / 2.0
         
-        var c = centerOffsets
+        let c = centerOffsets
         
         // create the circle box that will contain the pie-chart (the bounds of the pie-chart)
         _circleBox.origin.x = c.x - radius
@@ -98,7 +98,7 @@ public class PieChartView: PieRadarChartViewBase
         calcAngles()
     }
     
-    public override func getMarkerPosition(#entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
+    public override func getMarkerPosition(entry entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
     {
         /// PieChart does not support MarkerView
         return CGPoint(x: 0.0, y: 0.0)
@@ -119,7 +119,7 @@ public class PieChartView: PieRadarChartViewBase
 
         for (var i = 0; i < _data.dataSetCount; i++)
         {
-            var set = dataSets[i]
+            let set = dataSets[i]
             var entries = set.yVals
 
             for (var j = 0; j < entries.count; j++)
@@ -141,7 +141,7 @@ public class PieChartView: PieRadarChartViewBase
     }
     
     /// checks if the given index in the given DataSet is set for highlighting or not
-    public func needsHighlight(#xIndex: Int, dataSetIndex: Int) -> Bool
+    public func needsHighlight(xIndex xIndex: Int, dataSetIndex: Int) -> Bool
     {
         // no highlight
         if (!valuesToHighlight() || dataSetIndex < 0)
@@ -171,7 +171,7 @@ public class PieChartView: PieRadarChartViewBase
     public override func indexForAngle(angle: CGFloat) -> Int
     {
         // take the current angle of the chart into consideration
-        var a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
+        let a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
         for (var i = 0; i < _absoluteAngles.count; i++)
         {
             if (_absoluteAngles[i] > a)
@@ -263,7 +263,7 @@ public class PieChartView: PieRadarChartViewBase
         }
     }
     
-    /// :returns: true if the hole in the center of the pie-chart is set to be visible, false if not
+    /// - returns: true if the hole in the center of the pie-chart is set to be visible, false if not
     public var isDrawHoleEnabled: Bool
     {
         get
@@ -300,7 +300,7 @@ public class PieChartView: PieRadarChartViewBase
         }
     }
     
-    /// :returns: true if drawing the center text is enabled
+    /// - returns: true if drawing the center text is enabled
     public var isDrawCenterTextEnabled: Bool
     {
         get
@@ -408,7 +408,7 @@ public class PieChartView: PieRadarChartViewBase
         }
     }
     
-    /// :returns: true if drawing x-values is enabled, false if not
+    /// - returns: true if drawing x-values is enabled, false if not
     public var isDrawSliceTextEnabled: Bool
     {
         get
@@ -431,7 +431,7 @@ public class PieChartView: PieRadarChartViewBase
         }
     }
     
-    /// :returns: true if drawing x-values is enabled, false if not
+    /// - returns: true if drawing x-values is enabled, false if not
     public var isUsePercentValuesEnabled: Bool
     {
         get

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -31,7 +31,7 @@ public class PieChartView: PieRadarChartViewBase
         super.init(frame: frame)
     }
     
-    public required init?(coder aDecoder: NSCoder)
+    public required init(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -209,7 +209,7 @@ public class PieRadarChartViewBase: ChartViewBase
         _viewPortHandler.restrainViewPort(offsetLeft: offsetLeft, offsetTop: offsetTop, offsetRight: offsetRight, offsetBottom: offsetBottom)
     }
 
-    /// returns the angle relative to the chart center for the given point on the chart in degrees.
+    /// - returns: the angle relative to the chart center for the given point on the chart in degrees.
     /// The angle is always between 0 and 360°, 0° is NORTH, 90° is EAST, ...
     public func angleForPoint(x x: CGFloat, y: CGFloat) -> CGFloat
     {
@@ -247,7 +247,7 @@ public class PieRadarChartViewBase: ChartViewBase
                 y: center.y + dist * sin(angle * ChartUtils.Math.FDEG2RAD))
     }
 
-    /// Returns the distance of a certain point on the chart to the center of the chart.
+    /// - returns: the distance of a certain point on the chart to the center of the chart.
     public func distanceToCenter(x x: CGFloat, y: CGFloat) -> CGFloat
     {
         let c = self.centerOffsets
@@ -281,16 +281,17 @@ public class PieRadarChartViewBase: ChartViewBase
         return dist
     }
 
-    /// Returns the xIndex for the given angle around the center of the chart.
-    /// Returns -1 if not found / outofbounds.
+    /// - returns: the xIndex for the given angle around the center of the chart.
+    /// -1 if not found / outofbounds.
     public func indexForAngle(angle: CGFloat) -> Int
     {
         fatalError("indexForAngle() cannot be called on PieRadarChartViewBase")
     }
 
     /// current rotation angle of the pie chart
-    /// :returns will always return a normalized value, which will be between 0.0 < 360.0
-    /// :default: 270 --> top (NORTH)
+    ///
+    /// default: 270 --> top (NORTH)
+    /// - returns: will always return a normalized value, which will be between 0.0 < 360.0
     public var rotationAngle: CGFloat
     {
         get
@@ -312,26 +313,26 @@ public class PieRadarChartViewBase: ChartViewBase
         return _rawRotationAngle
     }
 
-    /// returns the diameter of the pie- or radar-chart
+    /// - returns: the diameter of the pie- or radar-chart
     public var diameter: CGFloat
     {
         let content = _viewPortHandler.contentRect
         return min(content.width, content.height)
     }
 
-    /// Returns the radius of the chart in pixels.
+    /// - returns: the radius of the chart in pixels.
     public var radius: CGFloat
     {
         fatalError("radius cannot be called on PieRadarChartViewBase")
     }
 
-    /// Returns the required bottom offset for the chart.
+    /// - returns: the required bottom offset for the chart.
     internal var requiredBottomOffset: CGFloat
     {
         fatalError("requiredBottomOffset cannot be called on PieRadarChartViewBase")
     }
 
-    /// Returns the base offset needed for the chart without calculating the
+    /// - returns: the base offset needed for the chart without calculating the
     /// legend size.
     internal var requiredBaseOffset: CGFloat
     {
@@ -348,7 +349,7 @@ public class PieRadarChartViewBase: ChartViewBase
         return 0.0
     }
     
-    /// Returns an array of SelectionDetail objects for the given x-index.
+    /// - returns: an array of SelectionDetail objects for the given x-index.
     /// The SelectionDetail objects give information about the value at the selected index and the DataSet it belongs to.
     public func getSelectionDetailsAtIndex(xIndex: Int) -> [ChartSelectionDetail]
     {
@@ -379,7 +380,8 @@ public class PieRadarChartViewBase: ChartViewBase
     
     /// flag that indicates if rotation is done with two fingers or one.
     /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
-    /// :default: false
+    /// 
+    /// default: false
     public var rotationWithTwoFingers: Bool
     {
         get
@@ -395,7 +397,8 @@ public class PieRadarChartViewBase: ChartViewBase
     
     /// flag that indicates if rotation is done with two fingers or one.
     /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
-    /// :default: false
+    ///
+    /// default: false
     public var isRotationWithTwoFingers: Bool
     {
         return _rotationWithTwoFingers
@@ -694,7 +697,7 @@ public class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    /// returns the distance between two points
+    /// - returns: the distance between two points
     private func distance(eventX eventX: CGFloat, startX: CGFloat, eventY: CGFloat, startY: CGFloat) -> CGFloat
     {
         let dx = eventX - startX
@@ -702,7 +705,7 @@ public class PieRadarChartViewBase: ChartViewBase
         return sqrt(dx * dx + dy * dy)
     }
     
-    /// returns the distance between two points
+    /// - returns: the distance between two points
     private func distance(from from: CGPoint, to: CGPoint) -> CGFloat
     {
         let dx = from.x - to.x

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -37,7 +37,7 @@ public class PieRadarChartViewBase: ChartViewBase
         super.init(frame: frame)
     }
     
-    public required init?(coder aDecoder: NSCoder)
+    public required init(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -37,7 +37,7 @@ public class PieRadarChartViewBase: ChartViewBase
         super.init(frame: frame)
     }
     
-    public required init(coder aDecoder: NSCoder)
+    public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -290,7 +290,7 @@ public class PieRadarChartViewBase: ChartViewBase
 
     /// current rotation angle of the pie chart
     ///
-    /// default: 270 --> top (NORTH)
+    /// **default**: 270 --> top (NORTH)
     /// - returns: will always return a normalized value, which will be between 0.0 < 360.0
     public var rotationAngle: CGFloat
     {
@@ -346,11 +346,12 @@ public class PieRadarChartViewBase: ChartViewBase
     
     public override var chartXMin: Double
     {
+        getSelectionDetailsAtIndex(1);
         return 0.0
     }
     
-    /// - returns: an array of SelectionDetail objects for the given x-index.
     /// The SelectionDetail objects give information about the value at the selected index and the DataSet it belongs to.
+    /// - returns: an array of SelectionDetail objects for the given x-index.
     public func getSelectionDetailsAtIndex(xIndex: Int) -> [ChartSelectionDetail]
     {
         var vals = [ChartSelectionDetail]()
@@ -381,7 +382,7 @@ public class PieRadarChartViewBase: ChartViewBase
     /// flag that indicates if rotation is done with two fingers or one.
     /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
     /// 
-    /// default: false
+    /// **default**: false
     public var rotationWithTwoFingers: Bool
     {
         get
@@ -398,7 +399,7 @@ public class PieRadarChartViewBase: ChartViewBase
     /// flag that indicates if rotation is done with two fingers or one.
     /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
     ///
-    /// default: false
+    /// **default**: false
     public var isRotationWithTwoFingers: Bool
     {
         return _rotationWithTwoFingers

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -108,23 +108,23 @@ public class PieRadarChartViewBase: ChartViewBase
                 // this is the space between the legend and the chart
                 let spacing = CGFloat(8.0)
                 
-                var legendWidth = fullLegendWidth + spacing
-                var legendHeight = _legend.neededHeight + _legend.textHeightMax
+                let legendWidth = fullLegendWidth + spacing
+                let legendHeight = _legend.neededHeight + _legend.textHeightMax
 
-                var c = self.midPoint
+                let c = self.midPoint
 
-                var bottomRight = CGPoint(x: self.bounds.width - legendWidth + 15.0, y: legendHeight + 15)
-                var distLegend = distanceToCenter(x: bottomRight.x, y: bottomRight.y)
+                let bottomRight = CGPoint(x: self.bounds.width - legendWidth + 15.0, y: legendHeight + 15)
+                let distLegend = distanceToCenter(x: bottomRight.x, y: bottomRight.y)
 
-                var reference = getPosition(center: c, dist: self.radius,
+                let reference = getPosition(center: c, dist: self.radius,
                     angle: angleForPoint(x: bottomRight.x, y: bottomRight.y))
 
-                var distReference = distanceToCenter(x: reference.x, y: reference.y)
-                var minOffset = CGFloat(5.0)
+                let distReference = distanceToCenter(x: reference.x, y: reference.y)
+                let minOffset = CGFloat(5.0)
 
                 if (distLegend < distReference)
                 {
-                    var diff = distReference - distLegend
+                    let diff = distReference - distLegend
                     legendRight = minOffset + diff
                 }
 
@@ -146,23 +146,23 @@ public class PieRadarChartViewBase: ChartViewBase
                 // this is the space between the legend and the chart
                 let spacing = CGFloat(8.0)
                 
-                var legendWidth = fullLegendWidth + spacing
-                var legendHeight = _legend.neededHeight + _legend.textHeightMax
+                let legendWidth = fullLegendWidth + spacing
+                let legendHeight = _legend.neededHeight + _legend.textHeightMax
 
-                var c = self.midPoint
+                let c = self.midPoint
 
-                var bottomLeft = CGPoint(x: legendWidth - 15.0, y: legendHeight + 15)
-                var distLegend = distanceToCenter(x: bottomLeft.x, y: bottomLeft.y)
+                let bottomLeft = CGPoint(x: legendWidth - 15.0, y: legendHeight + 15)
+                let distLegend = distanceToCenter(x: bottomLeft.x, y: bottomLeft.y)
 
-                var reference = getPosition(center: c, dist: self.radius,
+                let reference = getPosition(center: c, dist: self.radius,
                     angle: angleForPoint(x: bottomLeft.x, y: bottomLeft.y))
 
-                var distReference = distanceToCenter(x: reference.x, y: reference.y)
-                var min = CGFloat(5.0)
+                let distReference = distanceToCenter(x: reference.x, y: reference.y)
+                let min = CGFloat(5.0)
 
                 if (distLegend < distReference)
                 {
-                    var diff = distReference - distLegend
+                    let diff = distReference - distLegend
                     legendLeft = min + diff
                 }
 
@@ -175,7 +175,7 @@ public class PieRadarChartViewBase: ChartViewBase
                     || _legend.position == .BelowChartRight
                     || _legend.position == .BelowChartCenter)
             {
-                var yOffset = self.requiredBottomOffset; // It's possible that we do not need this offset anymore as it is available through the extraOffsets
+                let yOffset = self.requiredBottomOffset; // It's possible that we do not need this offset anymore as it is available through the extraOffsets
                 legendBottom = min(_legend.neededHeight + yOffset, _viewPortHandler.chartHeight * _legend.maxSizePercent)
             }
             
@@ -201,24 +201,24 @@ public class PieRadarChartViewBase: ChartViewBase
             }
         }
 
-        var offsetLeft = max(minOffset, legendLeft)
-        var offsetTop = max(minOffset, legendTop)
-        var offsetRight = max(minOffset, legendRight)
-        var offsetBottom = max(minOffset, max(self.requiredBaseOffset, legendBottom))
+        let offsetLeft = max(minOffset, legendLeft)
+        let offsetTop = max(minOffset, legendTop)
+        let offsetRight = max(minOffset, legendRight)
+        let offsetBottom = max(minOffset, max(self.requiredBaseOffset, legendBottom))
 
         _viewPortHandler.restrainViewPort(offsetLeft: offsetLeft, offsetTop: offsetTop, offsetRight: offsetRight, offsetBottom: offsetBottom)
     }
 
     /// returns the angle relative to the chart center for the given point on the chart in degrees.
     /// The angle is always between 0 and 360°, 0° is NORTH, 90° is EAST, ...
-    public func angleForPoint(#x: CGFloat, y: CGFloat) -> CGFloat
+    public func angleForPoint(x x: CGFloat, y: CGFloat) -> CGFloat
     {
-        var c = centerOffsets
+        let c = centerOffsets
         
-        var tx = Double(x - c.x)
-        var ty = Double(y - c.y)
-        var length = sqrt(tx * tx + ty * ty)
-        var r = acos(ty / length)
+        let tx = Double(x - c.x)
+        let ty = Double(y - c.y)
+        let length = sqrt(tx * tx + ty * ty)
+        let r = acos(ty / length)
 
         var angle = r * ChartUtils.Math.RAD2DEG
 
@@ -241,16 +241,16 @@ public class PieRadarChartViewBase: ChartViewBase
     
     /// Calculates the position around a center point, depending on the distance
     /// from the center, and the angle of the position around the center.
-    internal func getPosition(#center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
+    internal func getPosition(center center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
     {
         return CGPoint(x: center.x + dist * cos(angle * ChartUtils.Math.FDEG2RAD),
                 y: center.y + dist * sin(angle * ChartUtils.Math.FDEG2RAD))
     }
 
     /// Returns the distance of a certain point on the chart to the center of the chart.
-    public func distanceToCenter(#x: CGFloat, y: CGFloat) -> CGFloat
+    public func distanceToCenter(x x: CGFloat, y: CGFloat) -> CGFloat
     {
-        var c = self.centerOffsets
+        let c = self.centerOffsets
 
         var dist = CGFloat(0.0)
 
@@ -315,7 +315,7 @@ public class PieRadarChartViewBase: ChartViewBase
     /// returns the diameter of the pie- or radar-chart
     public var diameter: CGFloat
     {
-        var content = _viewPortHandler.contentRect
+        let content = _viewPortHandler.contentRect
         return min(content.width, content.height)
     }
 
@@ -356,7 +356,7 @@ public class PieRadarChartViewBase: ChartViewBase
         
         for (var i = 0; i < _data.dataSetCount; i++)
         {
-            var dataSet = _data.getDataSetByIndex(i)
+            let dataSet = _data.getDataSetByIndex(i)
             if (dataSet === nil || !dataSet.isHighlightEnabled)
             {
                 continue
@@ -406,7 +406,7 @@ public class PieRadarChartViewBase: ChartViewBase
     private var _spinAnimator: ChartAnimator!
     
     /// Applys a spin animation to the Chart.
-    public func spin(#duration: NSTimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easing: ChartEasingFunctionBlock?)
+    public func spin(duration duration: NSTimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easing: ChartEasingFunctionBlock?)
     {
         if (_spinAnimator != nil)
         {
@@ -422,12 +422,12 @@ public class PieRadarChartViewBase: ChartViewBase
         _spinAnimator.animate(xAxisDuration: duration, easing: easing)
     }
     
-    public func spin(#duration: NSTimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easingOption: ChartEasingOption)
+    public func spin(duration duration: NSTimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easingOption: ChartEasingOption)
     {
         spin(duration: duration, fromAngle: fromAngle, toAngle: toAngle, easing: easingFunctionFromOption(easingOption))
     }
     
-    public func spin(#duration: NSTimeInterval, fromAngle: CGFloat, toAngle: CGFloat)
+    public func spin(duration duration: NSTimeInterval, fromAngle: CGFloat, toAngle: CGFloat)
     {
         spin(duration: duration, fromAngle: fromAngle, toAngle: toAngle, easing: nil)
     }
@@ -459,7 +459,7 @@ public class PieRadarChartViewBase: ChartViewBase
     private var _decelerationDisplayLink: CADisplayLink!
     private var _decelerationAngularVelocity: CGFloat = 0.0
     
-    public override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
         // if rotation by touch is enabled
         if (rotationEnabled)
@@ -468,9 +468,9 @@ public class PieRadarChartViewBase: ChartViewBase
             
             if (!rotationWithTwoFingers)
             {
-                var touch = touches.first as! UITouch!
+                let touch = touches.first as UITouch!
                 
-                var touchLocation = touch.locationInView(self)
+                let touchLocation = touch.locationInView(self)
                 
                 self.resetVelocity()
                 
@@ -491,13 +491,13 @@ public class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    public override func touchesMoved(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
         if (rotationEnabled && !rotationWithTwoFingers)
         {
-            var touch = touches.first as! UITouch!
+            let touch = touches.first as UITouch!
             
-            var touchLocation = touch.locationInView(self)
+            let touchLocation = touch.locationInView(self)
             
             if (isDragDecelerationEnabled)
             {
@@ -521,7 +521,7 @@ public class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    public override func touchesEnded(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
         if (!_isRotating)
         {
@@ -530,9 +530,9 @@ public class PieRadarChartViewBase: ChartViewBase
         
         if (rotationEnabled && !rotationWithTwoFingers)
         {
-            var touch = touches.first as! UITouch!
+            let touch = touches.first as UITouch!
             
-            var touchLocation = touch.locationInView(self)
+            let touchLocation = touch.locationInView(self)
             
             if (isDragDecelerationEnabled)
             {
@@ -557,7 +557,7 @@ public class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    public override func touchesCancelled(touches: Set<NSObject>, withEvent event: UIEvent)
+    public override func touchesCancelled(touches: Set<UITouch>?, withEvent event: UIEvent?)
     {
         super.touchesCancelled(touches, withEvent: event)
         
@@ -572,9 +572,9 @@ public class PieRadarChartViewBase: ChartViewBase
         _velocitySamples.removeAll(keepCapacity: false)
     }
     
-    private func sampleVelocity(#touchLocation: CGPoint)
+    private func sampleVelocity(touchLocation touchLocation: CGPoint)
     {
-        var currentTime = CACurrentMediaTime()
+        let currentTime = CACurrentMediaTime()
         
         _velocitySamples.append(AngularVelocitySample(time: currentTime, angle: angleForPoint(x: touchLocation.x, y: touchLocation.y)))
         
@@ -653,7 +653,7 @@ public class PieRadarChartViewBase: ChartViewBase
     }
     
     /// sets the starting angle of the rotation, this is only used by the touch listener, x and y is the touch position
-    private func setGestureStartAngle(#x: CGFloat, y: CGFloat)
+    private func setGestureStartAngle(x x: CGFloat, y: CGFloat)
     {
         _startAngle = angleForPoint(x: x, y: y)
         
@@ -662,7 +662,7 @@ public class PieRadarChartViewBase: ChartViewBase
     }
     
     /// updates the view rotation depending on the given touch position, also takes the starting angle into consideration
-    private func updateGestureRotation(#x: CGFloat, y: CGFloat)
+    private func updateGestureRotation(x x: CGFloat, y: CGFloat)
     {
         self.rotationAngle = angleForPoint(x: x, y: y) - _startAngle
     }
@@ -678,11 +678,11 @@ public class PieRadarChartViewBase: ChartViewBase
     
     @objc private func decelerationLoop()
     {
-        var currentTime = CACurrentMediaTime()
+        let currentTime = CACurrentMediaTime()
         
         _decelerationAngularVelocity *= self.dragDecelerationFrictionCoef
         
-        var timeInterval = CGFloat(currentTime - _decelerationLastTime)
+        let timeInterval = CGFloat(currentTime - _decelerationLastTime)
         
         self.rotationAngle += _decelerationAngularVelocity * timeInterval
         
@@ -695,18 +695,18 @@ public class PieRadarChartViewBase: ChartViewBase
     }
     
     /// returns the distance between two points
-    private func distance(#eventX: CGFloat, startX: CGFloat, eventY: CGFloat, startY: CGFloat) -> CGFloat
+    private func distance(eventX eventX: CGFloat, startX: CGFloat, eventY: CGFloat, startY: CGFloat) -> CGFloat
     {
-        var dx = eventX - startX
-        var dy = eventY - startY
+        let dx = eventX - startX
+        let dy = eventY - startY
         return sqrt(dx * dx + dy * dy)
     }
     
     /// returns the distance between two points
-    private func distance(#from: CGPoint, to: CGPoint) -> CGFloat
+    private func distance(from from: CGPoint, to: CGPoint) -> CGFloat
     {
-        var dx = from.x - to.x
-        var dy = from.y - to.y
+        let dx = from.x - to.x
+        let dy = from.y - to.y
         return sqrt(dx * dx + dy * dy)
     }
     
@@ -717,8 +717,8 @@ public class PieRadarChartViewBase: ChartViewBase
     {
         if (recognizer.state == UIGestureRecognizerState.Ended)
         {
-            var location = recognizer.locationInView(self)
-            var distance = distanceToCenter(x: location.x, y: location.y)
+            let location = recognizer.locationInView(self)
+            let distance = distanceToCenter(x: location.x, y: location.y)
             
             // check if a slice was touched
             if (distance > self.radius)
@@ -737,7 +737,7 @@ public class PieRadarChartViewBase: ChartViewBase
                     angle /= _animator.phaseY
                 }
                 
-                var index = indexForAngle(angle)
+                let index = indexForAngle(angle)
                 
                 // check if the index could be found
                 if (index < 0)
@@ -747,7 +747,7 @@ public class PieRadarChartViewBase: ChartViewBase
                 }
                 else
                 {
-                    var valsAtIndex = getSelectionDetailsAtIndex(index)
+                    let valsAtIndex = getSelectionDetailsAtIndex(index)
                     
                     var dataSetIndex = 0
                     
@@ -764,7 +764,7 @@ public class PieRadarChartViewBase: ChartViewBase
                     }
                     else
                     {
-                        var h = ChartHighlight(xIndex: index, dataSetIndex: dataSetIndex)
+                        let h = ChartHighlight(xIndex: index, dataSetIndex: dataSetIndex)
                         
                         if (_lastHighlight !== nil && h == _lastHighlight)
                         {
@@ -793,14 +793,14 @@ public class PieRadarChartViewBase: ChartViewBase
         
         if (recognizer.state == UIGestureRecognizerState.Began || recognizer.state == UIGestureRecognizerState.Changed)
         {
-            var angle = ChartUtils.Math.FRAD2DEG * recognizer.rotation
+            let angle = ChartUtils.Math.FRAD2DEG * recognizer.rotation
             
             self.rotationAngle = _startAngle + angle
             setNeedsDisplay()
         }
         else if (recognizer.state == UIGestureRecognizerState.Ended)
         {
-            var angle = ChartUtils.Math.FRAD2DEG * recognizer.rotation
+            let angle = ChartUtils.Math.FRAD2DEG * recognizer.rotation
             
             self.rotationAngle = _startAngle + angle
             setNeedsDisplay()

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -51,7 +51,7 @@ public class RadarChartView: PieRadarChartViewBase
         super.init(frame: frame)
     }
     
-    public required init?(coder aDecoder: NSCoder)
+    public required init(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -174,7 +174,7 @@ public class RadarChartView: PieRadarChartViewBase
         drawMarkers(context: context)
     }
 
-    /// Returns the factor that is needed to transform values into pixels.
+    /// - returns: the factor that is needed to transform values into pixels.
     public var factor: CGFloat
     {
         let content = _viewPortHandler.contentRect
@@ -182,7 +182,7 @@ public class RadarChartView: PieRadarChartViewBase
                 / CGFloat(_yAxis.axisRange)
     }
 
-    /// Returns the angle that each slice in the radar chart occupies.
+    /// - returns: the angle that each slice in the radar chart occupies.
     public var sliceAngle: CGFloat
     {
         return 360.0 / CGFloat(_data.xValCount)
@@ -206,13 +206,13 @@ public class RadarChartView: PieRadarChartViewBase
         return 0
     }
 
-    /// Returns the object that represents all y-labels of the RadarChart.
+    /// - returns: the object that represents all y-labels of the RadarChart.
     public var yAxis: ChartYAxis
     {
         return _yAxis
     }
 
-    /// Returns the object that represents all x-labels that are placed around the RadarChart.
+    /// - returns: the object that represents all x-labels that are placed around the RadarChart.
     public var xAxis: ChartXAxis
     {
         return _xAxis
@@ -234,12 +234,12 @@ public class RadarChartView: PieRadarChartViewBase
         return min(content.width / 2.0, content.height / 2.0)
     }
 
-    /// Returns the maximum value this chart can display on it's y-axis.
+    /// - returns: the maximum value this chart can display on it's y-axis.
     public override var chartYMax: Double { return _yAxis.axisMaximum; }
     
-    /// Returns the minimum value this chart can display on it's y-axis.
+    /// - returns: the minimum value this chart can display on it's y-axis.
     public override var chartYMin: Double { return _yAxis.axisMinimum; }
     
-    /// Returns the range of y-values this chart can display.
+    /// - returns: the range of y-values this chart can display.
     public var yRange: Double { return _yAxis.axisRange}
 }

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -51,7 +51,7 @@ public class RadarChartView: PieRadarChartViewBase
         super.init(frame: frame)
     }
     
-    public required init(coder aDecoder: NSCoder)
+    public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -74,16 +74,16 @@ public class RadarChartView: PieRadarChartViewBase
     {
         super.calcMinMax()
         
-        var minLeft = _data.getYMin(.Left)
-        var maxLeft = _data.getYMax(.Left)
+        let minLeft = _data.getYMin(.Left)
+        let maxLeft = _data.getYMax(.Left)
         
         _chartXMax = Double(_data.xVals.count) - 1.0
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
         
-        var leftRange = CGFloat(abs(maxLeft - (_yAxis.isStartAtZeroEnabled ? 0.0 : minLeft)))
+        let leftRange = CGFloat(abs(maxLeft - (_yAxis.isStartAtZeroEnabled ? 0.0 : minLeft)))
         
-        var topSpaceLeft = leftRange * _yAxis.spaceTop
-        var bottomSpaceLeft = leftRange * _yAxis.spaceBottom
+        let topSpaceLeft = leftRange * _yAxis.spaceTop
+        let bottomSpaceLeft = leftRange * _yAxis.spaceBottom
         
         _chartXMax = Double(_data.xVals.count) - 1.0
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
@@ -100,13 +100,13 @@ public class RadarChartView: PieRadarChartViewBase
         _yAxis.axisRange = abs(_yAxis.axisMaximum - _yAxis.axisMinimum)
     }
 
-    public override func getMarkerPosition(#entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
+    public override func getMarkerPosition(entry entry: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
     {
-        var angle = self.sliceAngle * CGFloat(entry.xIndex) + self.rotationAngle
-        var val = CGFloat(entry.value) * self.factor
-        var c = self.centerOffsets
+        let angle = self.sliceAngle * CGFloat(entry.xIndex) + self.rotationAngle
+        let val = CGFloat(entry.value) * self.factor
+        let c = self.centerOffsets
         
-        var p = CGPoint(x: c.x + val * cos(angle * ChartUtils.Math.FDEG2RAD),
+        let p = CGPoint(x: c.x + val * cos(angle * ChartUtils.Math.FDEG2RAD),
             y: c.y + val * sin(angle * ChartUtils.Math.FDEG2RAD))
         
         return p
@@ -177,7 +177,7 @@ public class RadarChartView: PieRadarChartViewBase
     /// Returns the factor that is needed to transform values into pixels.
     public var factor: CGFloat
     {
-        var content = _viewPortHandler.contentRect
+        let content = _viewPortHandler.contentRect
         return min(content.width / 2.0, content.height / 2.0)
                 / CGFloat(_yAxis.axisRange)
     }
@@ -191,9 +191,9 @@ public class RadarChartView: PieRadarChartViewBase
     public override func indexForAngle(angle: CGFloat) -> Int
     {
         // take the current angle of the chart into consideration
-        var a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
+        let a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
         
-        var sliceAngle = self.sliceAngle
+        let sliceAngle = self.sliceAngle
         
         for (var i = 0; i < _data.xValCount; i++)
         {
@@ -230,7 +230,7 @@ public class RadarChartView: PieRadarChartViewBase
 
     public override var radius: CGFloat
     {
-        var content = _viewPortHandler.contentRect
+        let content = _viewPortHandler.contentRect
         return min(content.width / 2.0, content.height / 2.0)
     }
 

--- a/Charts/Classes/Components/ChartAxisBase.swift
+++ b/Charts/Classes/Components/ChartAxisBase.swift
@@ -48,7 +48,8 @@ public class ChartAxisBase: ChartComponentBase
     private var _limitLines = [ChartLimitLine]()
     
     /// Are the LimitLines drawn behind the data or in front of the data?
-    /// :default: false
+    /// 
+    /// default: false
     public var drawLimitLinesBehindDataEnabled = false
 
     public override init()
@@ -68,7 +69,8 @@ public class ChartAxisBase: ChartComponentBase
     public var isDrawLabelsEnabled: Bool { return drawLabelsEnabled; }
     
     /// Are the LimitLines drawn behind the data or in front of the data?
-    /// :default: false
+    /// 
+    /// default: false
     public var isDrawLimitLinesBehindDataEnabled: Bool { return drawLimitLinesBehindDataEnabled; }
     
     /// Adds a new ChartLimitLine to this axis.
@@ -96,7 +98,7 @@ public class ChartAxisBase: ChartComponentBase
         _limitLines.removeAll(keepCapacity: false)
     }
     
-    /// Returns the LimitLines of this axis.
+    /// - returns: the LimitLines of this axis.
     public var limitLines : [ChartLimitLine]
         {
             return _limitLines

--- a/Charts/Classes/Components/ChartAxisBase.swift
+++ b/Charts/Classes/Components/ChartAxisBase.swift
@@ -37,11 +37,11 @@ public class ChartAxisBase: ChartComponentBase
     public var drawLabelsEnabled = true
     
     /// Sets the used x-axis offset for the labels on this axis.
-    /// :default: 5.0
+    /// **default**: 5.0
     public var xOffset = CGFloat(5.0)
     
     /// Sets the used y-axis offset for the labels on this axis.
-    /// :default: 5.0 (or 0.0 on ChartYAxis)
+    /// **default**: 5.0 (or 0.0 on ChartYAxis)
     public var yOffset = CGFloat(5.0)
     
     /// array of limitlines that can be set for the axis
@@ -49,7 +49,7 @@ public class ChartAxisBase: ChartComponentBase
     
     /// Are the LimitLines drawn behind the data or in front of the data?
     /// 
-    /// default: false
+    /// **default**: false
     public var drawLimitLinesBehindDataEnabled = false
 
     public override init()
@@ -70,7 +70,7 @@ public class ChartAxisBase: ChartComponentBase
     
     /// Are the LimitLines drawn behind the data or in front of the data?
     /// 
-    /// default: false
+    /// **default**: false
     public var isDrawLimitLinesBehindDataEnabled: Bool { return drawLimitLinesBehindDataEnabled; }
     
     /// Adds a new ChartLimitLine to this axis.

--- a/Charts/Classes/Components/ChartLegend.swift
+++ b/Charts/Classes/Components/ChartLegend.swift
@@ -63,7 +63,8 @@ public class ChartLegend: ChartComponentBase
     public var extraLabels: [String?] { return _extraLabels; }
     
     /// Are the legend labels/colors a custom value or auto calculated? If false, then it's auto, if true, then custom.
-    /// :default: false (automatic legend)
+    /// 
+    /// default: false (automatic legend)
     private var _isLegendCustom = false
 
     public var position = ChartLegendPosition.BelowChartLeft
@@ -201,6 +202,7 @@ public class ChartLegend: ChartComponentBase
     /// this is currently supported only for: BelowChartLeft, BelowChartRight, BelowChartCenter.
     /// note that word wrapping a legend takes a toll on performance.
     /// you may want to set maxSizePercent when word wrapping, to set the point where the text wraps.
+    /// 
     /// default: false
     public var wordWrapEnabled = false
     
@@ -211,6 +213,7 @@ public class ChartLegend: ChartComponentBase
     /// If the legend is to the right/left of the chart, then this affects the width of the legend.
     /// If the legend is to the top/bottom of the chart, then this affects the height of the legend.
     /// If the legend is the center of the piechart, then this defines the size of the rectangular bounds out of the size of the "hole".
+    /// 
     /// default: 0.95 (95%)
     public var maxSizePercent: CGFloat = 0.95
     
@@ -388,8 +391,8 @@ public class ChartLegend: ChartComponentBase
         _isLegendCustom = false
     }
     
-    /// Returns true if a custom legend labels and colors has been set
-    /// :default: false (automatic legend)
+    /// default: false (automatic legend)
+    /// - returns: true if a custom legend labels and colors has been set
     public var isLegendCustom: Bool
     {
         return _isLegendCustom

--- a/Charts/Classes/Components/ChartLegend.swift
+++ b/Charts/Classes/Components/ChartLegend.swift
@@ -64,7 +64,7 @@ public class ChartLegend: ChartComponentBase
     
     /// Are the legend labels/colors a custom value or auto calculated? If false, then it's auto, if true, then custom.
     /// 
-    /// default: false (automatic legend)
+    /// **default**: false (automatic legend)
     private var _isLegendCustom = false
 
     public var position = ChartLegendPosition.BelowChartLeft
@@ -199,11 +199,11 @@ public class ChartLegend: ChartComponentBase
     public var textHeightMax = CGFloat(0.0)
     
     /// flag that indicates if word wrapping is enabled
-    /// this is currently supported only for: BelowChartLeft, BelowChartRight, BelowChartCenter.
+    /// this is currently supported only for: `BelowChartLeft`, `BelowChartRight`, `BelowChartCenter`.
     /// note that word wrapping a legend takes a toll on performance.
     /// you may want to set maxSizePercent when word wrapping, to set the point where the text wraps.
     /// 
-    /// default: false
+    /// **default**: false
     public var wordWrapEnabled = false
     
     /// if this is set, then word wrapping the legend is enabled.
@@ -214,7 +214,7 @@ public class ChartLegend: ChartComponentBase
     /// If the legend is to the top/bottom of the chart, then this affects the height of the legend.
     /// If the legend is the center of the piechart, then this defines the size of the rectangular bounds out of the size of the "hole".
     /// 
-    /// default: 0.95 (95%)
+    /// **default**: 0.95 (95%)
     public var maxSizePercent: CGFloat = 0.95
     
     public func calculateDimensions(labelFont labelFont: UIFont, viewPortHandler: ChartViewPortHandler)
@@ -377,7 +377,7 @@ public class ChartLegend: ChartComponentBase
     /// * A nil label will start a group.
     /// * A nil color will avoid drawing a form, and a clearColor will leave a space for the form.
     /// This will disable the feature that automatically calculates the legend labels and colors from the datasets.
-    /// Call resetCustom(...) to re-enable automatic calculation (and then notifyDataSetChanged() is needed).
+    /// Call `resetCustom(...)` to re-enable automatic calculation (and then `notifyDataSetChanged()` is needed).
     public func setCustom(colors colors: [UIColor?], labels: [String?])
     {
         self.labels = labels
@@ -385,13 +385,13 @@ public class ChartLegend: ChartComponentBase
         _isLegendCustom = true
     }
     
-    /// Calling this will disable the custom legend labels (set by setLegend(...)). Instead, the labels will again be calculated automatically (after notifyDataSetChanged() is called).
+    /// Calling this will disable the custom legend labels (set by `setLegend(...)`). Instead, the labels will again be calculated automatically (after `notifyDataSetChanged()` is called).
     public func resetCustom()
     {
         _isLegendCustom = false
     }
     
-    /// default: false (automatic legend)
+    /// **default**: false (automatic legend)
     /// - returns: true if a custom legend labels and colors has been set
     public var isLegendCustom: Bool
     {
@@ -407,7 +407,7 @@ public class ChartLegend: ChartComponentBase
     public var extraLabelsObjc: [NSObject] { return ChartUtils.bridgedObjCGetStringArray(swift: _extraLabels); }
     
     /// the legend colors array, each color is for the form drawn at the same index
-    /// (ObjC bridging functions, as Swift 1.2 does not bridge optionals in array to NSNulls)
+    /// (ObjC bridging functions, as Swift 1.2 does not bridge optionals in array to `NSNull`s)
     public var colorsObjc: [NSObject]
     {
         get { return ChartUtils.bridgedObjCGetUIColorArray(swift: colors); }
@@ -415,7 +415,7 @@ public class ChartLegend: ChartComponentBase
     }
     
     // the legend text array. a nil label will start a group.
-    /// (ObjC bridging functions, as Swift 1.2 does not bridge optionals in array to NSNulls)
+    /// (ObjC bridging functions, as Swift 1.2 does not bridge optionals in array to `NSNull`s)
     public var labelsObjc: [NSObject]
     {
         get { return ChartUtils.bridgedObjCGetStringArray(swift: labels); }
@@ -423,7 +423,7 @@ public class ChartLegend: ChartComponentBase
     }
     
     /// colors and labels that will be appended to the end of the auto calculated colors and labels after calculating the legend.
-    /// (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
+    /// (if the legend has already been calculated, you will need to call `notifyDataSetChanged()` to let the changes take effect)
     public func setExtra(colors colors: [NSObject], labels: [NSObject])
     {
         if (colors.count != labels.count)
@@ -441,7 +441,7 @@ public class ChartLegend: ChartComponentBase
     /// * A nil label will start a group.
     /// * A nil color will avoid drawing a form, and a clearColor will leave a space for the form.
     /// This will disable the feature that automatically calculates the legend labels and colors from the datasets.
-    /// Call resetLegendToAuto(...) to re-enable automatic calculation, and then if needed - call notifyDataSetChanged() on the chart to make it refresh the data.
+    /// Call `resetLegendToAuto(...)` to re-enable automatic calculation, and then if needed - call `notifyDataSetChanged()` on the chart to make it refresh the data.
     public func setCustom(colors colors: [NSObject], labels: [NSObject])
     {
         if (colors.count != labels.count)

--- a/Charts/Classes/Components/ChartLegend.swift
+++ b/Charts/Classes/Components/ChartLegend.swift
@@ -128,7 +128,7 @@ public class ChartLegend: ChartComponentBase
                 continue
             }
             
-            var size = (labels[i] as NSString!).sizeWithAttributes([NSFontAttributeName: font])
+            let size = (labels[i] as NSString!).sizeWithAttributes([NSFontAttributeName: font])
             
             if (size.width > maxW)
             {
@@ -167,7 +167,7 @@ public class ChartLegend: ChartComponentBase
                     width += formSize + formToTextSpace
                 }
                 
-                var size = (labels[i] as NSString!).sizeWithAttributes([NSFontAttributeName: labelFont])
+                let size = (labels[i] as NSString!).sizeWithAttributes([NSFontAttributeName: labelFont])
                 
                 width += size.width
                 height += size.height
@@ -214,7 +214,7 @@ public class ChartLegend: ChartComponentBase
     /// default: 0.95 (95%)
     public var maxSizePercent: CGFloat = 0.95
     
-    public func calculateDimensions(#labelFont: UIFont, viewPortHandler: ChartViewPortHandler)
+    public func calculateDimensions(labelFont labelFont: UIFont, viewPortHandler: ChartViewPortHandler)
     {
         if (position == .RightOfChart
             || position == .RightOfChartCenter
@@ -222,8 +222,8 @@ public class ChartLegend: ChartComponentBase
             || position == .LeftOfChartCenter
             || position == .PiechartCenter)
         {
-            var maxEntrySize = getMaximumEntrySize(labelFont)
-            var fullSize = getFullSize(labelFont)
+            let maxEntrySize = getMaximumEntrySize(labelFont)
+            let fullSize = getFullSize(labelFont)
             
             neededWidth = maxEntrySize.width
             neededHeight = fullSize.height
@@ -236,16 +236,16 @@ public class ChartLegend: ChartComponentBase
         {
             var labels = self.labels
             var colors = self.colors
-            var labelCount = labels.count
+            let labelCount = labels.count
             
-            var labelLineHeight = labelFont.lineHeight
-            var formSize = self.formSize
-            var formToTextSpace = self.formToTextSpace
-            var xEntrySpace = self.xEntrySpace
-            var stackSpace = self.stackSpace
-            var wordWrapEnabled = self.wordWrapEnabled
+            let labelLineHeight = labelFont.lineHeight
+            let formSize = self.formSize
+            let formToTextSpace = self.formToTextSpace
+            let xEntrySpace = self.xEntrySpace
+            let stackSpace = self.stackSpace
+            let wordWrapEnabled = self.wordWrapEnabled
             
-            var contentWidth: CGFloat = viewPortHandler.contentWidth
+            let contentWidth: CGFloat = viewPortHandler.contentWidth
             
             // Prepare arrays for calculated layout
             if (calculatedLabelSizes.count != labelCount)
@@ -262,7 +262,7 @@ public class ChartLegend: ChartComponentBase
             
             // Start calculating layout
             
-            var labelAttrs = [NSFontAttributeName: labelFont]
+            let labelAttrs = [NSFontAttributeName: labelFont]
             var maxLineWidth: CGFloat = 0.0
             var currentLineWidth: CGFloat = 0.0
             var requiredWidth: CGFloat = 0.0
@@ -270,7 +270,7 @@ public class ChartLegend: ChartComponentBase
             
             for (var i = 0; i < labelCount; i++)
             {
-                var drawingForm = colors[i] != nil
+                let drawingForm = colors[i] != nil
                 
                 calculatedLabelBreakPoints[i] = false
                 
@@ -306,7 +306,7 @@ public class ChartLegend: ChartComponentBase
                 
                 if (labels[i] != nil || i == labelCount - 1)
                 {
-                    var requiredSpacing = currentLineWidth == 0.0 ? 0.0 : xEntrySpace
+                    let requiredSpacing = currentLineWidth == 0.0 ? 0.0 : xEntrySpace
                     
                     if (!wordWrapEnabled || // No word wrapping, it must fit.
                         currentLineWidth == 0.0 || // The line is empty, it must fit.
@@ -337,7 +337,7 @@ public class ChartLegend: ChartComponentBase
                 stackedStartIndex = labels[i] != nil ? -1 : stackedStartIndex
             }
             
-            var maxEntrySize = getMaximumEntrySize(labelFont)
+            let maxEntrySize = getMaximumEntrySize(labelFont)
             
             textWidthMax = maxEntrySize.width
             textHeightMax = maxEntrySize.height
@@ -347,8 +347,8 @@ public class ChartLegend: ChartComponentBase
         }
         else
         {
-            var maxEntrySize = getMaximumEntrySize(labelFont)
-            var fullSize = getFullSize(labelFont)
+            let maxEntrySize = getMaximumEntrySize(labelFont)
+            let fullSize = getFullSize(labelFont)
             
             /* RightOfChartInside, LeftOfChartInside */
             neededWidth = fullSize.width
@@ -362,7 +362,7 @@ public class ChartLegend: ChartComponentBase
     
     /// colors and labels that will be appended to the end of the auto calculated colors and labels after calculating the legend.
     /// (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
-    public func setExtra(#colors: [UIColor?], labels: [String?])
+    public func setExtra(colors colors: [UIColor?], labels: [String?])
     {
         self._extraLabels = labels
         self._extraColors = colors
@@ -375,7 +375,7 @@ public class ChartLegend: ChartComponentBase
     /// * A nil color will avoid drawing a form, and a clearColor will leave a space for the form.
     /// This will disable the feature that automatically calculates the legend labels and colors from the datasets.
     /// Call resetCustom(...) to re-enable automatic calculation (and then notifyDataSetChanged() is needed).
-    public func setCustom(#colors: [UIColor?], labels: [String?])
+    public func setCustom(colors colors: [UIColor?], labels: [String?])
     {
         self.labels = labels
         self.colors = colors
@@ -421,7 +421,7 @@ public class ChartLegend: ChartComponentBase
     
     /// colors and labels that will be appended to the end of the auto calculated colors and labels after calculating the legend.
     /// (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
-    public func setExtra(#colors: [NSObject], labels: [NSObject])
+    public func setExtra(colors colors: [NSObject], labels: [NSObject])
     {
         if (colors.count != labels.count)
         {
@@ -439,7 +439,7 @@ public class ChartLegend: ChartComponentBase
     /// * A nil color will avoid drawing a form, and a clearColor will leave a space for the form.
     /// This will disable the feature that automatically calculates the legend labels and colors from the datasets.
     /// Call resetLegendToAuto(...) to re-enable automatic calculation, and then if needed - call notifyDataSetChanged() on the chart to make it refresh the data.
-    public func setCustom(#colors: [NSObject], labels: [NSObject])
+    public func setCustom(colors colors: [NSObject], labels: [NSObject])
     {
         if (colors.count != labels.count)
         {

--- a/Charts/Classes/Components/ChartMarker.swift
+++ b/Charts/Classes/Components/ChartMarker.swift
@@ -51,7 +51,7 @@ public class ChartMarker: ChartComponentBase
     
     /// This method enables a custom ChartMarker to update it's content everytime the MarkerView is redrawn according to the data entry it points to.
     ///
-    /// :param: highlight the highlight object contains information about the highlighted value such as it's dataset-index, the selected range or stack-index (only stacked bar entries).
+    /// - parameter highlight: the highlight object contains information about the highlighted value such as it's dataset-index, the selected range or stack-index (only stacked bar entries).
     public func refreshContent(entry entry: ChartDataEntry, highlight: ChartHighlight)
     {
         // Do nothing here...

--- a/Charts/Classes/Components/ChartMarker.swift
+++ b/Charts/Classes/Components/ChartMarker.swift
@@ -37,12 +37,12 @@ public class ChartMarker: ChartComponentBase
     }
     
     /// Draws the ChartMarker on the given position on the given context
-    public func draw(#context: CGContext, point: CGPoint)
+    public func draw(context context: CGContext, point: CGPoint)
     {
-        var offset = self.offset
-        var size = self.size
+        let offset = self.offset
+        let size = self.size
         
-        var rect = CGRect(x: point.x + offset.x, y: point.y + offset.y, width: size.width, height: size.height)
+        let rect = CGRect(x: point.x + offset.x, y: point.y + offset.y, width: size.width, height: size.height)
         
         UIGraphicsPushContext(context)
         image!.drawInRect(rect)
@@ -52,7 +52,7 @@ public class ChartMarker: ChartComponentBase
     /// This method enables a custom ChartMarker to update it's content everytime the MarkerView is redrawn according to the data entry it points to.
     ///
     /// :param: highlight the highlight object contains information about the highlighted value such as it's dataset-index, the selected range or stack-index (only stacked bar entries).
-    public func refreshContent(#entry: ChartDataEntry, highlight: ChartHighlight)
+    public func refreshContent(entry entry: ChartDataEntry, highlight: ChartHighlight)
     {
         // Do nothing here...
     }

--- a/Charts/Classes/Components/ChartXAxis.swift
+++ b/Charts/Classes/Components/ChartXAxis.swift
@@ -34,18 +34,18 @@ public class ChartXAxis: ChartAxisBase
     /// the space that should be left out (in characters) between the x-axis labels
     /// This only applies if the number of labels that will be skipped in between drawn axis labels is not custom set.
     /// 
-    /// default: 4
+    /// **default**: 4
     public var spaceBetweenLabels = Int(4)
     
-    /// the modulus that indicates if a value at a specified index in an array(list) for the x-axis-labels is drawn or not. Draw when (index % modulus) == 0.
+    /// the modulus that indicates if a value at a specified index in an array(list) for the x-axis-labels is drawn or not. Draw when `(index % modulus) == 0`.
     public var axisLabelModulus = Int(1)
     
     /// Is axisLabelModulus a custom value or auto calculated? If false, then it's auto, if true, then custom.
     /// 
-    /// default: false (automatic modulus)
+    /// **default**: false (automatic modulus)
     private var _isAxisModulusCustom = false
 
-    /// the modulus that indicates if a value at a specified index in an array(list) for the y-axis-labels is drawn or not. Draw when (index % modulus) == 0.
+    /// the modulus that indicates if a value at a specified index in an array(list) for the y-axis-labels is drawn or not. Draw when `(index % modulus) == 0`.
     /// Used only for Horizontal BarChart
     public var yAxisLabelModulus = Int(1)
 
@@ -56,9 +56,9 @@ public class ChartXAxis: ChartAxisBase
     public var labelPosition = XAxisLabelPosition.Top
     
     /// if set to true, word wrapping the labels will be enabled.
-    /// word wrapping is done using (value width * labelWidth)
+    /// word wrapping is done using `(value width * labelWidth)`
     ///
-    /// *NOTE: currently supports all charts except pie/radar/horizontal-bar*
+    /// *Note: currently supports all charts except pie/radar/horizontal-bar*
     public var wordWrapEnabled = false
     
     /// - returns: true if word wrapping the labels is enabled
@@ -67,7 +67,7 @@ public class ChartXAxis: ChartAxisBase
     /// the width for wrapping the labels, as percentage out of one value width.
     /// used only when isWordWrapEnabled = true.
     /// 
-    /// default: 1.0
+    /// **default**: 1.0
     public var wordWrapWidthPercent: CGFloat = 1.0
     
     public override init()
@@ -99,7 +99,7 @@ public class ChartXAxis: ChartAxisBase
 
     /// Sets the number of labels that should be skipped on the axis before the next label is drawn. 
     /// This will disable the feature that automatically calculates an adequate space between the axis labels and set the number of labels to be skipped to the fixed number provided by this method. 
-    /// Call resetLabelsToSkip(...) to re-enable automatic calculation.
+    /// Call `resetLabelsToSkip(...)` to re-enable automatic calculation.
     public func setLabelsToSkip(count: Int)
     {
         _isAxisModulusCustom = true
@@ -114,7 +114,7 @@ public class ChartXAxis: ChartAxisBase
         }
     }
     
-    /// Calling this will disable a custom number of labels to be skipped (set by setLabelsToSkip(...)) while drawing the x-axis. Instead, the number of values to skip will again be calculated automatically.
+    /// Calling this will disable a custom number of labels to be skipped (set by `setLabelsToSkip(...)`) while drawing the x-axis. Instead, the number of values to skip will again be calculated automatically.
     public func resetLabelsToSkip()
     {
         _isAxisModulusCustom = false

--- a/Charts/Classes/Components/ChartXAxis.swift
+++ b/Charts/Classes/Components/ChartXAxis.swift
@@ -77,9 +77,9 @@ public class ChartXAxis: ChartAxisBase
         
         for (var i = 0; i < values.count; i++)
         {
-            var text = values[i]
+            let text = values[i]
             
-            if (text != nil && count(longest) < count(text!))
+            if (text != nil && longest.characters.count < (text!).characters.count)
             {
                 longest = text!
             }

--- a/Charts/Classes/Components/ChartXAxis.swift
+++ b/Charts/Classes/Components/ChartXAxis.swift
@@ -33,14 +33,16 @@ public class ChartXAxis: ChartAxisBase
     
     /// the space that should be left out (in characters) between the x-axis labels
     /// This only applies if the number of labels that will be skipped in between drawn axis labels is not custom set.
-    /// :default: 4
+    /// 
+    /// default: 4
     public var spaceBetweenLabels = Int(4)
     
     /// the modulus that indicates if a value at a specified index in an array(list) for the x-axis-labels is drawn or not. Draw when (index % modulus) == 0.
     public var axisLabelModulus = Int(1)
     
     /// Is axisLabelModulus a custom value or auto calculated? If false, then it's auto, if true, then custom.
-    /// :default: false (automatic modulus)
+    /// 
+    /// default: false (automatic modulus)
     private var _isAxisModulusCustom = false
 
     /// the modulus that indicates if a value at a specified index in an array(list) for the y-axis-labels is drawn or not. Draw when (index % modulus) == 0.
@@ -55,15 +57,17 @@ public class ChartXAxis: ChartAxisBase
     
     /// if set to true, word wrapping the labels will be enabled.
     /// word wrapping is done using (value width * labelWidth)
-    /// NOTE: currently supports all charts except pie/radar/horizontal-bar
+    ///
+    /// *NOTE: currently supports all charts except pie/radar/horizontal-bar*
     public var wordWrapEnabled = false
     
-    /// :returns true if word wrapping the labels is enabled
+    /// - returns: true if word wrapping the labels is enabled
     public var isWordWrapEnabled: Bool { return wordWrapEnabled }
     
     /// the width for wrapping the labels, as percentage out of one value width.
     /// used only when isWordWrapEnabled = true.
-    /// :default 1.0
+    /// 
+    /// default: 1.0
     public var wordWrapWidthPercent: CGFloat = 1.0
     
     public override init()
@@ -116,7 +120,7 @@ public class ChartXAxis: ChartAxisBase
         _isAxisModulusCustom = false
     }
     
-    /// Returns true if a custom axis-modulus has been set that determines the number of labels to skip when drawing.
+    /// - returns: true if a custom axis-modulus has been set that determines the number of labels to skip when drawing.
     public var isAxisModulusCustom: Bool
     {
         return _isAxisModulusCustom

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -93,12 +93,14 @@ public class ChartYAxis: ChartAxisBase
     private var _axisDependency = AxisDependency.Left
     
     /// the minimum width that the axis should take
-    /// :default 0.0
+    /// 
+    /// default: 0.0
     public var minWidth = CGFloat(0)
     
     /// the maximum width that the axis can take.
     /// use zero for disabling the maximum
-    /// :default 0.0 (no maximum specified)
+    /// 
+    /// default: 0.0 (no maximum specified)
     public var maxWidth = CGFloat(0)
     
     public override init()
@@ -207,7 +209,7 @@ public class ChartYAxis: ChartAxisBase
         return longest
     }
 
-    /// Returns the formatted y-label at the specified index. This will either use the auto-formatter or the custom formatter (if one is set).
+    /// - returns: the formatted y-label at the specified index. This will either use the auto-formatter or the custom formatter (if one is set).
     public func getFormattedLabel(index: Int) -> String
     {
         if (index < 0 || index >= entries.count)
@@ -218,7 +220,7 @@ public class ChartYAxis: ChartAxisBase
         return (valueFormatter ?? _defaultValueFormatter).stringFromNumber(entries[index])!
     }
     
-    /// Returns true if this axis needs horizontal offset, false if no offset is needed.
+    /// - returns: true if this axis needs horizontal offset, false if no offset is needed.
     public var needsOffset: Bool
     {
         if (isEnabled && isDrawLabelsEnabled && labelPosition == .OutsideChart)

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -177,7 +177,7 @@ public class ChartYAxis: ChartAxisBase
     
     public func requiredSize() -> CGSize
     {
-        var label = getLongestLabel() as NSString
+        let label = getLongestLabel() as NSString
         var size = label.sizeWithAttributes([NSFontAttributeName: labelFont])
         size.width += xOffset * 2.0
         size.height += yOffset * 2.0
@@ -196,9 +196,9 @@ public class ChartYAxis: ChartAxisBase
         
         for (var i = 0; i < entries.count; i++)
         {
-            var text = getFormattedLabel(i)
+            let text = getFormattedLabel(i)
             
-            if (count(longest) < count(text))
+            if (longest.characters.count < text.characters.count)
             {
                 longest = text
             }

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -64,14 +64,14 @@ public class ChartYAxis: ChartAxisBase
     
     /// A custom minimum value for this axis. 
     /// If set, this value will not be calculated automatically depending on the provided data. 
-    /// Use resetCustomAxisMin() to undo this. 
+    /// Use `resetCustomAxisMin()` to undo this.
     /// Do not forget to set startAtZeroEnabled = false if you use this method.
     /// Otherwise, the axis-minimum value will still be forced to 0.
     public var customAxisMin = Double.NaN
         
     /// Set a custom maximum value for this axis. 
     /// If set, this value will not be calculated automatically depending on the provided data. 
-    /// Use resetCustomAxisMax() to undo this.
+    /// Use `resetCustomAxisMax()` to undo this.
     public var customAxisMax = Double.NaN
 
     /// axis space from the largest value to the top in percent of the total axis range
@@ -94,13 +94,13 @@ public class ChartYAxis: ChartAxisBase
     
     /// the minimum width that the axis should take
     /// 
-    /// default: 0.0
+    /// **default**: 0.0
     public var minWidth = CGFloat(0)
     
     /// the maximum width that the axis can take.
     /// use zero for disabling the maximum
     /// 
-    /// default: 0.0 (no maximum specified)
+    /// **default**: 0.0 (no maximum specified)
     public var maxWidth = CGFloat(0)
     
     public override init()

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -237,7 +237,7 @@ public class ChartYAxis: ChartAxisBase
     
     public var isStartAtZeroEnabled: Bool { return startAtZeroEnabled; }
 
-    /// :returns: true if focing the y-label count is enabled. Default: false
+    /// - returns: true if focing the y-label count is enabled. Default: false
     public var isForceLabelsEnabled: Bool { return forceLabelsEnabled }
 
     public var isShowOnlyMinMaxEnabled: Bool { return showOnlyMinMaxEnabled; }

--- a/Charts/Classes/Data/BarChartData.swift
+++ b/Charts/Classes/Data/BarChartData.swift
@@ -50,7 +50,7 @@ public class BarChartData: BarLineScatterCandleChartData
         }
     }
     
-    /// Returns true if this BarData object contains grouped DataSets (more than 1 DataSet).
+    /// - returns: true if this BarData object contains grouped DataSets (more than 1 DataSet).
     public var isGrouped: Bool
     {
         return _dataSets.count > 1 ? true : false

--- a/Charts/Classes/Data/BarChartDataEntry.swift
+++ b/Charts/Classes/Data/BarChartDataEntry.swift
@@ -131,7 +131,7 @@ public class BarChartDataEntry: ChartDataEntry
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! BarChartDataEntry
+        let copy = super.copyWithZone(zone) as! BarChartDataEntry
         copy._values = _values
         copy.value = value
         copy._negativeSum = _negativeSum

--- a/Charts/Classes/Data/BarChartDataEntry.swift
+++ b/Charts/Classes/Data/BarChartDataEntry.swift
@@ -70,13 +70,13 @@ public class BarChartDataEntry: ChartDataEntry
         return remainder
     }
     
-    /// :returns: the sum of all negative values this entry (if stacked) contains. (this is a positive number)
+    /// - returns: the sum of all negative values this entry (if stacked) contains. (this is a positive number)
     public var negativeSum: Double
     {
         return _negativeSum
     }
     
-    /// :returns: the sum of all positive values this entry (if stacked) contains.
+    /// - returns: the sum of all positive values this entry (if stacked) contains.
     public var positiveSum: Double
     {
         return _positiveSum
@@ -140,8 +140,8 @@ public class BarChartDataEntry: ChartDataEntry
     
     /// Calculates the sum across all values of the given stack.
     ///
-    /// :param: vals
-    /// :returns:
+    /// - parameter vals:
+    /// - returns:
     private static func calcSum(vals: [Double]?) -> Double
     {
         if vals == nil

--- a/Charts/Classes/Data/BarChartDataSet.swift
+++ b/Charts/Classes/Data/BarChartDataSet.swift
@@ -50,7 +50,7 @@ public class BarChartDataSet: BarLineScatterCandleChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! BarChartDataSet
+        let copy = super.copyWithZone(zone) as! BarChartDataSet
         copy.barSpace = barSpace
         copy._stackSize = _stackSize
         copy.barShadowColor = barShadowColor
@@ -68,7 +68,7 @@ public class BarChartDataSet: BarLineScatterCandleChartDataSet
         
         for (var i = 0; i < yVals.count; i++)
         {
-            var vals = yVals[i].values
+            let vals = yVals[i].values
             
             if (vals == nil)
             {
@@ -90,10 +90,10 @@ public class BarChartDataSet: BarLineScatterCandleChartDataSet
             {
                 if vals.count > _stackSize
                 {
-                    _stackSize = vals.count
-                }
+                _stackSize = vals.count
             }
         }
+    }
     }
     
     internal override func calcMinMax(#start : Int, end: Int)

--- a/Charts/Classes/Data/BarChartDataSet.swift
+++ b/Charts/Classes/Data/BarChartDataSet.swift
@@ -96,7 +96,7 @@ public class BarChartDataSet: BarLineScatterCandleChartDataSet
     }
     }
     
-    internal override func calcMinMax(#start : Int, end: Int)
+    internal override func calcMinMax(start start : Int, end: Int)
     {
         let yValCount = _yVals.count
         

--- a/Charts/Classes/Data/BarChartDataSet.swift
+++ b/Charts/Classes/Data/BarChartDataSet.swift
@@ -163,19 +163,19 @@ public class BarChartDataSet: BarLineScatterCandleChartDataSet
         }
     }
     
-    /// Returns the maximum number of bars that can be stacked upon another in this DataSet.
+    /// - returns: the maximum number of bars that can be stacked upon another in this DataSet.
     public var stackSize: Int
     {
         return _stackSize
     }
     
-    /// Returns true if this DataSet is stacked (stacksize > 1) or not.
+    /// - returns: true if this DataSet is stacked (stacksize > 1) or not.
     public var isStacked: Bool
     {
         return _stackSize > 1 ? true : false
     }
     
-    /// returns the overall entry count, including counting each stack-value individually
+    /// - returns: the overall entry count, including counting each stack-value individually
     public var entryCountStacks: Int
     {
         return _entryCountStacks

--- a/Charts/Classes/Data/BarLineScatterCandleChartDataSet.swift
+++ b/Charts/Classes/Data/BarLineScatterCandleChartDataSet.swift
@@ -25,7 +25,7 @@ public class BarLineScatterCandleChartDataSet: ChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! BarLineScatterCandleChartDataSet
+        let copy = super.copyWithZone(zone) as! BarLineScatterCandleChartDataSet
         copy.highlightColor = highlightColor
         copy.highlightLineWidth = highlightLineWidth
         copy.highlightLineDashPhase = highlightLineDashPhase

--- a/Charts/Classes/Data/BubbleChartDataEntry.swift
+++ b/Charts/Classes/Data/BubbleChartDataEntry.swift
@@ -42,7 +42,7 @@ public class BubbleChartDataEntry: ChartDataEntry
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! BubbleChartDataEntry
+        let copy = super.copyWithZone(zone) as! BubbleChartDataEntry
         copy.size = size
         return copy
     }

--- a/Charts/Classes/Data/BubbleChartDataEntry.swift
+++ b/Charts/Classes/Data/BubbleChartDataEntry.swift
@@ -17,9 +17,9 @@ public class BubbleChartDataEntry: ChartDataEntry
     /// The size of the bubble.
     public var size = CGFloat(0.0)
     
-    /// :xIndex: The index on the x-axis.
-    /// :val: The value on the y-axis.
-    /// :size: The size of the bubble.
+    /// - parameter xIndex: The index on the x-axis.
+    /// - parameter val: The value on the y-axis.
+    /// - parameter size: The size of the bubble.
     public init(xIndex: Int, value: Double, size: CGFloat)
     {
         super.init(value: value, xIndex: xIndex)
@@ -27,10 +27,10 @@ public class BubbleChartDataEntry: ChartDataEntry
         self.size = size
     }
     
-    /// :xIndex: The index on the x-axis.
-    /// :val: The value on the y-axis.
-    /// :size: The size of the bubble.
-    /// :data: Spot for additional data this Entry represents.
+    /// - parameter xIndex: The index on the x-axis.
+    /// - parameter val: The value on the y-axis.
+    /// - parameter size: The size of the bubble.
+    /// - parameter data: Spot for additional data this Entry represents.
     public init(xIndex: Int, value: Double, size: CGFloat, data: AnyObject?)
     {
         super.init(value: value, xIndex: xIndex, data: data)

--- a/Charts/Classes/Data/BubbleChartDataSet.swift
+++ b/Charts/Classes/Data/BubbleChartDataSet.swift
@@ -28,7 +28,7 @@ public class BubbleChartDataSet: BarLineScatterCandleChartDataSet
         super.setColor(color.colorWithAlphaComponent(alpha))
     }
     
-    internal override func calcMinMax(#start: Int, end: Int)
+    internal override func calcMinMax(start start: Int, end: Int)
     {
         if (yVals.count == 0)
         {

--- a/Charts/Classes/Data/CandleChartDataEntry.swift
+++ b/Charts/Classes/Data/CandleChartDataEntry.swift
@@ -47,13 +47,13 @@ public class CandleChartDataEntry: ChartDataEntry
         self.close = close
     }
     
-    /// Returns the overall range (difference) between shadow-high and shadow-low.
+    /// - returns: the overall range (difference) between shadow-high and shadow-low.
     public var shadowRange: Double
     {
         return abs(high - low)
     }
     
-    /// Returns the body size (difference between open and close).
+    /// - returns: the body size (difference between open and close).
     public var bodyRange: Double
     {
         return abs(open - close)

--- a/Charts/Classes/Data/CandleChartDataEntry.swift
+++ b/Charts/Classes/Data/CandleChartDataEntry.swift
@@ -76,7 +76,7 @@ public class CandleChartDataEntry: ChartDataEntry
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! CandleChartDataEntry
+        let copy = super.copyWithZone(zone) as! CandleChartDataEntry
         copy.high = high
         copy.high = low
         copy.high = open

--- a/Charts/Classes/Data/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/CandleChartDataSet.swift
@@ -18,11 +18,13 @@ import UIKit
 public class CandleChartDataSet: LineScatterCandleChartDataSet
 {
     /// the width of the candle-shadow-line in pixels. 
-    /// :default: 3.0
+    /// 
+    /// default: 3.0
     public var shadowWidth = CGFloat(1.5)
 
     /// the space between the candle entries
-    /// :default: 0.1 (10%)
+    /// 
+    /// default: 0.1 (10%)
     private var _bodySpace = CGFloat(0.1)
     
     /// the color of the shadow line
@@ -91,7 +93,7 @@ public class CandleChartDataSet: LineScatterCandleChartDataSet
     }
 
     /// the space that is left out on the left and right side of each candle,
-    /// :default: 0.1 (10%), max 0.45, min 0.0
+    /// default 0.1 (10%), max 0.45, min 0.0
     public var bodySpace: CGFloat
     {
         set

--- a/Charts/Classes/Data/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/CandleChartDataSet.swift
@@ -19,12 +19,12 @@ public class CandleChartDataSet: LineScatterCandleChartDataSet
 {
     /// the width of the candle-shadow-line in pixels. 
     /// 
-    /// default: 3.0
+    /// **default**: 3.0
     public var shadowWidth = CGFloat(1.5)
 
     /// the space between the candle entries
     /// 
-    /// default: 0.1 (10%)
+    /// **default**: 0.1 (10%)
     private var _bodySpace = CGFloat(0.1)
     
     /// the color of the shadow line
@@ -93,7 +93,7 @@ public class CandleChartDataSet: LineScatterCandleChartDataSet
     }
 
     /// the space that is left out on the left and right side of each candle,
-    /// default 0.1 (10%), max 0.45, min 0.0
+    /// **default**: 0.1 (10%), max 0.45, min 0.0
     public var bodySpace: CGFloat
     {
         set

--- a/Charts/Classes/Data/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/CandleChartDataSet.swift
@@ -48,7 +48,7 @@ public class CandleChartDataSet: LineScatterCandleChartDataSet
         super.init(yVals: yVals, label: label)
     }
     
-    internal override func calcMinMax(#start: Int, end: Int)
+    internal override func calcMinMax(start start: Int, end: Int)
     {
         if (yVals.count == 0)
         {
@@ -76,7 +76,7 @@ public class CandleChartDataSet: LineScatterCandleChartDataSet
         
         for (var i = start + 1; i <= endValue; i++)
         {
-            var e = entries[i]
+            let e = entries[i]
             
             if (e.low < _yMin)
             {

--- a/Charts/Classes/Data/ChartData.swift
+++ b/Charts/Classes/Data/ChartData.swift
@@ -110,7 +110,7 @@ public class ChartData: NSObject
         
         for (var i = 0; i < _xVals.count; i++)
         {
-            sum += _xVals[i] == nil ? 0 : count(_xVals[i]!)
+            sum += _xVals[i] == nil ? 0 : (_xVals[i]!).characters.count
         }
         
         _xValAverageLength = Double(sum) / Double(_xVals.count)
@@ -129,7 +129,7 @@ public class ChartData: NSObject
         {
             if (dataSets[i].yVals.count > _xVals.count)
             {
-                println("One or more of the DataSet Entry arrays are longer than the x-values array of this Data object.")
+                print("One or more of the DataSet Entry arrays are longer than the x-values array of this Data object.", appendNewline: true)
                 return
             }
         }
@@ -141,7 +141,7 @@ public class ChartData: NSObject
     }
     
     /// calc minimum and maximum y value over all datasets
-    internal func calcMinMax(#start: Int, end: Int)
+    internal func calcMinMax(start start: Int, end: Int)
     {
         
         if (_dataSets == nil || _dataSets.count < 1)
@@ -179,7 +179,7 @@ public class ChartData: NSObject
             }
             
             // left axis
-            var firstLeft = getFirstLeft()
+            let firstLeft = getFirstLeft()
 
             if (firstLeft !== nil)
             {
@@ -204,7 +204,7 @@ public class ChartData: NSObject
             }
 
             // right axis
-            var firstRight = getFirstRight()
+            let firstRight = getFirstRight()
 
             if (firstRight !== nil)
             {
@@ -377,10 +377,10 @@ public class ChartData: NSObject
     /// Retrieve the index of a ChartDataSet with a specific label from the ChartData. Search can be case sensitive or not.
     /// IMPORTANT: This method does calculations at runtime, do not over-use in performance critical situations.
     ///
-    /// :param: dataSets the DataSet array to search
-    /// :param: type
-    /// :param: ignorecase if true, the search is not case-sensitive
-    /// :returns:
+    /// - parameter dataSets: the DataSet array to search
+    /// - parameter type:
+    /// - parameter ignorecase: if true, the search is not case-sensitive
+    /// - returns:
     internal func getDataSetIndexByLabel(label: String, ignorecase: Bool) -> Int
     {
         if (ignorecase)
@@ -437,8 +437,8 @@ public class ChartData: NSObject
     
     /// Get the Entry for a corresponding highlight object
     ///
-    /// :param: highlight
-    /// :returns: the entry that is highlighted
+    /// - parameter highlight:
+    /// - returns: the entry that is highlighted
     public func getEntryForHighlight(highlight: ChartHighlight) -> ChartDataEntry?
     {
         if highlight.dataSetIndex >= dataSets.count
@@ -455,11 +455,11 @@ public class ChartData: NSObject
     /// sensitive or not. 
     /// IMPORTANT: This method does calculations at runtime. Use with care in performance critical situations.
     ///
-    /// :param: label
-    /// :param: ignorecase
+    /// - parameter label:
+    /// - parameter ignorecase:
     public func getDataSetByLabel(label: String, ignorecase: Bool) -> ChartDataSet?
     {
-        var index = getDataSetIndexByLabel(label, ignorecase: ignorecase)
+        let index = getDataSetIndexByLabel(label, ignorecase: ignorecase)
         
         if (index < 0 || index >= _dataSets.count)
         {
@@ -565,7 +565,7 @@ public class ChartData: NSObject
     /// Removes the given DataSet from this data object.
     /// Also recalculates all minimum and maximum values.
     ///
-    /// :returns: true if a DataSet was removed, false if no DataSet could be removed.
+    /// - returns: true if a DataSet was removed, false if no DataSet could be removed.
     public func removeDataSet(dataSet: ChartDataSet!) -> Bool
     {
         if (_dataSets == nil || dataSet === nil)
@@ -587,7 +587,7 @@ public class ChartData: NSObject
     /// Removes the DataSet at the given index in the DataSet array from the data object. 
     /// Also recalculates all minimum and maximum values. 
     ///
-    /// :returns: true if a DataSet was removed, false if no DataSet could be removed.
+    /// - returns: true if a DataSet was removed, false if no DataSet could be removed.
     public func removeDataSetByIndex(index: Int) -> Bool
     {
         if (_dataSets == nil || index >= _dataSets.count || index < 0)
@@ -595,7 +595,7 @@ public class ChartData: NSObject
             return false
         }
         
-        var d = _dataSets.removeAtIndex(index)
+        let d = _dataSets.removeAtIndex(index)
         _yValCount -= d.entryCount
         _yValueSum -= d.yValueSum
         
@@ -609,8 +609,8 @@ public class ChartData: NSObject
     {
         if (_dataSets != nil && _dataSets.count > dataSetIndex && dataSetIndex >= 0)
         {
-            var val = e.value
-            var set = _dataSets[dataSetIndex]
+            let val = e.value
+            let set = _dataSets[dataSetIndex]
             
             if (_yValCount == 0)
             {
@@ -672,7 +672,7 @@ public class ChartData: NSObject
         }
         else
         {
-            println("ChartData.addEntry() - dataSetIndex our of range.")
+            print("ChartData.addEntry() - dataSetIndex our of range.", appendNewline: true)
         }
     }
     
@@ -686,11 +686,11 @@ public class ChartData: NSObject
         }
         
         // remove the entry from the dataset
-        var removed = _dataSets[dataSetIndex].removeEntry(xIndex: entry.xIndex)
+        let removed = _dataSets[dataSetIndex].removeEntry(xIndex: entry.xIndex)
         
         if (removed)
         {
-            var val = entry.value
+            let val = entry.value
             
             _yValCount -= 1
             _yValueSum -= val
@@ -711,7 +711,7 @@ public class ChartData: NSObject
             return false
         }
         
-        var entry = _dataSets[dataSetIndex].entryForXIndex(xIndex)
+        let entry = _dataSets[dataSetIndex].entryForXIndex(xIndex)
         
         if (entry?.xIndex != xIndex)
         {
@@ -731,7 +731,7 @@ public class ChartData: NSObject
         
         for (var i = 0; i < _dataSets.count; i++)
         {
-            var set = _dataSets[i]
+            let set = _dataSets[i]
             
             for (var j = 0; j < set.entryCount; j++)
             {
@@ -805,7 +805,7 @@ public class ChartData: NSObject
         
         for (var i = 0; i < _dataSets.count; i++)
         {
-            var clrs = _dataSets[i].colors
+            let clrs = _dataSets[i].colors
             
             for clr in clrs
             {
@@ -901,7 +901,7 @@ public class ChartData: NSObject
     }
     
     /// Checks if this data object contains the specified Entry. Returns true if so, false if not.
-    public func contains(#entry: ChartDataEntry) -> Bool
+    public func contains(entry entry: ChartDataEntry) -> Bool
     {
         for set in dataSets
         {
@@ -915,7 +915,7 @@ public class ChartData: NSObject
     }
     
     /// Checks if this data object contains the specified DataSet. Returns true if so, false if not.
-    public func contains(#dataSet: ChartDataSet) -> Bool
+    public func contains(dataSet dataSet: ChartDataSet) -> Bool
     {
         for set in dataSets
         {

--- a/Charts/Classes/Data/ChartData.swift
+++ b/Charts/Classes/Data/ChartData.swift
@@ -269,7 +269,7 @@ public class ChartData: NSObject
         _yValCount = count
     }
     
-    /// returns the number of LineDataSets this object contains
+    /// - returns: the number of LineDataSets this object contains
     public var dataSetCount: Int
     {
         if (_dataSets == nil)
@@ -279,7 +279,7 @@ public class ChartData: NSObject
         return _dataSets.count
     }
     
-    /// returns the smallest y-value the data object contains.
+    /// - returns: the smallest y-value the data object contains.
     public var yMin: Double
     {
         return _yMin
@@ -302,7 +302,7 @@ public class ChartData: NSObject
         }
     }
     
-    /// returns the greatest y-value the data object contains.
+    /// - returns: the greatest y-value the data object contains.
     public var yMax: Double
     {
         return _yMax
@@ -325,25 +325,25 @@ public class ChartData: NSObject
         }
     }
     
-    /// returns the average length (in characters) across all values in the x-vals array
+    /// - returns: the average length (in characters) across all values in the x-vals array
     public var xValAverageLength: Double
     {
         return _xValAverageLength
     }
     
-    /// returns the total y-value sum across all DataSet objects the this object represents.
+    /// - returns: the total y-value sum across all DataSet objects the this object represents.
     public var yValueSum: Double
     {
         return _yValueSum
     }
     
-    /// Returns the total number of y-values across all DataSet objects the this object represents.
+    /// - returns: the total number of y-values across all DataSet objects the this object represents.
     public var yValCount: Int
     {
         return _yValCount
     }
     
-    /// returns the x-values the chart represents
+    /// - returns: the x-values the chart represents
     public var xVals: [String?]
     {
         return _xVals
@@ -361,7 +361,7 @@ public class ChartData: NSObject
         _xVals.removeAtIndex(index)
     }
     
-    /// Returns the array of ChartDataSets this object holds.
+    /// - returns: the array of ChartDataSets this object holds.
     public var dataSets: [ChartDataSet]
     {
         get
@@ -375,12 +375,13 @@ public class ChartData: NSObject
     }
     
     /// Retrieve the index of a ChartDataSet with a specific label from the ChartData. Search can be case sensitive or not.
-    /// IMPORTANT: This method does calculations at runtime, do not over-use in performance critical situations.
+    /// 
+    /// **IMPORTANT: This method does calculations at runtime, do not over-use in performance critical situations.**
     ///
     /// - parameter dataSets: the DataSet array to search
     /// - parameter type:
     /// - parameter ignorecase: if true, the search is not case-sensitive
-    /// - returns:
+    /// - returns: the index of the DataSet Object with the given label. Sensitive or not.
     internal func getDataSetIndexByLabel(label: String, ignorecase: Bool) -> Int
     {
         if (ignorecase)
@@ -411,13 +412,13 @@ public class ChartData: NSObject
         return -1
     }
     
-    /// returns the total number of x-values this ChartData object represents (the size of the x-values array)
+    /// - returns: the total number of x-values this ChartData object represents (the size of the x-values array)
     public var xValCount: Int
     {
         return _xVals.count
     }
     
-    /// Returns the labels of all DataSets as a string array.
+    /// - returns: the labels of all DataSets as a string array.
     internal func dataSetLabels() -> [String]
     {
         var types = [String]()
@@ -451,12 +452,11 @@ public class ChartData: NSObject
         }
     }
     
-    /// Returns the DataSet object with the given label. 
-    /// sensitive or not. 
-    /// IMPORTANT: This method does calculations at runtime. Use with care in performance critical situations.
+    /// **IMPORTANT: This method does calculations at runtime. Use with care in performance critical situations.**
     ///
     /// - parameter label:
     /// - parameter ignorecase:
+    /// - returns: the DataSet Object with the given label. Sensitive or not.
     public func getDataSetByLabel(label: String, ignorecase: Bool) -> ChartDataSet?
     {
         let index = getDataSetIndexByLabel(label, ignorecase: ignorecase)
@@ -702,8 +702,8 @@ public class ChartData: NSObject
     }
     
     /// Removes the Entry object at the given xIndex from the ChartDataSet at the
-    /// specified index. Returns true if an entry was removed, false if no Entry
-    /// was found that meets the specified requirements.
+    /// specified index. 
+    /// - returns: true if an entry was removed, false if no Entry was found that meets the specified requirements.
     public func removeEntryByXIndex(xIndex: Int, dataSetIndex: Int) -> Bool
     {
         if (dataSetIndex >= _dataSets.count)
@@ -721,7 +721,7 @@ public class ChartData: NSObject
         return removeEntry(entry, dataSetIndex: dataSetIndex)
     }
     
-    /// Returns the DataSet that contains the provided Entry, or null, if no DataSet contains this entry.
+    /// - returns: the DataSet that contains the provided Entry, or null, if no DataSet contains this entry.
     public func getDataSetForEntry(e: ChartDataEntry!) -> ChartDataSet?
     {
         if (e == nil)
@@ -745,8 +745,7 @@ public class ChartData: NSObject
         return nil
     }
     
-    /// Returns the index of the provided DataSet inside the DataSets array of
-    /// this data object. Returns -1 if the DataSet was not found.
+    /// - returns: the index of the provided DataSet inside the DataSets array of this data object. -1 if the DataSet was not found.
     public func indexOfDataSet(dataSet: ChartDataSet) -> Int
     {
         for (var i = 0; i < _dataSets.count; i++)
@@ -786,7 +785,7 @@ public class ChartData: NSObject
         return nil
     }
     
-    /// Returns all colors used across all DataSet objects this object represents.
+    /// - returns: all colors used across all DataSet objects this object represents.
     public func getColors() -> [UIColor]?
     {
         if (_dataSets == nil)
@@ -900,7 +899,8 @@ public class ChartData: NSObject
         notifyDataChanged()
     }
     
-    /// Checks if this data object contains the specified Entry. Returns true if so, false if not.
+    /// Checks if this data object contains the specified Entry. 
+    /// - returns: true if so, false if not.
     public func contains(entry entry: ChartDataEntry) -> Bool
     {
         for set in dataSets
@@ -914,7 +914,8 @@ public class ChartData: NSObject
         return false
     }
     
-    /// Checks if this data object contains the specified DataSet. Returns true if so, false if not.
+    /// Checks if this data object contains the specified DataSet. 
+    /// - returns: true if so, false if not.
     public func contains(dataSet dataSet: ChartDataSet) -> Bool
     {
         for set in dataSets
@@ -930,6 +931,6 @@ public class ChartData: NSObject
     
     /// MARK: - ObjC compatibility
     
-    /// returns the average length (in characters) across all values in the x-vals array
+    /// - returns: the average length (in characters) across all values in the x-vals array
     public var xValsObjc: [NSObject] { return ChartUtils.bridgedObjCGetStringArray(swift: _xVals); }
 }

--- a/Charts/Classes/Data/ChartDataEntry.swift
+++ b/Charts/Classes/Data/ChartDataEntry.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public class ChartDataEntry: NSObject, Equatable
+public class ChartDataEntry: NSObject
 {
     /// the actual value (y axis)
     public var value = Double(0.0)
@@ -90,7 +90,7 @@ public class ChartDataEntry: NSObject, Equatable
     
     public func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = self.dynamicType.allocWithZone(zone) as ChartDataEntry
+        let copy = self.dynamicType.allocWithZone(zone) as ChartDataEntry
         copy.value = value
         copy.xIndex = xIndex
         copy.data = data

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -323,7 +323,7 @@ public class ChartDataSet: NSObject
     /// - parameter e: the entry to add
     public func addEntryOrdered(e: ChartDataEntry)
     {
-        var val = e.value
+        let val = e.value
         
         if (_yVals == nil)
         {

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -157,9 +157,9 @@ public class ChartDataSet: NSObject
         else { return Double.NaN }
     }
     
-    /// Returns the first Entry object found at the given xIndex with binary search. 
+    /// - returns: the first Entry object found at the given xIndex with binary search.
     /// If the no Entry at the specifed x-index is found, this method returns the Entry at the closest x-index. 
-    /// Returns nil if no Entry object at that index.
+    /// nil if no Entry object at that index.
     public func entryForXIndex(x: Int) -> ChartDataEntry?
     {
         let index = self.entryIndex(xIndex: x)
@@ -279,13 +279,13 @@ public class ChartDataSet: NSObject
         return -1
     }
     
-    /// Returns the number of entries this DataSet holds.
+    /// - returns: the number of entries this DataSet holds.
     public var valueCount: Int { return _yVals.count; }
     
     /// Adds an Entry to the DataSet dynamically.
     /// Entries are added to the end of the list.
     /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
-    /// :param: e the entry to add
+    /// - parameter e: the entry to add
     public func addEntry(e: ChartDataEntry)
     {
         let val = e.value
@@ -320,7 +320,7 @@ public class ChartDataSet: NSObject
     /// Adds an Entry to the DataSet dynamically.
     /// Entries are added to their appropriate index respective to it's x-index.
     /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
-    /// :param: e the entry to add
+    /// - parameter e: the entry to add
     public func addEntryOrdered(e: ChartDataEntry)
     {
         var val = e.value

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -53,7 +53,7 @@ public class ChartDataSet: NSObject
     /// if true, value highlighting is enabled
     public var highlightEnabled = true
     
-    /// :returns: true if value highlighting is enabled for this dataset
+    /// - returns: true if value highlighting is enabled for this dataset
     public var isHighlightEnabled: Bool { return highlightEnabled }
     
     public override init()
@@ -87,7 +87,7 @@ public class ChartDataSet: NSObject
         calcYValueSum()
     }
     
-    internal func calcMinMax(#start : Int, end: Int)
+    internal func calcMinMax(start start : Int, end: Int)
     {
         let yValCount = _yVals.count
         
@@ -162,7 +162,7 @@ public class ChartDataSet: NSObject
     /// Returns nil if no Entry object at that index.
     public func entryForXIndex(x: Int) -> ChartDataEntry?
     {
-        var index = self.entryIndex(xIndex: x)
+        let index = self.entryIndex(xIndex: x)
         if (index > -1)
         {
             return _yVals[index]
@@ -226,7 +226,7 @@ public class ChartDataSet: NSObject
         while (low <= high)
         {
             var m = (high + low) / 2
-            var entry = _yVals[m]
+            let entry = _yVals[m]
             
             if (x == entry.xIndex)
             {
@@ -288,7 +288,7 @@ public class ChartDataSet: NSObject
     /// :param: e the entry to add
     public func addEntry(e: ChartDataEntry)
     {
-        var val = e.value
+        let val = e.value
         
         if (_yVals == nil)
         {
@@ -386,12 +386,12 @@ public class ChartDataSet: NSObject
         return removed
     }
     
-    public func removeEntry(#xIndex: Int) -> Bool
+    public func removeEntry(xIndex xIndex: Int) -> Bool
     {
-        var index = self.entryIndex(xIndex: xIndex)
+        let index = self.entryIndex(xIndex: xIndex)
         if (index > -1)
         {
-            var e = _yVals.removeAtIndex(index)
+            let e = _yVals.removeAtIndex(index)
             
             _yValueSum -= e.value
             calcMinMax(start: _lastStart, end: _lastEnd)
@@ -438,7 +438,7 @@ public class ChartDataSet: NSObject
     }
     
     /// Checks if this DataSet contains the specified Entry.
-    /// :returns: true if contains the entry, false if not.
+    /// - returns: true if contains the entry, false if not.
     public func contains(e: ChartDataEntry) -> Bool
     {
         for entry in _yVals
@@ -484,7 +484,7 @@ public class ChartDataSet: NSObject
     
     public func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = self.dynamicType.allocWithZone(zone) as ChartDataSet
+        let copy = self.dynamicType.allocWithZone(zone) as ChartDataSet
         copy.colors = colors
         copy._yVals = _yVals
         copy._yMax = _yMax

--- a/Charts/Classes/Data/LineChartDataSet.swift
+++ b/Charts/Classes/Data/LineChartDataSet.swift
@@ -90,7 +90,7 @@ public class LineChartDataSet: LineRadarChartDataSet
     }
     
     /// resets the circle-colors array and creates a new one
-    public func resetCircleColors(var index: Int)
+    public func resetCircleColors(index: Int)
     {
         circleColors.removeAll(keepCapacity: false)
     }
@@ -105,7 +105,7 @@ public class LineChartDataSet: LineRadarChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! LineChartDataSet
+        let copy = super.copyWithZone(zone) as! LineChartDataSet
         copy.circleColors = circleColors
         copy.circleRadius = circleRadius
         copy.cubicIntensity = cubicIntensity

--- a/Charts/Classes/Data/LineChartDataSet.swift
+++ b/Charts/Classes/Data/LineChartDataSet.swift
@@ -47,7 +47,8 @@ public class LineChartDataSet: LineRadarChartDataSet
     }
 
     /// intensity for cubic lines (min = 0.05, max = 1)
-    /// :default: 0.2
+    /// 
+    /// default: 0.2
     public var cubicIntensity: CGFloat
     {
         get
@@ -68,7 +69,7 @@ public class LineChartDataSet: LineRadarChartDataSet
         }
     }
     
-    /// Returns the color at the given index of the DataSet's circle-color array.
+    /// - returns: the color at the given index of the DataSet's circle-color array.
     /// Performs a IndexOutOfBounds check by modulus.
     public func getCircleColor(var index: Int) -> UIColor?
     {

--- a/Charts/Classes/Data/LineChartDataSet.swift
+++ b/Charts/Classes/Data/LineChartDataSet.swift
@@ -48,7 +48,7 @@ public class LineChartDataSet: LineRadarChartDataSet
 
     /// intensity for cubic lines (min = 0.05, max = 1)
     /// 
-    /// default: 0.2
+    /// **default**: 0.2
     public var cubicIntensity: CGFloat
     {
         get

--- a/Charts/Classes/Data/LineRadarChartDataSet.swift
+++ b/Charts/Classes/Data/LineRadarChartDataSet.swift
@@ -53,7 +53,7 @@ public class LineRadarChartDataSet: LineScatterCandleChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! LineRadarChartDataSet
+        let copy = super.copyWithZone(zone) as! LineRadarChartDataSet
         copy.fillColor = fillColor
         copy._lineWidth = _lineWidth
         copy.drawFilledEnabled = drawFilledEnabled

--- a/Charts/Classes/Data/LineRadarChartDataSet.swift
+++ b/Charts/Classes/Data/LineRadarChartDataSet.swift
@@ -23,7 +23,8 @@ public class LineRadarChartDataSet: LineScatterCandleChartDataSet
     public var drawFilledEnabled = false
     
     /// line width of the chart (min = 0.2, max = 10)
-    /// :default: 1
+    /// 
+    /// default: 1
     public var lineWidth: CGFloat
     {
         get

--- a/Charts/Classes/Data/LineRadarChartDataSet.swift
+++ b/Charts/Classes/Data/LineRadarChartDataSet.swift
@@ -24,7 +24,7 @@ public class LineRadarChartDataSet: LineScatterCandleChartDataSet
     
     /// line width of the chart (min = 0.2, max = 10)
     /// 
-    /// default: 1
+    /// **default**: 1
     public var lineWidth: CGFloat
     {
         get

--- a/Charts/Classes/Data/LineScatterCandleChartDataSet.swift
+++ b/Charts/Classes/Data/LineScatterCandleChartDataSet.swift
@@ -37,7 +37,7 @@ public class LineScatterCandleChartDataSet: BarLineScatterCandleChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! LineScatterCandleChartDataSet
+        let copy = super.copyWithZone(zone) as! LineScatterCandleChartDataSet
         copy.drawHorizontalHighlightIndicatorEnabled = drawHorizontalHighlightIndicatorEnabled
         copy.drawVerticalHighlightIndicatorEnabled = drawVerticalHighlightIndicatorEnabled
         return copy

--- a/Charts/Classes/Data/PieChartDataSet.swift
+++ b/Charts/Classes/Data/PieChartDataSet.swift
@@ -65,7 +65,7 @@ public class PieChartDataSet: ChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! PieChartDataSet
+        let copy = super.copyWithZone(zone) as! PieChartDataSet
         copy._sliceSpace = _sliceSpace
         copy.selectionShift = selectionShift
         return copy

--- a/Charts/Classes/Data/ScatterChartData.swift
+++ b/Charts/Classes/Data/ScatterChartData.swift
@@ -30,7 +30,7 @@ public class ScatterChartData: BarLineScatterCandleChartData
         super.init(xVals: xVals, dataSets: dataSets)
     }
     
-    /// Returns the maximum shape-size across all DataSets.
+    /// - returns: the maximum shape-size across all DataSets.
     public func getGreatestShapeSize() -> CGFloat
     {
         var max = CGFloat(0.0)

--- a/Charts/Classes/Data/ScatterChartData.swift
+++ b/Charts/Classes/Data/ScatterChartData.swift
@@ -41,7 +41,7 @@ public class ScatterChartData: BarLineScatterCandleChartData
             
             if (scatterDataSet == nil)
             {
-                println("ScatterChartData: Found a DataSet which is not a ScatterChartDataSet")
+                print("ScatterChartData: Found a DataSet which is not a ScatterChartDataSet", appendNewline: true)
             }
             else
             {

--- a/Charts/Classes/Data/ScatterChartDataSet.swift
+++ b/Charts/Classes/Data/ScatterChartDataSet.swift
@@ -34,7 +34,7 @@ public class ScatterChartDataSet: LineScatterCandleChartDataSet
     
     public override func copyWithZone(zone: NSZone) -> AnyObject
     {
-        var copy = super.copyWithZone(zone) as! ScatterChartDataSet
+        let copy = super.copyWithZone(zone) as! ScatterChartDataSet
         copy.scatterShapeSize = scatterShapeSize
         copy.scatterShape = scatterShape
         copy.customScatterShape = customScatterShape

--- a/Charts/Classes/Filters/ChartDataApproximatorFilter.swift
+++ b/Charts/Classes/Filters/ChartDataApproximatorFilter.swift
@@ -64,7 +64,7 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
     
     /// Filters according to type. Uses the pre set set tolerance
     ///
-    /// :param: points the points to filter
+    /// - parameter points: the points to filter
     public override func filter(points: [ChartDataEntry]) -> [ChartDataEntry]
     {
         return filter(points, tolerance: tolerance)
@@ -72,8 +72,8 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
     
     /// Filters according to type.
     ///
-    /// :param: points the points to filter
-    /// :param: tolerance the angle in degrees that will trigger the filtering
+    /// - parameter points: the points to filter
+    /// - parameter tolerance: the angle in degrees that will trigger the filtering
     public func filter(points: [ChartDataEntry], tolerance: Double) -> [ChartDataEntry]
     {
         if (tolerance <= 0)
@@ -124,10 +124,10 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
     
     /// apply the Douglas-Peucker-Reduction to an ArrayList of Entry with a given epsilon (tolerance)
     ///
-    /// :param: entries
-    /// :param: epsilon as y-value
-    /// :param: start
-    /// :param: end
+    /// - parameter entries:
+    /// - parameter epsilon: as y-value
+    /// - parameter start:
+    /// - parameter end:
     private func algorithmDouglasPeucker(entries: [ChartDataEntry], epsilon: Double, start: Int, end: Int, inout keep: [Bool])
     {
         if (end <= start + 1)
@@ -140,12 +140,12 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
         var maxDistIndex = Int(0)
         var distMax = Double(0.0)
         
-        var firstEntry = entries[start]
-        var lastEntry = entries[end]
+        let firstEntry = entries[start]
+        let lastEntry = entries[end]
         
         for (var i = start + 1; i < end; i++)
         {
-            var dist = calcAngleBetweenLines(firstEntry, end1: lastEntry, start2: firstEntry, end2: entries[i])
+            let dist = calcAngleBetweenLines(firstEntry, end1: lastEntry, start2: firstEntry, end2: entries[i])
             
             // keep the point with the greatest distance
             if (dist > distMax)
@@ -168,15 +168,15 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
     
     /// calculate the distance between a line between two entries and an entry (point)
     ///
-    /// :param: startEntry line startpoint
-    /// :param: endEntry line endpoint
-    /// :param: entryPoint the point to which the distance is measured from the line
+    /// - parameter startEntry: line startpoint
+    /// - parameter endEntry: line endpoint
+    /// - parameter entryPoint: the point to which the distance is measured from the line
     private func calcPointToLineDistance(startEntry: ChartDataEntry, endEntry: ChartDataEntry, entryPoint: ChartDataEntry) -> Double
     {
-        var xDiffEndStart = Double(endEntry.xIndex) - Double(startEntry.xIndex)
-        var xDiffEntryStart = Double(entryPoint.xIndex) - Double(startEntry.xIndex)
+        let xDiffEndStart = Double(endEntry.xIndex) - Double(startEntry.xIndex)
+        let xDiffEntryStart = Double(entryPoint.xIndex) - Double(startEntry.xIndex)
         
-        var normalLength = sqrt((xDiffEndStart)
+        let normalLength = sqrt((xDiffEndStart)
             * (xDiffEndStart)
             + (endEntry.value - startEntry.value)
             * (endEntry.value - startEntry.value))
@@ -190,8 +190,8 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
     /// Calculates the angle between two given lines. The provided entries mark the starting and end points of the lines.
     private func calcAngleBetweenLines(start1: ChartDataEntry, end1: ChartDataEntry, start2: ChartDataEntry, end2: ChartDataEntry) -> Double
     {
-        var angle1 = calcAngleWithRatios(start1, p2: end1)
-        var angle2 = calcAngleWithRatios(start2, p2: end2)
+        let angle1 = calcAngleWithRatios(start1, p2: end1)
+        let angle2 = calcAngleWithRatios(start2, p2: end2)
         
         return fabs(angle1 - angle2)
     }
@@ -199,16 +199,16 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
     /// calculates the angle between two entries (points) in the chart taking ratios into consideration
     private func calcAngleWithRatios(p1: ChartDataEntry, p2: ChartDataEntry) -> Double
     {
-        var dx = Double(p2.xIndex) * Double(deltaRatio) - Double(p1.xIndex) * Double(deltaRatio)
-        var dy = p2.value * scaleRatio - p1.value * scaleRatio
+        let dx = Double(p2.xIndex) * Double(deltaRatio) - Double(p1.xIndex) * Double(deltaRatio)
+        let dy = p2.value * scaleRatio - p1.value * scaleRatio
         return atan2(Double(dy), dx) * ChartUtils.Math.RAD2DEG
     }
     
     // calculates the angle between two entries (points) in the chart
     private func calcAngle(p1: ChartDataEntry, p2: ChartDataEntry) -> Double
     {
-        var dx = p2.xIndex - p1.xIndex
-        var dy = p2.value - p1.value
+        let dx = p2.xIndex - p1.xIndex
+        let dy = p2.value - p1.value
         return atan2(Double(dy), Double(dx)) * ChartUtils.Math.RAD2DEG
     }
 }

--- a/Charts/Classes/Highlight/BarChartHighlighter.swift
+++ b/Charts/Classes/Highlight/BarChartHighlighter.swift
@@ -22,9 +22,9 @@ internal class BarChartHighlighter: ChartHighlighter
         super.init(chart: chart)
     }
     
-    internal override func getHighlight(#x: Double, y: Double) -> ChartHighlight?
+    internal override func getHighlight(x x: Double, y: Double) -> ChartHighlight?
     {
-        var h = super.getHighlight(x: x, y: y)
+        let h = super.getHighlight(x: x, y: y)
         
         if h === nil
         {
@@ -86,7 +86,7 @@ internal class BarChartHighlighter: ChartHighlighter
         }
     }
     
-    internal override func getDataSetIndex(#xIndex: Int, x: Double, y: Double) -> Int
+    internal override func getDataSetIndex(xIndex xIndex: Int, x: Double, y: Double) -> Int
     {
         if let barChartData = _chart?.data as? BarChartData
         {
@@ -120,15 +120,15 @@ internal class BarChartHighlighter: ChartHighlighter
     }
     
     /// This method creates the Highlight object that also indicates which value of a stacked BarEntry has been selected.
-    /// :param: old the old highlight object before looking for stacked values
-    /// :param: set
-    /// :param: xIndex
-    /// :param: dataSetIndex
-    /// :param: yValue
-    /// :returns:
-    internal func getStackedHighlight(#old: ChartHighlight?, set: BarChartDataSet, xIndex: Int, dataSetIndex: Int, yValue: Double) -> ChartHighlight?
+    /// - parameter old: the old highlight object before looking for stacked values
+    /// - parameter set:
+    /// - parameter xIndex:
+    /// - parameter dataSetIndex:
+    /// - parameter yValue:
+    /// - returns:
+    internal func getStackedHighlight(old old: ChartHighlight?, set: BarChartDataSet, xIndex: Int, dataSetIndex: Int, yValue: Double) -> ChartHighlight?
     {
-        var entry = set.entryForXIndex(xIndex) as? BarChartDataEntry
+        let entry = set.entryForXIndex(xIndex) as? BarChartDataEntry
         
         if entry?.values === nil
         {
@@ -145,10 +145,10 @@ internal class BarChartHighlighter: ChartHighlighter
     }
     
     /// Returns the index of the closest value inside the values array / ranges (stacked barchart) to the value given as a parameter.
-    /// :param: entry
-    /// :param: value
-    /// :returns:
-    internal func getClosestStackIndex(#ranges: [ChartRange]?, value: Double) -> Int
+    /// - parameter entry:
+    /// - parameter value:
+    /// - returns:
+    internal func getClosestStackIndex(ranges ranges: [ChartRange]?, value: Double) -> Int
     {
         if ranges == nil
         {
@@ -175,8 +175,8 @@ internal class BarChartHighlighter: ChartHighlighter
     }
     
     /// Returns the base x-value to the corresponding x-touch value in pixels.
-    /// :param: x
-    /// :returns:
+    /// - parameter x:
+    /// - returns:
     internal func getBase(x: Double) -> Double
     {
         if let barChartData = _chart?.data as? BarChartData
@@ -207,9 +207,9 @@ internal class BarChartHighlighter: ChartHighlighter
     }
 
     /// Splits up the stack-values of the given bar-entry into Range objects.
-    /// :param: entry
-    /// :returns:
-    internal func getRanges(#entry: BarChartDataEntry) -> [ChartRange]?
+    /// - parameter entry:
+    /// - returns:
+    internal func getRanges(entry entry: BarChartDataEntry) -> [ChartRange]?
     {
         let values = entry.values
         if (values == nil)

--- a/Charts/Classes/Highlight/ChartHighlight.swift
+++ b/Charts/Classes/Highlight/ChartHighlight.swift
@@ -23,7 +23,8 @@ public class ChartHighlight: NSObject
     private var _dataSetIndex = Int(0)
     
     /// index which value of a stacked bar entry is highlighted
-    /// :default: -1
+    /// 
+    /// default: -1
     private var _stackIndex = Int(-1)
     
     /// the range of the bar that is selected (only for stacked-barchart)

--- a/Charts/Classes/Highlight/ChartHighlight.swift
+++ b/Charts/Classes/Highlight/ChartHighlight.swift
@@ -24,7 +24,7 @@ public class ChartHighlight: NSObject
     
     /// index which value of a stacked bar entry is highlighted
     /// 
-    /// default: -1
+    /// **default**: -1
     private var _stackIndex = Int(-1)
     
     /// the range of the bar that is selected (only for stacked-barchart)

--- a/Charts/Classes/Highlight/ChartHighlight.swift
+++ b/Charts/Classes/Highlight/ChartHighlight.swift
@@ -54,10 +54,10 @@ public class ChartHighlight: NSObject
     
     /// Constructor, only used for stacked-barchart.
     ///
-    /// :param: x the index of the highlighted value on the x-axis
-    /// :param: dataSet the index of the DataSet the highlighted value belongs to
-    /// :param: stackIndex references which value of a stacked-bar entry has been selected
-    /// :param: range the range the selected stack-value is in
+    /// - parameter x: the index of the highlighted value on the x-axis
+    /// - parameter dataSet: the index of the DataSet the highlighted value belongs to
+    /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
+    /// - parameter range: the range the selected stack-value is in
     public convenience init(xIndex x: Int, dataSetIndex: Int, stackIndex: Int, range: ChartRange)
     {
         self.init(xIndex: x, dataSetIndex: dataSetIndex, stackIndex: stackIndex)
@@ -69,7 +69,7 @@ public class ChartHighlight: NSObject
     public var xIndex: Int { return _xIndex; }
     public var stackIndex: Int { return _stackIndex; }
     
-    /// :returns: the range of values the selected value of a stacked bar is in. (this is only relevant for stacked-barchart)
+    /// - returns: the range of values the selected value of a stacked bar is in. (this is only relevant for stacked-barchart)
     public var range: ChartRange? { return _range }
 
     // MARK: NSObject

--- a/Charts/Classes/Highlight/ChartHighlighter.swift
+++ b/Charts/Classes/Highlight/ChartHighlighter.swift
@@ -26,10 +26,10 @@ internal class ChartHighlighter
     }
     
     /// Returns a Highlight object corresponding to the given x- and y- touch positions in pixels.
-    /// :param: x
-    /// :param: y
-    /// :returns:
-    internal func getHighlight(#x: Double, y: Double) -> ChartHighlight?
+    /// - parameter x:
+    /// - parameter y:
+    /// - returns:
+    internal func getHighlight(x x: Double, y: Double) -> ChartHighlight?
     {
         let xIndex = getXIndex(x)
         if (xIndex == -Int.max)
@@ -47,8 +47,8 @@ internal class ChartHighlighter
     }
     
     /// Returns the corresponding x-index for a given touch-position in pixels.
-    /// :param: x
-    /// :returns:
+    /// - parameter x:
+    /// - returns:
     internal func getXIndex(x: Double) -> Int
     {
         // create an array of the touch-point
@@ -61,11 +61,11 @@ internal class ChartHighlighter
     }
     
     /// Returns the corresponding dataset-index for a given xIndex and xy-touch position in pixels.
-    /// :param: xIndex
-    /// :param: x
-    /// :param: y
-    /// :returns:
-    internal func getDataSetIndex(#xIndex: Int, x: Double, y: Double) -> Int
+    /// - parameter xIndex:
+    /// - parameter x:
+    /// - parameter y:
+    /// - returns:
+    internal func getDataSetIndex(xIndex xIndex: Int, x: Double, y: Double) -> Int
     {
         let valsAtIndex = getSelectionDetailsAtIndex(xIndex)
         
@@ -80,8 +80,8 @@ internal class ChartHighlighter
     }
     
     /// Returns a list of SelectionDetail object corresponding to the given xIndex.
-    /// :param: xIndex
-    /// :return:
+    /// - parameter xIndex:
+    /// - returns:
     internal func getSelectionDetailsAtIndex(xIndex: Int) -> [ChartSelectionDetail]
     {
         var vals = [ChartSelectionDetail]()
@@ -89,7 +89,7 @@ internal class ChartHighlighter
         
         for (var i = 0, dataSetCount = _chart?.data?.dataSetCount; i < dataSetCount; i++)
         {
-            var dataSet = _chart!.data!.getDataSetByIndex(i)
+            let dataSet = _chart!.data!.getDataSetByIndex(i)
             
             // dont include datasets that cannot be highlighted
             if !dataSet.isHighlightEnabled

--- a/Charts/Classes/Highlight/ChartRange.swift
+++ b/Charts/Classes/Highlight/ChartRange.swift
@@ -28,7 +28,7 @@ public class ChartRange: NSObject
     }
 
     /// Returns true if this range contains (if the value is in between) the given value, false if not.
-    /// :param: value
+    /// - parameter value:
     public func contains(value: Double) -> Bool
     {
         if value > from && value <= to

--- a/Charts/Classes/Highlight/HorizontalBarChartHighlighter.swift
+++ b/Charts/Classes/Highlight/HorizontalBarChartHighlighter.swift
@@ -17,9 +17,9 @@ import CoreGraphics
 
 internal class HorizontalBarChartHighlighter: BarChartHighlighter
 {
-    internal override func getHighlight(#x: Double, y: Double) -> ChartHighlight?
+    internal override func getHighlight(x x: Double, y: Double) -> ChartHighlight?
     {
-        var h = super.getHighlight(x: x, y: y)
+        let h = super.getHighlight(x: x, y: y)
         
         if h === nil
         {
@@ -88,8 +88,8 @@ internal class HorizontalBarChartHighlighter: BarChartHighlighter
     }
     
     /// Returns the base y-value to the corresponding x-touch value in pixels.
-    /// :param: y
-    /// :returns:
+    /// - parameter y:
+    /// - returns:
     internal override func getBase(y: Double) -> Double
     {
         if let barChartData = _chart?.data as? BarChartData

--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -43,9 +43,9 @@ public class BarChartRenderer: ChartDataRendererBase
         self.delegate = delegate
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
-        var barData = delegate!.barChartRendererData(self)
+        let barData = delegate!.barChartRendererData(self)
         
         if (barData === nil)
         {
@@ -54,7 +54,7 @@ public class BarChartRenderer: ChartDataRendererBase
         
         for (var i = 0; i < barData.dataSetCount; i++)
         {
-            var set = barData.getDataSetByIndex(i)
+            let set = barData.getDataSetByIndex(i)
             
             if (set !== nil && set!.isVisible)
             {
@@ -63,25 +63,25 @@ public class BarChartRenderer: ChartDataRendererBase
         }
     }
     
-    internal func drawDataSet(#context: CGContext, dataSet: BarChartDataSet, index: Int)
+    internal func drawDataSet(context context: CGContext, dataSet: BarChartDataSet, index: Int)
     {
         CGContextSaveGState(context)
         
-        var barData = delegate!.barChartRendererData(self)
+        let barData = delegate!.barChartRendererData(self)
         
-        var trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+        let trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
-        var drawBarShadowEnabled: Bool = delegate!.barChartIsDrawBarShadowEnabled(self)
-        var dataSetOffset = (barData.dataSetCount - 1)
-        var groupSpace = barData.groupSpace
-        var groupSpaceHalf = groupSpace / 2.0
-        var barSpace = dataSet.barSpace
-        var barSpaceHalf = barSpace / 2.0
-        var containsStacks = dataSet.isStacked
-        var isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
+        let drawBarShadowEnabled: Bool = delegate!.barChartIsDrawBarShadowEnabled(self)
+        let dataSetOffset = (barData.dataSetCount - 1)
+        let groupSpace = barData.groupSpace
+        let groupSpaceHalf = groupSpace / 2.0
+        let barSpace = dataSet.barSpace
+        let barSpaceHalf = barSpace / 2.0
+        let containsStacks = dataSet.isStacked
+        let isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
         var entries = dataSet.yVals as! [BarChartDataEntry]
-        var barWidth: CGFloat = 0.5
-        var phaseY = _animator.phaseY
+        let barWidth: CGFloat = 0.5
+        let phaseY = _animator.phaseY
         var barRect = CGRect()
         var barShadow = CGRect()
         var y: Double
@@ -89,10 +89,10 @@ public class BarChartRenderer: ChartDataRendererBase
         // do the drawing
         for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * _animator.phaseX)); j < count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
             
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + e.xIndex * dataSetOffset) + CGFloat(index)
+            let x = CGFloat(e.xIndex + e.xIndex * dataSetOffset) + CGFloat(index)
                 + groupSpace * CGFloat(e.xIndex) + groupSpaceHalf
             var vals = e.values
             
@@ -100,8 +100,8 @@ public class BarChartRenderer: ChartDataRendererBase
             {
                 y = e.value
                 
-                var left = x - barWidth + barSpaceHalf
-                var right = x + barWidth - barSpaceHalf
+                let left = x - barWidth + barSpaceHalf
+                let right = x + barWidth - barSpaceHalf
                 var top = isInverted ? (y <= 0.0 ? CGFloat(y) : 0) : (y >= 0.0 ? CGFloat(y) : 0)
                 var bottom = isInverted ? (y >= 0.0 ? CGFloat(y) : 0) : (y <= 0.0 ? CGFloat(y) : 0)
                 
@@ -159,8 +159,8 @@ public class BarChartRenderer: ChartDataRendererBase
                 {
                     y = e.value
                     
-                    var left = x - barWidth + barSpaceHalf
-                    var right = x + barWidth - barSpaceHalf
+                    let left = x - barWidth + barSpaceHalf
+                    let right = x + barWidth - barSpaceHalf
                     var top = isInverted ? (y <= 0.0 ? CGFloat(y) : 0) : (y >= 0.0 ? CGFloat(y) : 0)
                     var bottom = isInverted ? (y >= 0.0 ? CGFloat(y) : 0) : (y <= 0.0 ? CGFloat(y) : 0)
                     
@@ -208,8 +208,8 @@ public class BarChartRenderer: ChartDataRendererBase
                         negY += abs(value)
                     }
                     
-                    var left = x - barWidth + barSpaceHalf
-                    var right = x + barWidth - barSpaceHalf
+                    let left = x - barWidth + barSpaceHalf
+                    let right = x + barWidth - barSpaceHalf
                     var top: CGFloat, bottom: CGFloat
                     if isInverted
                     {
@@ -256,14 +256,14 @@ public class BarChartRenderer: ChartDataRendererBase
     }
     
     /// Prepares a bar for being highlighted.
-    internal func prepareBarHighlight(#x: CGFloat, y1: Double, y2: Double, barspacehalf: CGFloat, trans: ChartTransformer, inout rect: CGRect)
+    internal func prepareBarHighlight(x x: CGFloat, y1: Double, y2: Double, barspacehalf: CGFloat, trans: ChartTransformer, inout rect: CGRect)
     {
         let barWidth: CGFloat = 0.5
         
-        var left = x - barWidth + barspacehalf
-        var right = x + barWidth - barspacehalf
-        var top = CGFloat(y1)
-        var bottom = CGFloat(y2)
+        let left = x - barWidth + barspacehalf
+        let right = x + barWidth - barspacehalf
+        let top = CGFloat(y1)
+        let bottom = CGFloat(y2)
         
         rect.origin.x = left
         rect.origin.y = top
@@ -273,37 +273,37 @@ public class BarChartRenderer: ChartDataRendererBase
         trans.rectValueToPixel(&rect, phaseY: _animator.phaseY)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
         // if values are drawn
         if (passesCheck())
         {
-            var barData = delegate!.barChartRendererData(self)
+            let barData = delegate!.barChartRendererData(self)
             
-            var defaultValueFormatter = delegate!.barChartDefaultRendererValueFormatter(self)
+            let defaultValueFormatter = delegate!.barChartDefaultRendererValueFormatter(self)
             
             var dataSets = barData.dataSets
             
-            var drawValueAboveBar = delegate!.barChartIsDrawValueAboveBarEnabled(self)
-            
+            let drawValueAboveBar = delegate!.barChartIsDrawValueAboveBarEnabled(self)
+
             var posOffset: CGFloat
             var negOffset: CGFloat
             
             for (var i = 0, count = barData.dataSetCount; i < count; i++)
             {
-                var dataSet = dataSets[i] as! BarChartDataSet
+                let dataSet = dataSets[i] as! BarChartDataSet
                 
                 if (!dataSet.isDrawValuesEnabled)
                 {
                     continue
                 }
                 
-                var isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
+                let isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
                 
                 // calculate the correct offset depending on the draw position of the value
                 let valueOffsetPlus: CGFloat = 4.5
-                var valueFont = dataSet.valueFont
-                var valueTextHeight = valueFont.lineHeight
+                let valueFont = dataSet.valueFont
+                let valueTextHeight = valueFont.lineHeight
                 posOffset = (drawValueAboveBar ? -(valueTextHeight + valueOffsetPlus) : valueOffsetPlus)
                 negOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextHeight + valueOffsetPlus))
                 
@@ -313,7 +313,7 @@ public class BarChartRenderer: ChartDataRendererBase
                     negOffset = -negOffset - valueTextHeight
                 }
                 
-                var valueTextColor = dataSet.valueTextColor
+                let valueTextColor = dataSet.valueTextColor
                 
                 var formatter = dataSet.valueFormatter
                 if (formatter === nil)
@@ -321,7 +321,7 @@ public class BarChartRenderer: ChartDataRendererBase
                     formatter = defaultValueFormatter
                 }
                 
-                var trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+                let trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
                 
                 var entries = dataSet.yVals as! [BarChartDataEntry]
                 
@@ -343,7 +343,7 @@ public class BarChartRenderer: ChartDataRendererBase
                             continue
                         }
                         
-                        var val = entries[j].value
+                        let val = entries[j].value
                     
                         drawValue(context: context,
                             value: formatter!.stringFromNumber(val)!,
@@ -360,7 +360,7 @@ public class BarChartRenderer: ChartDataRendererBase
                     
                     for (var j = 0, count = Int(ceil(CGFloat(valuePoints.count) * _animator.phaseX)); j < count; j++)
                     {
-                        var e = entries[j]
+                        let e = entries[j]
                         
                         let values = e.values
                         
@@ -419,8 +419,8 @@ public class BarChartRenderer: ChartDataRendererBase
                             
                             for (var k = 0; k < transformed.count; k++)
                             {
-                                var x = valuePoints[j].x
-                                var y = transformed[k].y + (vals[k] >= 0 ? posOffset : negOffset)
+                                let x = valuePoints[j].x
+                                let y = transformed[k].y + (vals[k] >= 0 ? posOffset : negOffset)
                                 
                                 if (!viewPortHandler.isInBoundsRight(x))
                                 {
@@ -448,21 +448,21 @@ public class BarChartRenderer: ChartDataRendererBase
     }
     
     /// Draws a value at the specified x and y position.
-    internal func drawValue(#context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: UIFont, align: NSTextAlignment, color: UIColor)
+    internal func drawValue(context context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: UIFont, align: NSTextAlignment, color: UIColor)
     {
         ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: color])
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         
     }
     
     private var _highlightArrowPtsBuffer = [CGPoint](count: 3, repeatedValue: CGPoint())
     
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
-        var barData = delegate!.barChartRendererData(self)
+        let barData = delegate!.barChartRendererData(self)
         if (barData === nil)
         {
             return
@@ -470,26 +470,26 @@ public class BarChartRenderer: ChartDataRendererBase
         
         CGContextSaveGState(context)
         
-        var setCount = barData.dataSetCount
-        var drawHighlightArrowEnabled = delegate!.barChartIsDrawHighlightArrowEnabled(self)
+        let setCount = barData.dataSetCount
+        let drawHighlightArrowEnabled = delegate!.barChartIsDrawHighlightArrowEnabled(self)
         var barRect = CGRect()
         
         for (var i = 0; i < indices.count; i++)
         {
-            var h = indices[i]
-            var index = h.xIndex
+            let h = indices[i]
+            let index = h.xIndex
             
-            var dataSetIndex = h.dataSetIndex
-            var set = barData.getDataSetByIndex(dataSetIndex) as! BarChartDataSet!
+            let dataSetIndex = h.dataSetIndex
+            let set = barData.getDataSetByIndex(dataSetIndex) as! BarChartDataSet!
             
             if (set === nil || !set.isHighlightEnabled)
             {
                 continue
             }
             
-            var barspaceHalf = set.barSpace / 2.0
+            let barspaceHalf = set.barSpace / 2.0
             
-            var trans = delegate!.barChartRenderer(self, transformerForAxis: set.axisDependency)
+            let trans = delegate!.barChartRenderer(self, transformerForAxis: set.axisDependency)
             
             CGContextSetFillColorWithColor(context, set.highlightColor.CGColor)
             CGContextSetAlpha(context, set.highLightAlpha)
@@ -497,18 +497,18 @@ public class BarChartRenderer: ChartDataRendererBase
             // check outofbounds
             if (CGFloat(index) < (CGFloat(delegate!.barChartRendererChartXMax(self)) * _animator.phaseX) / CGFloat(setCount))
             {
-                var e = set.entryForXIndex(index) as! BarChartDataEntry!
+                let e = set.entryForXIndex(index) as! BarChartDataEntry!
                 
                 if (e === nil || e.xIndex != index)
                 {
                     continue
                 }
                 
-                var groupspace = barData.groupSpace
-                var isStack = h.stackIndex < 0 ? false : true
+                let groupspace = barData.groupSpace
+                let isStack = h.stackIndex < 0 ? false : true
 
                 // calculate the correct x-position
-                var x = CGFloat(index * setCount + dataSetIndex) + groupspace / 2.0 + groupspace * CGFloat(index)
+                let x = CGFloat(index * setCount + dataSetIndex) + groupspace / 2.0 + groupspace * CGFloat(index)
                 
                 let y1: Double
                 let y2: Double
@@ -533,15 +533,15 @@ public class BarChartRenderer: ChartDataRendererBase
                     CGContextSetAlpha(context, 1.0)
                     
                     // distance between highlight arrow and bar
-                    var offsetY = _animator.phaseY * 0.07
+                    let offsetY = _animator.phaseY * 0.07
                     
                     CGContextSaveGState(context)
                     
-                    var pixelToValueMatrix = trans.pixelToValueMatrix
-                    var xToYRel = abs(sqrt(pixelToValueMatrix.b * pixelToValueMatrix.b + pixelToValueMatrix.d * pixelToValueMatrix.d) / sqrt(pixelToValueMatrix.a * pixelToValueMatrix.a + pixelToValueMatrix.c * pixelToValueMatrix.c))
+                    let pixelToValueMatrix = trans.pixelToValueMatrix
+                    let xToYRel = abs(sqrt(pixelToValueMatrix.b * pixelToValueMatrix.b + pixelToValueMatrix.d * pixelToValueMatrix.d) / sqrt(pixelToValueMatrix.a * pixelToValueMatrix.a + pixelToValueMatrix.c * pixelToValueMatrix.c))
                     
-                    var arrowWidth = set.barSpace / 2.0
-                    var arrowHeight = arrowWidth * xToYRel
+                    let arrowWidth = set.barSpace / 2.0
+                    let arrowHeight = arrowWidth * xToYRel
                     
                     let yArrow = y1 > -y2 ? y1 : y1;
                     
@@ -570,14 +570,14 @@ public class BarChartRenderer: ChartDataRendererBase
         CGContextRestoreGState(context)
     }
     
-    public func getTransformedValues(#trans: ChartTransformer, entries: [BarChartDataEntry], dataSetIndex: Int) -> [CGPoint]
+    public func getTransformedValues(trans trans: ChartTransformer, entries: [BarChartDataEntry], dataSetIndex: Int) -> [CGPoint]
     {
         return trans.generateTransformedValuesBarChart(entries, dataSet: dataSetIndex, barData: delegate!.barChartRendererData(self)!, phaseY: _animator.phaseY)
     }
     
     internal func passesCheck() -> Bool
     {
-        var barData = delegate!.barChartRendererData(self)
+        let barData = delegate!.barChartRendererData(self)
         
         if (barData === nil)
         {

--- a/Charts/Classes/Renderers/BubbleChartRenderer.swift
+++ b/Charts/Classes/Renderers/BubbleChartRenderer.swift
@@ -38,7 +38,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         self.delegate = delegate
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
         let bubbleData = delegate!.bubbleChartRendererData(self)
         
@@ -51,7 +51,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         }
     }
     
-    private func getShapeSize(#entrySize: CGFloat, maxSize: CGFloat, reference: CGFloat) -> CGFloat
+    private func getShapeSize(entrySize entrySize: CGFloat, maxSize: CGFloat, reference: CGFloat) -> CGFloat
     {
         let factor: CGFloat = (maxSize == 0.0) ? 1.0 : sqrt(entrySize / maxSize)
         let shapeSize: CGFloat = reference * factor
@@ -61,7 +61,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
     private var _pointBuffer = CGPoint()
     private var _sizeBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawDataSet(#context: CGContext, dataSet: BubbleChartDataSet)
+    internal func drawDataSet(context context: CGContext, dataSet: BubbleChartDataSet)
     {
         let trans = delegate!.bubbleChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
@@ -74,11 +74,11 @@ public class BubbleChartRenderer: ChartDataRendererBase
         
         CGContextSaveGState(context)
         
-        var entryFrom = dataSet.entryForXIndex(_minX)
-        var entryTo = dataSet.entryForXIndex(_maxX)
+        let entryFrom = dataSet.entryForXIndex(_minX)
+        let entryTo = dataSet.entryForXIndex(_maxX)
         
-        var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-        var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+        let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+        let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
         
         _sizeBuffer[0].x = 0.0
         _sizeBuffer[0].y = 0.0
@@ -94,7 +94,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         
         for (var j = minx; j < maxx; j++)
         {
-            var entry = entries[j]
+            let entry = entries[j]
             
             _pointBuffer.x = CGFloat(entry.xIndex - minx) * phaseX + CGFloat(minx)
             _pointBuffer.y = CGFloat(entry.value) * phaseY
@@ -135,7 +135,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
         let bubbleData = delegate!.bubbleChartRendererData(self)
         if (bubbleData === nil)
@@ -167,11 +167,11 @@ public class BubbleChartRenderer: ChartDataRendererBase
                 
                 let entries = dataSet.yVals
                 
-                var entryFrom = dataSet.entryForXIndex(_minX)
-                var entryTo = dataSet.entryForXIndex(_maxX)
+                let entryFrom = dataSet.entryForXIndex(_minX)
+                let entryTo = dataSet.entryForXIndex(_maxX)
                 
-                var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-                var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+                let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+                let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
                 
                 let positions = delegate!.bubbleChartRenderer(self, transformerForAxis: dataSet.axisDependency).generateTransformedValuesBubble(entries, phaseX: phaseX, phaseY: phaseY, from: minx, to: maxx)
                 
@@ -203,12 +203,12 @@ public class BubbleChartRenderer: ChartDataRendererBase
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         
     }
     
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
         let bubbleData = delegate!.bubbleChartRendererData(self)
         
@@ -226,11 +226,11 @@ public class BubbleChartRenderer: ChartDataRendererBase
                 continue
             }
             
-            var entryFrom = dataSet.entryForXIndex(_minX)
-            var entryTo = dataSet.entryForXIndex(_maxX)
+            let entryFrom = dataSet.entryForXIndex(_minX)
+            let entryTo = dataSet.entryForXIndex(_maxX)
             
-            var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-            var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, dataSet.entryCount)
+            let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+            let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, dataSet.entryCount)
             
             let entry: BubbleChartDataEntry! = bubbleData.getEntryForHighlight(indice) as! BubbleChartDataEntry
             if (entry === nil || entry.xIndex != indice.xIndex)

--- a/Charts/Classes/Renderers/CandleStickChartRenderer.swift
+++ b/Charts/Classes/Renderers/CandleStickChartRenderer.swift
@@ -39,9 +39,9 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         self.delegate = delegate
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
-        var candleData = delegate!.candleStickChartRendererCandleData(self)
+        let candleData = delegate!.candleStickChartRendererCandleData(self)
 
         for set in candleData.dataSets as! [CandleChartDataSet]
         {
@@ -56,22 +56,21 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
     private var _bodyRect = CGRect()
     private var _lineSegments = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawDataSet(#context: CGContext, dataSet: CandleChartDataSet)
+    internal func drawDataSet(context context: CGContext, dataSet: CandleChartDataSet)
     {
+        let trans = delegate!.candleStickChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
-        var trans = delegate!.candleStickChartRenderer(self, transformerForAxis: dataSet.axisDependency)
-        
-        var phaseX = _animator.phaseX
-        var phaseY = _animator.phaseY
-        var bodySpace = dataSet.bodySpace
+        let phaseX = _animator.phaseX
+        let phaseY = _animator.phaseY
+        let bodySpace = dataSet.bodySpace
         
         var entries = dataSet.yVals as! [CandleChartDataEntry]
         
-        var entryFrom = dataSet.entryForXIndex(_minX)
-        var entryTo = dataSet.entryForXIndex(_maxX)
+        let entryFrom = dataSet.entryForXIndex(_minX)
+        let entryTo = dataSet.entryForXIndex(_maxX)
         
-        var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-        var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+        let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+        let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
         
         CGContextSaveGState(context)
         
@@ -80,7 +79,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
         {
             // get the entry
-            var e = entries[j]
+            let e = entries[j]
             
             if (e.xIndex < _minX || e.xIndex > _maxX)
             {
@@ -132,7 +131,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
             
             if (e.open > e.close)
             {
-                var color = dataSet.decreasingColor ?? dataSet.colorAt(j)
+                let color = dataSet.decreasingColor ?? dataSet.colorAt(j)
                 
                 if (dataSet.isDecreasingFilled)
                 {
@@ -147,8 +146,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
             }
             else if (e.open < e.close)
             {
-                
-                var color = dataSet.increasingColor ?? dataSet.colorAt(j)
+                let color = dataSet.increasingColor ?? dataSet.colorAt(j)
                 
                 if (dataSet.isIncreasingFilled)
                 {
@@ -171,15 +169,15 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
-        var candleData = delegate!.candleStickChartRendererCandleData(self)
+        let candleData = delegate!.candleStickChartRendererCandleData(self)
         if (candleData === nil)
         {
             return
         }
         
-        var defaultValueFormatter = delegate!.candleStickChartDefaultRendererValueFormatter(self)
+        let defaultValueFormatter = delegate!.candleStickChartDefaultRendererValueFormatter(self)
         
         // if values are drawn
         if (candleData.yValCount < Int(ceil(CGFloat(delegate!.candleStickChartRendererMaxVisibleValueCount(self)) * viewPortHandler.scaleX)))
@@ -188,15 +186,15 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
             
             for (var i = 0; i < dataSets.count; i++)
             {
-                var dataSet = dataSets[i]
+                let dataSet = dataSets[i]
                 
                 if (!dataSet.isDrawValuesEnabled)
                 {
                     continue
                 }
                 
-                var valueFont = dataSet.valueFont
-                var valueTextColor = dataSet.valueTextColor
+                let valueFont = dataSet.valueFont
+                let valueTextColor = dataSet.valueTextColor
                 
                 var formatter = dataSet.valueFormatter
                 if (formatter === nil)
@@ -204,25 +202,25 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
                     formatter = defaultValueFormatter
                 }
                 
-                var trans = delegate!.candleStickChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+                let trans = delegate!.candleStickChartRenderer(self, transformerForAxis: dataSet.axisDependency)
                 
                 var entries = dataSet.yVals as! [CandleChartDataEntry]
                 
-                var entryFrom = dataSet.entryForXIndex(_minX)
-                var entryTo = dataSet.entryForXIndex(_maxX)
+                let entryFrom = dataSet.entryForXIndex(_minX)
+                let entryTo = dataSet.entryForXIndex(_maxX)
                 
-                var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-                var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+                let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+                let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
                 
                 var positions = trans.generateTransformedValuesCandle(entries, phaseY: _animator.phaseY)
                 
-                var lineHeight = valueFont.lineHeight
-                var yOffset: CGFloat = lineHeight + 5.0
+                let lineHeight = valueFont.lineHeight
+                let yOffset: CGFloat = lineHeight + 5.0
                 
                 for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * _animator.phaseX + CGFloat(minx))); j < count; j++)
                 {
-                    var x = positions[j].x
-                    var y = positions[j].y
+                    let x = positions[j].x
+                    let y = positions[j].y
                     
                     if (!viewPortHandler.isInBoundsRight(x))
                     {
@@ -234,7 +232,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
                         continue
                     }
                     
-                    var val = entries[j].high
+                    let val = entries[j].high
                     
                     ChartUtils.drawText(context: context, text: formatter!.stringFromNumber(val)!, point: CGPoint(x: x, y: y - yOffset), align: .Center, attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor])
                 }
@@ -242,14 +240,14 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
     }
     
     private var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
-        var candleData = delegate!.candleStickChartRendererCandleData(self)
+        let candleData = delegate!.candleStickChartRendererCandleData(self)
         if (candleData === nil)
         {
             return
@@ -257,23 +255,23 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         
         for (var i = 0; i < indices.count; i++)
         {
-            var xIndex = indices[i].xIndex; // get the x-position
+            let xIndex = indices[i].xIndex; // get the x-position
             
-            var set = candleData.getDataSetByIndex(indices[i].dataSetIndex) as! CandleChartDataSet!
+            let set = candleData.getDataSetByIndex(indices[i].dataSetIndex) as! CandleChartDataSet!
             
             if (set === nil || !set.isHighlightEnabled)
             {
                 continue
             }
             
-            var e = set.entryForXIndex(xIndex) as! CandleChartDataEntry!
+            let e = set.entryForXIndex(xIndex) as! CandleChartDataEntry!
             
             if (e === nil || e.xIndex != xIndex)
             {
                 continue
             }
             
-            var trans = delegate!.candleStickChartRenderer(self, transformerForAxis: set.axisDependency)
+            let trans = delegate!.candleStickChartRenderer(self, transformerForAxis: set.axisDependency)
             
             CGContextSetStrokeColorWithColor(context, set.highlightColor.CGColor)
             CGContextSetLineWidth(context, set.highlightLineWidth)
@@ -286,9 +284,9 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
                 CGContextSetLineDash(context, 0.0, nil, 0)
             }
             
-            var low = CGFloat(e.low) * _animator.phaseY
-            var high = CGFloat(e.high) * _animator.phaseY
-            var y = (low + high) / 2.0
+            let low = CGFloat(e.low) * _animator.phaseY
+            let high = CGFloat(e.high) * _animator.phaseY
+            let y = (low + high) / 2.0
             
             _highlightPtsBuffer[0] = CGPoint(x: CGFloat(xIndex), y: CGFloat(delegate!.candleStickChartRendererChartYMax(self)))
             _highlightPtsBuffer[1] = CGPoint(x: CGFloat(xIndex), y: CGFloat(delegate!.candleStickChartRendererChartYMin(self)))

--- a/Charts/Classes/Renderers/ChartAxisRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartAxisRendererBase.swift
@@ -31,25 +31,25 @@ public class ChartAxisRendererBase: ChartRendererBase
     }
     
     /// Draws the axis labels on the specified context
-    public func renderAxisLabels(#context: CGContext)
+    public func renderAxisLabels(context context: CGContext)
     {
         fatalError("renderAxisLabels() cannot be called on ChartAxisRendererBase")
     }
     
     /// Draws the grid lines belonging to the axis.
-    public func renderGridLines(#context: CGContext)
+    public func renderGridLines(context context: CGContext)
     {
         fatalError("renderGridLines() cannot be called on ChartAxisRendererBase")
     }
     
     /// Draws the line that goes alongside the axis.
-    public func renderAxisLine(#context: CGContext)
+    public func renderAxisLine(context context: CGContext)
     {
         fatalError("renderAxisLine() cannot be called on ChartAxisRendererBase")
     }
     
     /// Draws the LimitLines associated with this axis to the screen.
-    public func renderLimitLines(#context: CGContext)
+    public func renderLimitLines(context context: CGContext)
     {
         fatalError("renderLimitLines() cannot be called on ChartAxisRendererBase")
     }

--- a/Charts/Classes/Renderers/ChartDataRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartDataRendererBase.swift
@@ -24,22 +24,22 @@ public class ChartDataRendererBase: ChartRendererBase
         _animator = animator
     }
 
-    public func drawData(#context: CGContext)
+    public func drawData(context context: CGContext)
     {
         fatalError("drawData() cannot be called on ChartDataRendererBase")
     }
     
-    public func drawValues(#context: CGContext)
+    public func drawValues(context context: CGContext)
     {
         fatalError("drawValues() cannot be called on ChartDataRendererBase")
     }
     
-    public func drawExtras(#context: CGContext)
+    public func drawExtras(context context: CGContext)
     {
         fatalError("drawExtras() cannot be called on ChartDataRendererBase")
     }
     
-    public func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
         fatalError("drawHighlighted() cannot be called on ChartDataRendererBase")
     }

--- a/Charts/Classes/Renderers/ChartLegendRenderer.swift
+++ b/Charts/Classes/Renderers/ChartLegendRenderer.swift
@@ -37,15 +37,15 @@ public class ChartLegendRenderer: ChartRendererBase
             // loop for building up the colors and labels used in the legend
             for (var i = 0, count = data.dataSetCount; i < count; i++)
             {
-                var dataSet = data.getDataSetByIndex(i)!
+                let dataSet = data.getDataSetByIndex(i)!
                 
                 var clrs: [UIColor] = dataSet.colors
-                var entryCount = dataSet.entryCount
+                let entryCount = dataSet.entryCount
                 
                 // if we have a barchart with stacked bars
                 if (dataSet.isKindOfClass(BarChartDataSet) && (dataSet as! BarChartDataSet).isStacked)
                 {
-                    var bds = dataSet as! BarChartDataSet
+                    let bds = dataSet as! BarChartDataSet
                     var sLabels = bds.stackLabels
                     
                     for (var j = 0; j < clrs.count && j < bds.stackSize; j++)
@@ -64,7 +64,7 @@ public class ChartLegendRenderer: ChartRendererBase
                 else if (dataSet.isKindOfClass(PieChartDataSet))
                 {
                     var xVals = data.xVals
-                    var pds = dataSet as! PieChartDataSet
+                    let pds = dataSet as! PieChartDataSet
                     
                     for (var j = 0; j < clrs.count && j < entryCount && j < xVals.count; j++)
                     {
@@ -107,33 +107,33 @@ public class ChartLegendRenderer: ChartRendererBase
         _legend.calculateDimensions(labelFont: _legend.font, viewPortHandler: viewPortHandler)
     }
     
-    public func renderLegend(#context: CGContext)
+    public func renderLegend(context context: CGContext)
     {
         if (_legend === nil || !_legend.enabled)
         {
             return
         }
         
-        var labelFont = _legend.font
-        var labelTextColor = _legend.textColor
-        var labelLineHeight = labelFont.lineHeight
-        var formYOffset = labelLineHeight / 2.0
+        let labelFont = _legend.font
+        let labelTextColor = _legend.textColor
+        let labelLineHeight = labelFont.lineHeight
+        let formYOffset = labelLineHeight / 2.0
 
         var labels = _legend.labels
         var colors = _legend.colors
         
-        var formSize = _legend.formSize
-        var formToTextSpace = _legend.formToTextSpace
-        var xEntrySpace = _legend.xEntrySpace
-        var direction = _legend.direction
+        let formSize = _legend.formSize
+        let formToTextSpace = _legend.formToTextSpace
+        let xEntrySpace = _legend.xEntrySpace
+        let direction = _legend.direction
 
         // space between the entries
-        var stackSpace = _legend.stackSpace
+        let stackSpace = _legend.stackSpace
 
-        var yoffset = _legend.yOffset
-        var xoffset = _legend.xOffset
+        let yoffset = _legend.yOffset
+        let xoffset = _legend.xOffset
         
-        var legendPosition = _legend.position
+        let legendPosition = _legend.position
         
         switch (legendPosition)
         {
@@ -141,7 +141,7 @@ public class ChartLegendRenderer: ChartRendererBase
         case .BelowChartRight: fallthrough
         case .BelowChartCenter:
             
-            var contentWidth: CGFloat = viewPortHandler.contentWidth
+            let contentWidth: CGFloat = viewPortHandler.contentWidth
             
             var originPosX: CGFloat
             
@@ -191,8 +191,8 @@ public class ChartLegendRenderer: ChartRendererBase
                     lineIndex++
                 }
                 
-                var drawingForm = colors[i] != nil
-                var isStacked = labels[i] == nil; // grouped forms have null labels
+                let drawingForm = colors[i] != nil
+                let isStacked = labels[i] == nil; // grouped forms have null labels
                 
                 if (drawingForm)
                 {
@@ -258,7 +258,7 @@ public class ChartLegendRenderer: ChartRendererBase
             }
             else
             {
-                var isRightAligned = legendPosition == .RightOfChart ||
+                let isRightAligned = legendPosition == .RightOfChart ||
                     legendPosition == .RightOfChartCenter ||
                     legendPosition == .RightOfChartInside
                 
@@ -298,7 +298,7 @@ public class ChartLegendRenderer: ChartRendererBase
             
             for (var i = 0; i < labels.count; i++)
             {
-                var drawingForm = colors[i] != nil
+                let drawingForm = colors[i] != nil
                 var x = posX
                 
                 if (drawingForm)
@@ -366,14 +366,14 @@ public class ChartLegendRenderer: ChartRendererBase
     /// Draws the Legend-form at the given position with the color at the given index.
     internal func drawForm(context: CGContext, x: CGFloat, y: CGFloat, colorIndex: Int, legend: ChartLegend)
     {
-        var formColor = legend.colors[colorIndex]
+        let formColor = legend.colors[colorIndex]
         
         if (formColor === nil || formColor == UIColor.clearColor())
         {
             return
         }
         
-        var formsize = legend.formSize
+        let formsize = legend.formSize
         
         CGContextSaveGState(context)
         

--- a/Charts/Classes/Renderers/ChartRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartRendererBase.swift
@@ -36,7 +36,7 @@ public class ChartRendererBase: NSObject
         self.viewPortHandler = viewPortHandler
     }
 
-    /// Returns true if the specified value fits in between the provided min and max bounds, false if not.
+    /// - returns: true if the specified value fits in between the provided min and max bounds, false if not.
     internal func fitsBounds(val: Double, min: Double, max: Double) -> Bool
     {
         if (val < min || val > max)

--- a/Charts/Classes/Renderers/ChartRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartRendererBase.swift
@@ -50,7 +50,7 @@ public class ChartRendererBase: NSObject
     }
     
     /// Calculates the minimum and maximum x-value the chart can currently display (with the given zoom level).
-    public func calcXBounds(#chart: BarLineChartViewBase, xAxisModulus: Int)
+    public func calcXBounds(chart chart: BarLineChartViewBase, xAxisModulus: Int)
     {
         let low = chart.lowestVisibleXIndex
         let high = chart.highestVisibleXIndex

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -26,32 +26,32 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         _xAxis = xAxis
     }
     
-    public func computeAxis(#xValAverageLength: Double, xValues: [String?])
+    public func computeAxis(xValAverageLength xValAverageLength: Double, xValues: [String?])
     {
         var a = ""
         
-        var max = Int(round(xValAverageLength + Double(_xAxis.spaceBetweenLabels)))
+        let max = Int(round(xValAverageLength + Double(_xAxis.spaceBetweenLabels)))
         
         for (var i = 0; i < max; i++)
         {
             a += "h"
         }
         
-        var widthText = a as NSString
+        let widthText = a as NSString
         
         _xAxis.labelWidth = widthText.sizeWithAttributes([NSFontAttributeName: _xAxis.labelFont]).width
         _xAxis.labelHeight = _xAxis.labelFont.lineHeight
         _xAxis.values = xValues
     }
     
-    public override func renderAxisLabels(#context: CGContext)
+    public override func renderAxisLabels(context context: CGContext)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawLabelsEnabled)
         {
             return
         }
         
-        var yoffset = CGFloat(4.0)
+        let yoffset = CGFloat(4.0)
         
         if (_xAxis.labelPosition == .Top)
         {
@@ -78,7 +78,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(#context: CGContext)
+    public override func renderAxisLine(context context: CGContext)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawAxisLineEnabled)
         {
@@ -124,16 +124,16 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     }
     
     /// draws the x-labels on the specified y-position
-    internal func drawLabels(#context: CGContext, pos: CGFloat)
+    internal func drawLabels(context context: CGContext, pos: CGFloat)
     {
-        var paraStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
+        let paraStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
         paraStyle.alignment = .Center
         
-        var labelAttrs = [NSFontAttributeName: _xAxis.labelFont,
+        let labelAttrs = [NSFontAttributeName: _xAxis.labelFont,
             NSForegroundColorAttributeName: _xAxis.labelTextColor,
             NSParagraphStyleAttributeName: paraStyle]
         
-        var valueToPixelMatrix = transformer.valueToPixelMatrix
+        let valueToPixelMatrix = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
@@ -146,7 +146,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         
         for (var i = _minX, maxX = min(_maxX + 1, _xAxis.values.count); i < maxX; i += _xAxis.axisLabelModulus)
         {
-            var label = _xAxis.values[i]
+            let label = _xAxis.values[i]
             if (label == nil)
             {
                 continue
@@ -158,14 +158,14 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
             
             if (viewPortHandler.isInBoundsX(position.x))
             {
-                var labelns = label! as NSString
+                let labelns = label! as NSString
                 
                 if (_xAxis.isAvoidFirstLastClippingEnabled)
                 {
                     // avoid clipping of the last
                     if (i == _xAxis.values.count - 1 && _xAxis.values.count > 1)
                     {
-                        var width = labelns.boundingRectWithSize(labelMaxSize, options: .UsesLineFragmentOrigin, attributes: labelAttrs, context: nil).size.width
+                        let width = labelns.boundingRectWithSize(labelMaxSize, options: .UsesLineFragmentOrigin, attributes: labelAttrs, context: nil).size.width
                         
                         if (width > viewPortHandler.offsetRight * 2.0
                             && position.x + width > viewPortHandler.chartWidth)
@@ -175,7 +175,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
                     }
                     else if (i == 0)
                     { // avoid clipping of the first
-                        var width = labelns.boundingRectWithSize(labelMaxSize, options: .UsesLineFragmentOrigin, attributes: labelAttrs, context: nil).size.width
+                        let width = labelns.boundingRectWithSize(labelMaxSize, options: .UsesLineFragmentOrigin, attributes: labelAttrs, context: nil).size.width
                         position.x += width / 2.0
                     }
                 }
@@ -187,7 +187,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _gridLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(#context: CGContext)
+    public override func renderGridLines(context context: CGContext)
     {
         if (!_xAxis.isDrawGridLinesEnabled || !_xAxis.isEnabled)
         {
@@ -207,7 +207,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
             CGContextSetLineDash(context, 0.0, nil, 0)
         }
         
-        var valueToPixelMatrix = transformer.valueToPixelMatrix
+        let valueToPixelMatrix = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
@@ -233,7 +233,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(#context: CGContext)
+    public override func renderLimitLines(context context: CGContext)
     {
         var limitLines = _xAxis.limitLines
         
@@ -244,13 +244,13 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         
         CGContextSaveGState(context)
         
-        var trans = transformer.valueToPixelMatrix
+        let trans = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
         for (var i = 0; i < limitLines.count; i++)
         {
-            var l = limitLines[i]
+            let l = limitLines[i]
             
             position.x = CGFloat(l.limit)
             position.y = 0.0
@@ -274,16 +274,16 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
             
             CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
             
-            var label = l.label
+            let label = l.label
             
             // if drawing the limit-value label is enabled
-            if (count(label) > 0)
+            if (label.characters.count > 0)
             {
-                var labelLineHeight = l.valueFont.lineHeight
+                let labelLineHeight = l.valueFont.lineHeight
                 
                 let add = CGFloat(4.0)
-                var xOffset: CGFloat = l.lineWidth
-                var yOffset: CGFloat = add / 2.0
+                let xOffset: CGFloat = l.lineWidth
+                let yOffset: CGFloat = add / 2.0
                 
                 if (l.labelPosition == .Right)
                 {

--- a/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
@@ -27,24 +27,24 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
     }
     
     /// draws the x-labels on the specified y-position
-    internal override func drawLabels(#context: CGContext, pos: CGFloat)
+    internal override func drawLabels(context context: CGContext, pos: CGFloat)
     {
         if (_chart.data === nil)
         {
             return
         }
         
-        var paraStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
+        let paraStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
         paraStyle.alignment = .Center
         
-        var labelAttrs = [NSFontAttributeName: _xAxis.labelFont,
+        let labelAttrs = [NSFontAttributeName: _xAxis.labelFont,
             NSForegroundColorAttributeName: _xAxis.labelTextColor,
             NSParagraphStyleAttributeName: paraStyle]
         
-        var barData = _chart.data as! BarChartData
-        var step = barData.dataSetCount
+        let barData = _chart.data as! BarChartData
+        let step = barData.dataSetCount
         
-        var valueToPixelMatrix = transformer.valueToPixelMatrix
+        let valueToPixelMatrix = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
@@ -57,7 +57,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
         
         for (var i = _minX, maxX = min(_maxX + 1, _xAxis.values.count); i < maxX; i += _xAxis.axisLabelModulus)
         {
-            var label = i >= 0 && i < _xAxis.values.count ? _xAxis.values[i] : nil
+            let label = i >= 0 && i < _xAxis.values.count ? _xAxis.values[i] : nil
             if (label == nil)
             {
                 continue
@@ -81,7 +81,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
                     // avoid clipping of the last
                     if (i == _xAxis.values.count - 1)
                     {
-                        var width = label!.sizeWithAttributes(labelAttrs).width
+                        let width = label!.sizeWithAttributes(labelAttrs).width
                         
                         if (width > viewPortHandler.offsetRight * 2.0
                             && position.x + width > viewPortHandler.chartWidth)
@@ -91,7 +91,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
                     }
                     else if (i == 0)
                     { // avoid clipping of the first
-                        var width = label!.sizeWithAttributes(labelAttrs).width
+                        let width = label!.sizeWithAttributes(labelAttrs).width
                         position.x += width / 2.0
                     }
                 }
@@ -103,15 +103,15 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
     
     private var _gridLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(#context: CGContext)
+    public override func renderGridLines(context context: CGContext)
     {
         if (!_xAxis.isDrawGridLinesEnabled || !_xAxis.isEnabled)
         {
             return
         }
         
-        var barData = _chart.data as! BarChartData
-        var step = barData.dataSetCount
+        let barData = _chart.data as! BarChartData
+        let step = barData.dataSetCount
         
         CGContextSaveGState(context)
         
@@ -126,7 +126,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
             CGContextSetLineDash(context, 0.0, nil, 0)
         }
         
-        var valueToPixelMatrix = transformer.valueToPixelMatrix
+        let valueToPixelMatrix = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         

--- a/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
@@ -22,24 +22,24 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
         super.init(viewPortHandler: viewPortHandler, xAxis: xAxis, transformer: transformer, chart: chart)
     }
     
-    public override func computeAxis(#xValAverageLength: Double, xValues: [String?])
+    public override func computeAxis(xValAverageLength xValAverageLength: Double, xValues: [String?])
     {
         _xAxis.values = xValues
        
-        var longest = _xAxis.getLongestLabel() as NSString
-        var longestSize = longest.sizeWithAttributes([NSFontAttributeName: _xAxis.labelFont])
+        let longest = _xAxis.getLongestLabel() as NSString
+        let longestSize = longest.sizeWithAttributes([NSFontAttributeName: _xAxis.labelFont])
         _xAxis.labelWidth = floor(longestSize.width + _xAxis.xOffset * 3.5)
         _xAxis.labelHeight = longestSize.height
     }
 
-    public override func renderAxisLabels(#context: CGContext)
+    public override func renderAxisLabels(context context: CGContext)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawLabelsEnabled || _chart.data === nil)
         {
             return
         }
         
-        var xoffset = _xAxis.xOffset
+        let xoffset = _xAxis.xOffset
         
         if (_xAxis.labelPosition == .Top)
         {
@@ -65,20 +65,20 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     }
 
     /// draws the x-labels on the specified y-position
-    internal func drawLabels(#context: CGContext, pos: CGFloat, align: NSTextAlignment)
+    internal func drawLabels(context context: CGContext, pos: CGFloat, align: NSTextAlignment)
     {
-        var labelFont = _xAxis.labelFont
-        var labelTextColor = _xAxis.labelTextColor
+        let labelFont = _xAxis.labelFont
+        let labelTextColor = _xAxis.labelTextColor
         
         // pre allocate to save performance (dont allocate in loop)
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        var bd = _chart.data as! BarChartData
-        var step = bd.dataSetCount
+        let bd = _chart.data as! BarChartData
+        let step = bd.dataSetCount
         
         for (var i = _minX, maxX = min(_maxX + 1, _xAxis.values.count); i < maxX; i += _xAxis.axisLabelModulus)
         {
-            var label = _xAxis.values[i]
+            let label = _xAxis.values[i]
             
             if (label == nil)
             {
@@ -105,7 +105,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     private var _gridLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(#context: CGContext)
+    public override func renderGridLines(context context: CGContext)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawGridLinesEnabled || _chart.data === nil)
         {
@@ -127,10 +127,10 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        var bd = _chart.data as! BarChartData
+        let bd = _chart.data as! BarChartData
         
         // take into consideration that multiple DataSets increase _deltaX
-        var step = bd.dataSetCount
+        let step = bd.dataSetCount
         
         for (var i = _minX, maxX = min(_maxX + 1, _xAxis.values.count); i < maxX; i += _xAxis.axisLabelModulus)
         {
@@ -154,7 +154,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(#context: CGContext)
+    public override func renderAxisLine(context context: CGContext)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawAxisLineEnabled)
         {
@@ -201,7 +201,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(#context: CGContext)
+    public override func renderLimitLines(context context: CGContext)
     {
         var limitLines = _xAxis.limitLines
         
@@ -212,13 +212,13 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
         
         CGContextSaveGState(context)
         
-        var trans = transformer.valueToPixelMatrix
+        let trans = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
         for (var i = 0; i < limitLines.count; i++)
         {
-            var l = limitLines[i]
+            let l = limitLines[i]
             
             position.x = 0.0
             position.y = CGFloat(l.limit)
@@ -242,16 +242,16 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
             
             CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
             
-            var label = l.label
+            let label = l.label
             
             // if drawing the limit-value label is enabled
-            if (count(label) > 0)
+            if (label.characters.count > 0)
             {
-                var labelLineHeight = l.valueFont.lineHeight
+                let labelLineHeight = l.valueFont.lineHeight
                 
                 let add = CGFloat(4.0)
-                var xOffset: CGFloat = add
-                var yOffset: CGFloat = l.lineWidth + labelLineHeight / 2.0
+                let xOffset: CGFloat = add
+                let yOffset: CGFloat = l.lineWidth + labelLineHeight / 2.0
                 
                 if (l.labelPosition == .Right)
                 {

--- a/Charts/Classes/Renderers/ChartXAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererRadarChart.swift
@@ -26,41 +26,41 @@ public class ChartXAxisRendererRadarChart: ChartXAxisRenderer
         _chart = chart
     }
     
-    public override func renderAxisLabels(#context: CGContext)
+    public override func renderAxisLabels(context context: CGContext)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawLabelsEnabled)
         {
             return
         }
         
-        var labelFont = _xAxis.labelFont
-        var labelTextColor = _xAxis.labelTextColor
+        let labelFont = _xAxis.labelFont
+        let labelTextColor = _xAxis.labelTextColor
         
-        var sliceangle = _chart.sliceAngle
+        let sliceangle = _chart.sliceAngle
         
         // calculate the factor that is needed for transforming the value to pixels
-        var factor = _chart.factor
+        let factor = _chart.factor
         
-        var center = _chart.centerOffsets
+        let center = _chart.centerOffsets
         
         for (var i = 0, count = _xAxis.values.count; i < count; i++)
         {
-            var text = _xAxis.values[i]
+            let text = _xAxis.values[i]
             
             if (text == nil)
             {
                 continue
             }
             
-            var angle = (sliceangle * CGFloat(i) + _chart.rotationAngle) % 360.0
+            let angle = (sliceangle * CGFloat(i) + _chart.rotationAngle) % 360.0
             
-            var p = ChartUtils.getPosition(center: center, dist: CGFloat(_chart.yRange) * factor + _xAxis.labelWidth / 2.0, angle: angle)
+            let p = ChartUtils.getPosition(center: center, dist: CGFloat(_chart.yRange) * factor + _xAxis.labelWidth / 2.0, angle: angle)
             
             ChartUtils.drawText(context: context, text: text!, point: CGPoint(x: p.x, y: p.y - _xAxis.labelHeight / 2.0), align: .Center, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }
     
-    public override func renderLimitLines(#context: CGContext)
+    public override func renderLimitLines(context context: CGContext)
     {
         /// XAxis LimitLines on RadarChart not yet supported.
     }

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -27,14 +27,14 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     }
     
     /// Computes the axis values.
-    public func computeAxis(var #yMin: Double, var yMax: Double)
+    public func computeAxis(var yMin yMin: Double, var yMax: Double)
     {
         // calculate the starting and entry point of the y-labels (depending on
         // zoom / contentrect bounds)
         if (viewPortHandler.contentWidth > 10.0 && !viewPortHandler.isFullyZoomedOutY)
         {
-            var p1 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop))
-            var p2 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentBottom))
+            let p1 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop))
+            let p2 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentBottom))
             
             if (!_yAxis.isInverted)
             {
@@ -54,13 +54,13 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     /// Sets up the y-axis labels. Computes the desired number of labels between
     /// the two given extremes. Unlike the papareXLabels() method, this method
     /// needs to be called upon every refresh of the view.
-    internal func computeAxisValues(#min: Double, max: Double)
+    internal func computeAxisValues(min min: Double, max: Double)
     {
-        var yMin = min
-        var yMax = max
+        let yMin = min
+        let yMax = max
         
-        var labelCount = _yAxis.labelCount
-        var range = abs(yMax - yMin)
+        let labelCount = _yAxis.labelCount
+        let range = abs(yMax - yMin)
     
         if (labelCount == 0 || range <= 0)
         {
@@ -68,10 +68,10 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             return
         }
         
-        var rawInterval = range / Double(labelCount)
+        let rawInterval = range / Double(labelCount)
         var interval = ChartUtils.roundToNextSignificant(number: Double(rawInterval))
-        var intervalMagnitude = pow(10.0, round(log10(interval)))
-        var intervalSigDigit = (interval / intervalMagnitude)
+        let intervalMagnitude = pow(10.0, round(log10(interval)))
+        let intervalSigDigit = (interval / intervalMagnitude)
         if (intervalSigDigit > 5)
         {
             // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
@@ -105,55 +105,55 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         } else {
             // no forced count
             
-            // if the labels should only show min and max
-            if (_yAxis.isShowOnlyMinMaxEnabled)
+        // if the labels should only show min and max
+        if (_yAxis.isShowOnlyMinMaxEnabled)
+        {
+            _yAxis.entries = [yMin, yMax]
+        }
+        else
+        {
+            let first = ceil(Double(yMin) / interval) * interval
+            let last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval)
+            
+            var f: Double
+            var i: Int
+            var n = 0
+            for (f = first; f <= last; f += interval)
             {
-                _yAxis.entries = [yMin, yMax]
+                ++n
             }
-            else
+            
+            if (_yAxis.entries.count < n)
             {
-                var first = ceil(Double(yMin) / interval) * interval
-                var last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval)
-                
-                var f: Double
-                var i: Int
-                var n = 0
-                for (f = first; f <= last; f += interval)
-                {
-                    ++n
-                }
-                
-                if (_yAxis.entries.count < n)
-                {
-                    // Ensure stops contains at least numStops elements.
-                    _yAxis.entries = [Double](count: n, repeatedValue: 0.0)
-                }
-                else if (_yAxis.entries.count > n)
-                {
-                    _yAxis.entries.removeRange(n..<_yAxis.entries.count)
-                }
-                
-                for (f = first, i = 0; i < n; f += interval, ++i)
-                {
-                    _yAxis.entries[i] = Double(f)
-                }
+                // Ensure stops contains at least numStops elements.
+                _yAxis.entries = [Double](count: n, repeatedValue: 0.0)
+            }
+            else if (_yAxis.entries.count > n)
+            {
+                _yAxis.entries.removeRange(n..<_yAxis.entries.count)
+            }
+            
+            for (f = first, i = 0; i < n; f += interval, ++i)
+            {
+                _yAxis.entries[i] = Double(f)
             }
         }
     }
+    }
     
     /// draws the y-axis labels to the screen
-    public override func renderAxisLabels(#context: CGContext)
+    public override func renderAxisLabels(context context: CGContext)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawLabelsEnabled)
         {
             return
         }
         
-        var xoffset = _yAxis.xOffset
-        var yoffset = _yAxis.labelFont.lineHeight / 2.5 + _yAxis.yOffset
+        let xoffset = _yAxis.xOffset
+        let yoffset = _yAxis.labelFont.lineHeight / 2.5 + _yAxis.yOffset
         
-        var dependency = _yAxis.axisDependency
-        var labelPosition = _yAxis.labelPosition
+        let dependency = _yAxis.axisDependency
+        let labelPosition = _yAxis.labelPosition
         
         var xPos = CGFloat(0.0)
         
@@ -192,7 +192,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(#context: CGContext)
+    public override func renderAxisLine(context context: CGContext)
     {
         if (!_yAxis.isEnabled || !_yAxis.drawAxisLineEnabled)
         {
@@ -233,18 +233,18 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     }
     
     /// draws the y-labels on the specified x-position
-    internal func drawYLabels(#context: CGContext, fixedPosition: CGFloat, offset: CGFloat, textAlign: NSTextAlignment)
+    internal func drawYLabels(context context: CGContext, fixedPosition: CGFloat, offset: CGFloat, textAlign: NSTextAlignment)
     {
-        var labelFont = _yAxis.labelFont
-        var labelTextColor = _yAxis.labelTextColor
+        let labelFont = _yAxis.labelFont
+        let labelTextColor = _yAxis.labelTextColor
         
-        var valueToPixelMatrix = transformer.valueToPixelMatrix
+        let valueToPixelMatrix = transformer.valueToPixelMatrix
         
         var pt = CGPoint()
         
         for (var i = 0; i < _yAxis.entryCount; i++)
         {
-            var text = _yAxis.getFormattedLabel(i)
+            let text = _yAxis.getFormattedLabel(i)
             
             if (!_yAxis.isDrawTopYLabelEntryEnabled && i >= _yAxis.entryCount - 1)
             {
@@ -264,7 +264,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     
     private var _gridLineBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(#context: CGContext)
+    public override func renderGridLines(context context: CGContext)
     {
         if (!_yAxis.isDrawGridLinesEnabled || !_yAxis.isEnabled)
         {
@@ -284,7 +284,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             CGContextSetLineDash(context, 0.0, nil, 0)
         }
         
-        var valueToPixelMatrix = transformer.valueToPixelMatrix
+        let valueToPixelMatrix = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
@@ -307,7 +307,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(#context: CGContext)
+    public override func renderLimitLines(context context: CGContext)
     {
         var limitLines = _yAxis.limitLines
         
@@ -318,13 +318,13 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         
         CGContextSaveGState(context)
         
-        var trans = transformer.valueToPixelMatrix
+        let trans = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
         for (var i = 0; i < limitLines.count; i++)
         {
-            var l = limitLines[i]
+            let l = limitLines[i]
             
             position.x = 0.0
             position.y = CGFloat(l.limit)
@@ -348,16 +348,16 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             
             CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
             
-            var label = l.label
+            let label = l.label
             
             // if drawing the limit-value label is enabled
-            if (count(label) > 0)
+            if (label.characters.count > 0)
             {
-                var labelLineHeight = l.valueFont.lineHeight
+                let labelLineHeight = l.valueFont.lineHeight
                 
                 let add = CGFloat(4.0)
-                var xOffset: CGFloat = add
-                var yOffset: CGFloat = l.lineWidth + labelLineHeight / 2.0
+                let xOffset: CGFloat = add
+                let yOffset: CGFloat = l.lineWidth + labelLineHeight / 2.0
                 
                 if (l.labelPosition == .Right)
                 {

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -23,13 +23,13 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// Computes the axis values.
-    public override func computeAxis(var #yMin: Double, var yMax: Double)
+    public override func computeAxis(var yMin yMin: Double, var yMax: Double)
     {
         // calculate the starting and entry point of the y-labels (depending on zoom / contentrect bounds)
         if (viewPortHandler.contentHeight > 10.0 && !viewPortHandler.isFullyZoomedOutX)
         {
-            var p1 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop))
-            var p2 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentRight, y: viewPortHandler.contentTop))
+            let p1 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop))
+            let p2 = transformer.getValueByTouchPoint(CGPoint(x: viewPortHandler.contentRight, y: viewPortHandler.contentTop))
             
             if (!_yAxis.isInverted)
             {
@@ -47,7 +47,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// draws the y-axis labels to the screen
-    public override func renderAxisLabels(#context: CGContext)
+    public override func renderAxisLabels(context context: CGContext)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawLabelsEnabled)
         {
@@ -64,11 +64,11 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         
         transformer.pointValuesToPixel(&positions)
         
-        var lineHeight = _yAxis.labelFont.lineHeight
-        var baseYOffset: CGFloat = 2.5
+        let lineHeight = _yAxis.labelFont.lineHeight
+        let baseYOffset: CGFloat = 2.5
         
-        var dependency = _yAxis.axisDependency
-        var labelPosition = _yAxis.labelPosition
+        let dependency = _yAxis.axisDependency
+        let labelPosition = _yAxis.labelPosition
         
         var yPos: CGFloat = 0.0
         
@@ -104,7 +104,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(#context: CGContext)
+    public override func renderAxisLine(context context: CGContext)
     {
         if (!_yAxis.isEnabled || !_yAxis.drawAxisLineEnabled)
         {
@@ -145,14 +145,14 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// draws the y-labels on the specified x-position
-    internal func drawYLabels(#context: CGContext, fixedPosition: CGFloat, positions: [CGPoint], offset: CGFloat)
+    internal func drawYLabels(context context: CGContext, fixedPosition: CGFloat, positions: [CGPoint], offset: CGFloat)
     {
-        var labelFont = _yAxis.labelFont
-        var labelTextColor = _yAxis.labelTextColor
+        let labelFont = _yAxis.labelFont
+        let labelTextColor = _yAxis.labelTextColor
         
         for (var i = 0; i < _yAxis.entryCount; i++)
         {
-            var text = _yAxis.getFormattedLabel(i)
+            let text = _yAxis.getFormattedLabel(i)
             
             if (!_yAxis.isDrawTopYLabelEntryEnabled && i >= _yAxis.entryCount - 1)
             {
@@ -163,7 +163,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         }
     }
 
-    public override func renderGridLines(#context: CGContext)
+    public override func renderGridLines(context context: CGContext)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawGridLinesEnabled)
         {
@@ -204,7 +204,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(#context: CGContext)
+    public override func renderLimitLines(context context: CGContext)
     {
         var limitLines = _yAxis.limitLines
 
@@ -215,13 +215,13 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         
         CGContextSaveGState(context)
         
-        var trans = transformer.valueToPixelMatrix
+        let trans = transformer.valueToPixelMatrix
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
         for (var i = 0; i < limitLines.count; i++)
         {
-            var l = limitLines[i]
+            let l = limitLines[i]
             
             position.x = CGFloat(l.limit)
             position.y = 0.0
@@ -245,16 +245,16 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
             
             CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
 
-            var label = l.label
+            let label = l.label
 
             // if drawing the limit-value label is enabled
-            if (count(label) > 0)
+            if (label.characters.count > 0)
             {
-                var labelLineHeight = l.valueFont.lineHeight
+                let labelLineHeight = l.valueFont.lineHeight
                 
                 let add = CGFloat(4.0)
-                var xOffset: CGFloat = l.lineWidth
-                var yOffset: CGFloat = add / 2.0
+                let xOffset: CGFloat = l.lineWidth
+                let yOffset: CGFloat = add / 2.0
 
                 if (l.labelPosition == .Right)
                 {

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -26,15 +26,15 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         _chart = chart
     }
  
-    public override func computeAxis(#yMin: Double, yMax: Double)
+    public override func computeAxis(yMin yMin: Double, yMax: Double)
     {
         computeAxisValues(min: yMin, max: yMax)
     }
     
     internal override func computeAxisValues(min yMin: Double, max yMax: Double)
     {
-        var labelCount = _yAxis.labelCount
-        var range = abs(yMax - yMin)
+        let labelCount = _yAxis.labelCount
+        let range = abs(yMax - yMin)
         
         if (labelCount == 0 || range <= 0)
         {
@@ -42,10 +42,10 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             return
         }
         
-        var rawInterval = range / Double(labelCount)
+        let rawInterval = range / Double(labelCount)
         var interval = ChartUtils.roundToNextSignificant(number: Double(rawInterval))
-        var intervalMagnitude = pow(10.0, round(log10(interval)))
-        var intervalSigDigit = Int(interval / intervalMagnitude)
+        let intervalMagnitude = pow(10.0, round(log10(interval)))
+        let intervalSigDigit = Int(interval / intervalMagnitude)
         
         if (intervalSigDigit > 5)
         {
@@ -81,76 +81,76 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         } else {
             // no forced count
             
-            // clean old values
-            if (_yAxis.entries.count > 0)
-            {
-                _yAxis.entries.removeAll(keepCapacity: false)
+        // clean old values
+        if (_yAxis.entries.count > 0)
+        {
+            _yAxis.entries.removeAll(keepCapacity: false)
+        }
+        
+        // if the labels should only show min and max
+        if (_yAxis.isShowOnlyMinMaxEnabled)
+        {
+            _yAxis.entries = [Double]()
+            _yAxis.entries.append(yMin)
+            _yAxis.entries.append(yMax)
+        }
+        else
+        {
+            var first = ceil(Double(yMin) / interval) * interval
+            
+            if (first == 0.0)
+            { // Fix for IEEE negative zero case (Where value == -0.0, and 0.0 == -0.0)
+                first = 0.0
             }
             
-            // if the labels should only show min and max
-            if (_yAxis.isShowOnlyMinMaxEnabled)
+            let last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval)
+            
+            var f: Double
+            var i: Int
+            var n = 0
+            for (f = first; f <= last; f += interval)
             {
-                _yAxis.entries = [Double]()
-                _yAxis.entries.append(yMin)
-                _yAxis.entries.append(yMax)
+                ++n
             }
-            else
+            
+            if (isnan(_yAxis.customAxisMax))
             {
-                var first = ceil(Double(yMin) / interval) * interval
-                
-                if (first == 0.0)
-                { // Fix for IEEE negative zero case (Where value == -0.0, and 0.0 == -0.0)
-                    first = 0.0
-                }
-                
-                var last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval)
-                
-                var f: Double
-                var i: Int
-                var n = 0
-                for (f = first; f <= last; f += interval)
-                {
-                    ++n
-                }
-                
-                if (isnan(_yAxis.customAxisMax))
-                {
-                    n += 1
-                }
-                
-                if (_yAxis.entries.count < n)
-                {
-                    // Ensure stops contains at least numStops elements.
-                    _yAxis.entries = [Double](count: n, repeatedValue: 0.0)
-                }
-                
-                for (f = first, i = 0; i < n; f += interval, ++i)
-                {
-                    _yAxis.entries[i] = Double(f)
-                }
+                n += 1
             }
+
+            if (_yAxis.entries.count < n)
+            {
+                // Ensure stops contains at least numStops elements.
+                _yAxis.entries = [Double](count: n, repeatedValue: 0.0)
+            }
+
+            for (f = first, i = 0; i < n; f += interval, ++i)
+            {
+                _yAxis.entries[i] = Double(f)
+            }
+        }
         }
         
         _yAxis.axisMaximum = _yAxis.entries[_yAxis.entryCount - 1]
         _yAxis.axisRange = abs(_yAxis.axisMaximum - _yAxis.axisMinimum)
     }
     
-    public override func renderAxisLabels(#context: CGContext)
+    public override func renderAxisLabels(context context: CGContext)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawLabelsEnabled)
         {
             return
         }
         
-        var labelFont = _yAxis.labelFont
-        var labelTextColor = _yAxis.labelTextColor
+        let labelFont = _yAxis.labelFont
+        let labelTextColor = _yAxis.labelTextColor
         
-        var center = _chart.centerOffsets
-        var factor = _chart.factor
+        let center = _chart.centerOffsets
+        let factor = _chart.factor
         
-        var labelCount = _yAxis.entryCount
+        let labelCount = _yAxis.entryCount
         
-        var labelLineHeight = _yAxis.labelFont.lineHeight
+        let labelLineHeight = _yAxis.labelFont.lineHeight
         
         for (var j = 0; j < labelCount; j++)
         {
@@ -159,17 +159,17 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
                 break
             }
             
-            var r = CGFloat(_yAxis.entries[j] - _yAxis.axisMinimum) * factor
+            let r = CGFloat(_yAxis.entries[j] - _yAxis.axisMinimum) * factor
             
-            var p = ChartUtils.getPosition(center: center, dist: r, angle: _chart.rotationAngle)
+            let p = ChartUtils.getPosition(center: center, dist: r, angle: _chart.rotationAngle)
             
-            var label = _yAxis.getFormattedLabel(j)
+            let label = _yAxis.getFormattedLabel(j)
             
             ChartUtils.drawText(context: context, text: label, point: CGPoint(x: p.x + 10.0, y: p.y - labelLineHeight), align: .Left, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }
     
-    public override func renderLimitLines(#context: CGContext)
+    public override func renderLimitLines(context context: CGContext)
     {
         var limitLines = _yAxis.limitLines
         
@@ -180,16 +180,16 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         
         CGContextSaveGState(context)
         
-        var sliceangle = _chart.sliceAngle
+        let sliceangle = _chart.sliceAngle
         
         // calculate the factor that is needed for transforming the value to pixels
-        var factor = _chart.factor
+        let factor = _chart.factor
         
-        var center = _chart.centerOffsets
+        let center = _chart.centerOffsets
         
         for (var i = 0; i < limitLines.count; i++)
         {
-            var l = limitLines[i]
+            let l = limitLines[i]
             
             CGContextSetStrokeColorWithColor(context, l.lineColor.CGColor)
             CGContextSetLineWidth(context, l.lineWidth)
@@ -202,13 +202,13 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
                 CGContextSetLineDash(context, 0.0, nil, 0)
             }
             
-            var r = CGFloat(l.limit - _chart.chartYMin) * factor
+            let r = CGFloat(l.limit - _chart.chartYMin) * factor
             
             CGContextBeginPath(context)
             
             for (var j = 0, count = _chart.data!.xValCount; j < count; j++)
             {
-                var p = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
+                let p = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
                 
                 if (j == 0)
                 {

--- a/Charts/Classes/Renderers/CombinedChartRenderer.swift
+++ b/Charts/Classes/Renderers/CombinedChartRenderer.swift
@@ -93,7 +93,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
 
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
         for renderer in _renderers
         {
@@ -101,7 +101,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
         for renderer in _renderers
         {
@@ -109,7 +109,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         for renderer in _renderers
         {
@@ -117,7 +117,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
         for renderer in _renderers
         {
@@ -125,7 +125,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func calcXBounds(#chart: BarLineChartViewBase, xAxisModulus: Int)
+    public override func calcXBounds(chart chart: BarLineChartViewBase, xAxisModulus: Int)
     {
         for renderer in _renderers
         {
@@ -134,7 +134,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
     }
 
     /// Returns the sub-renderer object at the specified index.
-    public func getSubRenderer(#index: Int) -> ChartDataRendererBase?
+    public func getSubRenderer(index index: Int) -> ChartDataRendererBase?
     {
         if (index >= _renderers.count || index < 0)
         {
@@ -145,7 +145,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
             return _renderers[index]
         }
     }
-    
+
     /// Returns all sub-renderers.
     public var subRenderers: [ChartDataRendererBase]
     {

--- a/Charts/Classes/Renderers/CombinedChartRenderer.swift
+++ b/Charts/Classes/Renderers/CombinedChartRenderer.swift
@@ -133,7 +133,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
 
-    /// Returns the sub-renderer object at the specified index.
+    /// - returns: the sub-renderer object at the specified index.
     public func getSubRenderer(index index: Int) -> ChartDataRendererBase?
     {
         if (index >= _renderers.count || index < 0)
@@ -395,13 +395,13 @@ public class CombinedChartRenderer: ChartDataRendererBase,
     
     // MARK: Accessors
     
-    /// returns true if drawing the highlighting arrow is enabled, false if not
+    /// - returns: true if drawing the highlighting arrow is enabled, false if not
     public var isDrawHighlightArrowEnabled: Bool { return drawHighlightArrowEnabled; }
     
-    /// returns true if drawing values above bars is enabled, false if not
+    /// - returns: true if drawing values above bars is enabled, false if not
     public var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled; }
     
-    /// returns true if drawing shadows (maxvalue) for each bar is enabled, false if not
+    /// - returns: true if drawing shadows (maxvalue) for each bar is enabled, false if not
     public var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled; }
     
     /// the order in which the provided data objects should be drawn.

--- a/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
+++ b/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
@@ -22,25 +22,25 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         super.init(delegate: delegate, animator: animator, viewPortHandler: viewPortHandler)
     }
     
-    internal override func drawDataSet(#context: CGContext, dataSet: BarChartDataSet, index: Int)
+    internal override func drawDataSet(context context: CGContext, dataSet: BarChartDataSet, index: Int)
     {
         CGContextSaveGState(context)
         
-        var barData = delegate!.barChartRendererData(self)
+        let barData = delegate!.barChartRendererData(self)
         
-        var trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+        let trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
-        var drawBarShadowEnabled: Bool = delegate!.barChartIsDrawBarShadowEnabled(self)
-        var dataSetOffset = (barData.dataSetCount - 1)
-        var groupSpace = barData.groupSpace
-        var groupSpaceHalf = groupSpace / 2.0
-        var barSpace = dataSet.barSpace
-        var barSpaceHalf = barSpace / 2.0
-        var containsStacks = dataSet.isStacked
-        var isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
+        let drawBarShadowEnabled: Bool = delegate!.barChartIsDrawBarShadowEnabled(self)
+        let dataSetOffset = (barData.dataSetCount - 1)
+        let groupSpace = barData.groupSpace
+        let groupSpaceHalf = groupSpace / 2.0
+        let barSpace = dataSet.barSpace
+        let barSpaceHalf = barSpace / 2.0
+        let containsStacks = dataSet.isStacked
+        let isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
         var entries = dataSet.yVals as! [BarChartDataEntry]
-        var barWidth: CGFloat = 0.5
-        var phaseY = _animator.phaseY
+        let barWidth: CGFloat = 0.5
+        let phaseY = _animator.phaseY
         var barRect = CGRect()
         var barShadow = CGRect()
         var y: Double
@@ -48,10 +48,10 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         // do the drawing
         for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * _animator.phaseX)); j < count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
             
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + e.xIndex * dataSetOffset) + CGFloat(index)
+            let x = CGFloat(e.xIndex + e.xIndex * dataSetOffset) + CGFloat(index)
                 + groupSpace * CGFloat(e.xIndex) + groupSpaceHalf
             let values = e.values
             
@@ -59,8 +59,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
             {
                 y = e.value
                 
-                var bottom = x - barWidth + barSpaceHalf
-                var top = x + barWidth - barSpaceHalf
+                let bottom = x - barWidth + barSpaceHalf
+                let top = x + barWidth - barSpaceHalf
                 var right = isInverted ? (y <= 0.0 ? CGFloat(y) : 0) : (y >= 0.0 ? CGFloat(y) : 0)
                 var left = isInverted ? (y >= 0.0 ? CGFloat(y) : 0) : (y <= 0.0 ? CGFloat(y) : 0)
                 
@@ -119,8 +119,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 {
                     y = e.value
                     
-                    var bottom = x - barWidth + barSpaceHalf
-                    var top = x + barWidth - barSpaceHalf
+                    let bottom = x - barWidth + barSpaceHalf
+                    let top = x + barWidth - barSpaceHalf
                     var right = isInverted ? (y <= 0.0 ? CGFloat(y) : 0) : (y >= 0.0 ? CGFloat(y) : 0)
                     var left = isInverted ? (y >= 0.0 ? CGFloat(y) : 0) : (y <= 0.0 ? CGFloat(y) : 0)
                     
@@ -168,8 +168,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                         negY += abs(value)
                     }
                     
-                    var bottom = x - barWidth + barSpaceHalf
-                    var top = x + barWidth - barSpaceHalf
+                    let bottom = x - barWidth + barSpaceHalf
+                    let top = x + barWidth - barSpaceHalf
                     var right: CGFloat, left: CGFloat
                     if isInverted
                     {
@@ -215,14 +215,14 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    internal override func prepareBarHighlight(#x: CGFloat, y1: Double, y2: Double, barspacehalf: CGFloat, trans: ChartTransformer, inout rect: CGRect)
+    internal override func prepareBarHighlight(x x: CGFloat, y1: Double, y2: Double, barspacehalf: CGFloat, trans: ChartTransformer, inout rect: CGRect)
     {
         let barWidth: CGFloat = 0.5
         
-        var top = x - barWidth + barspacehalf
-        var bottom = x + barWidth - barspacehalf
-        var left = CGFloat(y1)
-        var right = CGFloat(y2)
+        let top = x - barWidth + barspacehalf
+        let bottom = x + barWidth - barspacehalf
+        let left = CGFloat(y1)
+        let right = CGFloat(y2)
         
         rect.origin.x = left
         rect.origin.y = top
@@ -232,23 +232,23 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         trans.rectValueToPixelHorizontal(&rect, phaseY: _animator.phaseY)
     }
     
-    public override func getTransformedValues(#trans: ChartTransformer, entries: [BarChartDataEntry], dataSetIndex: Int) -> [CGPoint]
+    public override func getTransformedValues(trans trans: ChartTransformer, entries: [BarChartDataEntry], dataSetIndex: Int) -> [CGPoint]
     {
         return trans.generateTransformedValuesHorizontalBarChart(entries, dataSet: dataSetIndex, barData: delegate!.barChartRendererData(self)!, phaseY: _animator.phaseY)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
         // if values are drawn
         if (passesCheck())
         {
-            var barData = delegate!.barChartRendererData(self)
+            let barData = delegate!.barChartRendererData(self)
             
-            var defaultValueFormatter = delegate!.barChartDefaultRendererValueFormatter(self)
+            let defaultValueFormatter = delegate!.barChartDefaultRendererValueFormatter(self)
             
             var dataSets = barData.dataSets
             
-            var drawValueAboveBar = delegate!.barChartIsDrawValueAboveBarEnabled(self)
+            let drawValueAboveBar = delegate!.barChartIsDrawValueAboveBarEnabled(self)
             
             let textAlign = drawValueAboveBar ? NSTextAlignment.Left : NSTextAlignment.Right
             
@@ -258,18 +258,18 @@ public class HorizontalBarChartRenderer: BarChartRenderer
             
             for (var i = 0, count = barData.dataSetCount; i < count; i++)
             {
-                var dataSet = dataSets[i] as! BarChartDataSet
+                let dataSet = dataSets[i] as! BarChartDataSet
                 
                 if (!dataSet.isDrawValuesEnabled)
                 {
                     continue
                 }
                 
-                var isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
+                let isInverted = delegate!.barChartIsInverted(self, axis: dataSet.axisDependency)
                 
-                var valueFont = dataSet.valueFont
-                var valueTextColor = dataSet.valueTextColor
-                var yOffset = -valueFont.lineHeight / 2.0
+                let valueFont = dataSet.valueFont
+                let valueTextColor = dataSet.valueTextColor
+                let yOffset = -valueFont.lineHeight / 2.0
                 
                 var formatter = dataSet.valueFormatter
                 if (formatter === nil)
@@ -277,7 +277,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                     formatter = defaultValueFormatter
                 }
                 
-                var trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+                let trans = delegate!.barChartRenderer(self, transformerForAxis: dataSet.axisDependency)
                 
                 var entries = dataSet.yVals as! [BarChartDataEntry]
                 
@@ -303,11 +303,11 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                             continue
                         }
                         
-                        var val = entries[j].value
-                        var valueText = formatter!.stringFromNumber(val)!
+                        let val = entries[j].value
+                        let valueText = formatter!.stringFromNumber(val)!
                         
                         // calculate the correct offset depending on the draw position of the value
-                        var valueTextWidth = valueText.sizeWithAttributes([NSFontAttributeName: valueFont]).width
+                        let valueTextWidth = valueText.sizeWithAttributes([NSFontAttributeName: valueFont]).width
                         posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
                         negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
                         
@@ -333,7 +333,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                     
                     for (var j = 0, count = Int(ceil(CGFloat(valuePoints.count) * _animator.phaseX)); j < count; j++)
                     {
-                        var e = entries[j]
+                        let e = entries[j]
                         
                         let values = e.values
                         
@@ -355,11 +355,11 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                                 continue
                             }
                             
-                            var val = e.value
-                            var valueText = formatter!.stringFromNumber(val)!
+                            let val = e.value
+                            let valueText = formatter!.stringFromNumber(val)!
                             
                             // calculate the correct offset depending on the draw position of the value
-                            var valueTextWidth = valueText.sizeWithAttributes([NSFontAttributeName: valueFont]).width
+                            let valueTextWidth = valueText.sizeWithAttributes([NSFontAttributeName: valueFont]).width
                             posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
                             negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
                             
@@ -409,11 +409,11 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                             
                             for (var k = 0; k < transformed.count; k++)
                             {
-                                var val = vals[k]
-                                var valueText = formatter!.stringFromNumber(val)!
+                                let val = vals[k]
+                                let valueText = formatter!.stringFromNumber(val)!
                                 
                                 // calculate the correct offset depending on the draw position of the value
-                                var valueTextWidth = valueText.sizeWithAttributes([NSFontAttributeName: valueFont]).width
+                                let valueTextWidth = valueText.sizeWithAttributes([NSFontAttributeName: valueFont]).width
                                 posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
                                 negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
                                 
@@ -423,8 +423,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                                     negOffset = -negOffset - valueTextWidth
                                 }
                                 
-                                var x = transformed[k].x + (val >= 0 ? posOffset : negOffset)
-                                var y = valuePoints[j].y
+                                let x = transformed[k].x + (val >= 0 ? posOffset : negOffset)
+                                let y = valuePoints[j].y
                                 
                                 if (!viewPortHandler.isInBoundsTop(y))
                                 {
@@ -458,7 +458,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
     
     internal override func passesCheck() -> Bool
     {
-        var barData = delegate!.barChartRendererData(self)
+        let barData = delegate!.barChartRendererData(self)
         
         if (barData === nil)
         {

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -40,9 +40,9 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         self.delegate = delegate
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
-        var lineData = delegate!.lineChartRendererData(self)
+        let lineData = delegate!.lineChartRendererData(self)
         
         if (lineData === nil)
         {
@@ -51,7 +51,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         
         for (var i = 0; i < lineData.dataSetCount; i++)
         {
-            var set = lineData.getDataSetByIndex(i)
+            let set = lineData.getDataSetByIndex(i)
             
             if (set !== nil && set!.isVisible)
             {
@@ -77,9 +77,9 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    internal func drawDataSet(#context: CGContext, dataSet: LineChartDataSet)
+    internal func drawDataSet(context context: CGContext, dataSet: LineChartDataSet)
     {
-        var entries = dataSet.yVals
+        let entries = dataSet.yVals
         
         if (entries.count < 1)
         {
@@ -111,30 +111,30 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    internal func drawCubic(#context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry])
+    internal func drawCubic(context context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry])
     {
-        var trans = delegate?.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+        let trans = delegate?.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
-        var entryFrom = dataSet.entryForXIndex(_minX)
-        var entryTo = dataSet.entryForXIndex(_maxX)
+        let entryFrom = dataSet.entryForXIndex(_minX)
+        let entryTo = dataSet.entryForXIndex(_maxX)
         
-        var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-        var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+        let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+        let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
         
-        var phaseX = _animator.phaseX
-        var phaseY = _animator.phaseY
+        let phaseX = _animator.phaseX
+        let phaseY = _animator.phaseY
         
         // get the color that is specified for this position from the DataSet
-        var drawingColor = dataSet.colors.first!
+        let drawingColor = dataSet.colors.first!
         
-        var intensity = dataSet.cubicIntensity
+        let intensity = dataSet.cubicIntensity
         
         // the path for the cubic-spline
-        var cubicPath = CGPathCreateMutable()
+        let cubicPath = CGPathCreateMutable()
         
         var valueToPixelMatrix = trans!.valueToPixelMatrix
         
-        var size = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
+        let size = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
         
         if (size - minx >= 2)
         {
@@ -214,11 +214,11 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    internal func drawCubicFill(#context: CGContext, dataSet: LineChartDataSet, spline: CGMutablePath, var matrix: CGAffineTransform, from: Int, to: Int)
+    internal func drawCubicFill(context context: CGContext, dataSet: LineChartDataSet, spline: CGMutablePath, matrix: CGAffineTransform, from: Int, to: Int)
     {
         CGContextSaveGState(context)
         
-        var fillMin = delegate!.lineChartRendererFillFormatter(self).getFillLinePosition(
+        let fillMin = delegate!.lineChartRendererFillFormatter(self).getFillLinePosition(
             dataSet: dataSet,
             data: delegate!.lineChartRendererData(self),
             chartMaxY: delegate!.lineChartRendererChartYMax(self),
@@ -244,21 +244,21 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
     
     private var _lineSegments = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawLinear(#context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry])
+    internal func drawLinear(context context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry])
     {
-        var trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
-        var valueToPixelMatrix = trans.valueToPixelMatrix
+        let trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+        let valueToPixelMatrix = trans.valueToPixelMatrix
         
-        var phaseX = _animator.phaseX
-        var phaseY = _animator.phaseY
+        let phaseX = _animator.phaseX
+        let phaseY = _animator.phaseY
         
         CGContextSaveGState(context)
         
-        var entryFrom = dataSet.entryForXIndex(_minX)
-        var entryTo = dataSet.entryForXIndex(_maxX)
+        let entryFrom = dataSet.entryForXIndex(_minX)
+        let entryTo = dataSet.entryForXIndex(_maxX)
         
-        var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-        var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+        let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+        let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
         
         // more than 1 color
         if (dataSet.colors.count > 1)
@@ -324,7 +324,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
             
             e1 = entries[minx]
             
-            var count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
+            let count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
             
             for (var x = count > 1 ? minx + 1 : minx, j = 0; x < count; x++)
             {
@@ -335,7 +335,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                 _lineSegments[j++] = CGPointApplyAffineTransform(CGPoint(x: CGFloat(e2.xIndex), y: CGFloat(e2.value) * phaseY), valueToPixelMatrix)
             }
             
-            var size = max((count - minx - 1) * 2, 2)
+            let size = max((count - minx - 1) * 2, 2)
             CGContextSetStrokeColorWithColor(context, dataSet.colorAt(0).CGColor)
             CGContextStrokeLineSegments(context, _lineSegments, size)
         }
@@ -349,7 +349,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    internal func drawLinearFill(#context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry], minx: Int, maxx: Int, trans: ChartTransformer)
+    internal func drawLinearFill(context context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry], minx: Int, maxx: Int, trans: ChartTransformer)
     {
         CGContextSaveGState(context)
         
@@ -358,7 +358,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         // filled is usually drawn with less alpha
         CGContextSetAlpha(context, dataSet.fillAlpha)
         
-        var filled = generateFilledPath(
+        let filled = generateFilledPath(
             entries,
             fillMin: delegate!.lineChartRendererFillFormatter(self).getFillLinePosition(
                 dataSet: dataSet,
@@ -379,17 +379,17 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
     /// Generates the path that is used for filled drawing.
     private func generateFilledPath(entries: [ChartDataEntry], fillMin: CGFloat, from: Int, to: Int, var matrix: CGAffineTransform) -> CGPath
     {
+        let phaseX = _animator.phaseX
+        let phaseY = _animator.phaseY
         
-        var phaseX = _animator.phaseX
-        var phaseY = _animator.phaseY
-        var filled = CGPathCreateMutable()
+        let filled = CGPathCreateMutable()
         CGPathMoveToPoint(filled, &matrix, CGFloat(entries[from].xIndex), fillMin)
         CGPathAddLineToPoint(filled, &matrix, CGFloat(entries[from].xIndex), CGFloat(entries[from].value) * phaseY)
         
         // create a new path
         for (var x = from + 1, count = Int(ceil(CGFloat(to - from) * phaseX + CGFloat(from))); x < count; x++)
         {
-            var e = entries[x]
+            let e = entries[x]
             CGPathAddLineToPoint(filled, &matrix, CGFloat(e.xIndex), CGFloat(e.value) * phaseY)
         }
         
@@ -400,15 +400,15 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         return filled
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
-        var lineData = delegate!.lineChartRendererData(self)
+        let lineData = delegate!.lineChartRendererData(self)
         if (lineData === nil)
         {
             return
         }
         
-        var defaultValueFormatter = delegate!.lineChartDefaultRendererValueFormatter(self)
+        let defaultValueFormatter = delegate!.lineChartDefaultRendererValueFormatter(self)
         
         if (CGFloat(lineData.yValCount) < CGFloat(delegate!.lineChartRendererMaxVisibleValueCount(self)) * viewPortHandler.scaleX)
         {
@@ -416,15 +416,15 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
             
             for (var i = 0; i < dataSets.count; i++)
             {
-                var dataSet = dataSets[i] as! LineChartDataSet
+                let dataSet = dataSets[i] as! LineChartDataSet
                 
                 if (!dataSet.isDrawValuesEnabled)
                 {
                     continue
                 }
                 
-                var valueFont = dataSet.valueFont
-                var valueTextColor = dataSet.valueTextColor
+                let valueFont = dataSet.valueFont
+                let valueTextColor = dataSet.valueTextColor
                 
                 var formatter = dataSet.valueFormatter
                 if (formatter === nil)
@@ -432,7 +432,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                     formatter = defaultValueFormatter
                 }
                 
-                var trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+                let trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
                 
                 // make sure the values do not interfear with the circles
                 var valOffset = Int(dataSet.circleRadius * 1.75)
@@ -444,11 +444,11 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                 
                 var entries = dataSet.yVals
                 
-                var entryFrom = dataSet.entryForXIndex(_minX)
-                var entryTo = dataSet.entryForXIndex(_maxX)
+                let entryFrom = dataSet.entryForXIndex(_minX)
+                let entryTo = dataSet.entryForXIndex(_maxX)
                 
-                var minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
-                var maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
+                let minx = max(dataSet.entryIndex(entry: entryFrom!, isEqual: true), 0)
+                let maxx = min(dataSet.entryIndex(entry: entryTo!, isEqual: true) + 1, entries.count)
                 
                 var positions = trans.generateTransformedValuesLine(
                     entries,
@@ -469,7 +469,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                         continue
                     }
                     
-                    var val = entries[j + minx].value
+                    let val = entries[j + minx].value
                     
                     ChartUtils.drawText(context: context, text: formatter!.stringFromNumber(val)!, point: CGPoint(x: positions[j].x, y: positions[j].y - CGFloat(valOffset) - valueFont.lineHeight), align: .Center, attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor])
                 }
@@ -477,19 +477,19 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         drawCircles(context: context)
     }
     
-    private func drawCircles(#context: CGContext)
+    private func drawCircles(context context: CGContext)
     {
-        var phaseX = _animator.phaseX
-        var phaseY = _animator.phaseY
+        let phaseX = _animator.phaseX
+        let phaseY = _animator.phaseY
         
-        var lineData = delegate!.lineChartRendererData(self)
+        let lineData = delegate!.lineChartRendererData(self)
         
-        var dataSets = lineData.dataSets
+        let dataSets = lineData.dataSets
         
         var pt = CGPoint()
         var rect = CGRect()
@@ -498,33 +498,33 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         
         for (var i = 0, count = dataSets.count; i < count; i++)
         {
-            var dataSet = lineData.getDataSetByIndex(i) as! LineChartDataSet!
+            let dataSet = lineData.getDataSetByIndex(i) as! LineChartDataSet!
             
             if (!dataSet.isVisible || !dataSet.isDrawCirclesEnabled)
             {
                 continue
             }
             
-            var trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
-            var valueToPixelMatrix = trans.valueToPixelMatrix
+            let trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+            let valueToPixelMatrix = trans.valueToPixelMatrix
             
             var entries = dataSet.yVals
             
-            var circleRadius = dataSet.circleRadius
-            var circleDiameter = circleRadius * 2.0
-            var circleHoleDiameter = circleRadius
-            var circleHoleRadius = circleHoleDiameter / 2.0
-            var isDrawCircleHoleEnabled = dataSet.isDrawCircleHoleEnabled
+            let circleRadius = dataSet.circleRadius
+            let circleDiameter = circleRadius * 2.0
+            let circleHoleDiameter = circleRadius
+            let circleHoleRadius = circleHoleDiameter / 2.0
+            let isDrawCircleHoleEnabled = dataSet.isDrawCircleHoleEnabled
             
-            var entryFrom = dataSet.entryForXIndex(_minX)!
-            var entryTo = dataSet.entryForXIndex(_maxX)!
+            let entryFrom = dataSet.entryForXIndex(_minX)!
+            let entryTo = dataSet.entryForXIndex(_maxX)!
             
-            var minx = max(dataSet.entryIndex(entry: entryFrom, isEqual: true), 0)
-            var maxx = min(dataSet.entryIndex(entry: entryTo, isEqual: true) + 1, entries.count)
+            let minx = max(dataSet.entryIndex(entry: entryFrom, isEqual: true), 0)
+            let maxx = min(dataSet.entryIndex(entry: entryTo, isEqual: true) + 1, entries.count)
             
             for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
             {
-                var e = entries[j]
+                let e = entries[j]
                 pt.x = CGFloat(e.xIndex)
                 pt.y = CGFloat(e.value) * phaseY
                 pt = CGPointApplyAffineTransform(pt, valueToPixelMatrix)
@@ -566,18 +566,18 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
     
     var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
     
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
-        var lineData = delegate!.lineChartRendererData(self)
-        var chartXMax = delegate!.lineChartRendererChartXMax(self)
-        var chartYMax = delegate!.lineChartRendererChartYMax(self)
-        var chartYMin = delegate!.lineChartRendererChartYMin(self)
+        let lineData = delegate!.lineChartRendererData(self)
+        let chartXMax = delegate!.lineChartRendererChartXMax(self)
+        let chartYMax = delegate!.lineChartRendererChartYMax(self)
+        let chartYMin = delegate!.lineChartRendererChartYMin(self)
         
         CGContextSaveGState(context)
         
         for (var i = 0; i < indices.count; i++)
         {
-            var set = lineData.getDataSetByIndex(indices[i].dataSetIndex) as! LineChartDataSet!
+            let set = lineData.getDataSetByIndex(indices[i].dataSetIndex) as! LineChartDataSet!
             
             if (set === nil || !set.isHighlightEnabled)
             {
@@ -595,7 +595,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                 CGContextSetLineDash(context, 0.0, nil, 0)
             }
             
-            var xIndex = indices[i].xIndex; // get the x-position
+            let xIndex = indices[i].xIndex; // get the x-position
             
             if (CGFloat(xIndex) > CGFloat(chartXMax) * _animator.phaseX)
             {
@@ -608,14 +608,14 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                 continue
             }
             
-            var y = CGFloat(yValue) * _animator.phaseY; // get the y-position
+            let y = CGFloat(yValue) * _animator.phaseY; // get the y-position
             
             _highlightPtsBuffer[0] = CGPoint(x: CGFloat(xIndex), y: CGFloat(chartYMax))
             _highlightPtsBuffer[1] = CGPoint(x: CGFloat(xIndex), y: CGFloat(chartYMin))
             _highlightPtsBuffer[2] = CGPoint(x: CGFloat(delegate!.lineChartRendererChartXMin(self)), y: y)
             _highlightPtsBuffer[3] = CGPoint(x: CGFloat(chartXMax), y: y)
             
-            var trans = delegate!.lineChartRenderer(self, transformerForAxis: set.axisDependency)
+            let trans = delegate!.lineChartRenderer(self, transformerForAxis: set.axisDependency)
             
             trans.pointValuesToPixel(&_highlightPtsBuffer)
             

--- a/Charts/Classes/Renderers/LineScatterCandleRadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineScatterCandleRadarChartRenderer.swift
@@ -27,7 +27,7 @@ public class LineScatterCandleRadarChartRenderer: ChartDataRendererBase
     /// :param: points
     /// :param: horizontal
     /// :param: vertical
-    public func drawHighlightLines(#context: CGContext, points: UnsafePointer<CGPoint>, horizontal: Bool, vertical: Bool)
+    public func drawHighlightLines(context context: CGContext, points: UnsafePointer<CGPoint>, horizontal: Bool, vertical: Bool)
     {
         // draw vertical highlight lines
         if vertical
@@ -38,7 +38,6 @@ public class LineScatterCandleRadarChartRenderer: ChartDataRendererBase
         // draw horizontal highlight lines
         if horizontal
         {
-            var pts = UnsafePointer<CGPoint>()
             CGContextStrokeLineSegments(context, points.advancedBy(2), 2)
         }
     }

--- a/Charts/Classes/Renderers/PieChartRenderer.swift
+++ b/Charts/Classes/Renderers/PieChartRenderer.swift
@@ -40,11 +40,11 @@ public class PieChartRenderer: ChartDataRendererBase
         _chart = chart
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
         if (_chart !== nil)
         {
-            var pieData = _chart.data
+            let pieData = _chart.data
             
             if (pieData != nil)
             {
@@ -59,7 +59,7 @@ public class PieChartRenderer: ChartDataRendererBase
         }
     }
     
-    internal func drawDataSet(#context: CGContext, dataSet: PieChartDataSet)
+    internal func drawDataSet(context context: CGContext, dataSet: PieChartDataSet)
     {
         var angle = _chart.rotationAngle
         
@@ -67,18 +67,18 @@ public class PieChartRenderer: ChartDataRendererBase
         
         var entries = dataSet.yVals
         var drawAngles = _chart.drawAngles
-        var circleBox = _chart.circleBox
-        var radius = _chart.radius
-        var innerRadius = drawHoleEnabled && holeTransparent ? radius * holeRadiusPercent : 0.0
+        let circleBox = _chart.circleBox
+        let radius = _chart.radius
+        let innerRadius = drawHoleEnabled && holeTransparent ? radius * holeRadiusPercent : 0.0
         
         CGContextSaveGState(context)
         
         for (var j = 0; j < entries.count; j++)
         {
-            var newangle = drawAngles[cnt]
-            var sliceSpace = dataSet.sliceSpace
+            let newangle = drawAngles[cnt]
+            let sliceSpace = dataSet.sliceSpace
             
-            var e = entries[j]
+            let e = entries[j]
             
             // draw only if the value is greater than zero
             if ((abs(e.value) > 0.000001))
@@ -86,16 +86,16 @@ public class PieChartRenderer: ChartDataRendererBase
                 if (!_chart.needsHighlight(xIndex: e.xIndex,
                     dataSetIndex: _chart.data!.indexOfDataSet(dataSet)))
                 {
-                    var startAngle = angle + sliceSpace / 2.0
+                    let startAngle = angle + sliceSpace / 2.0
                     var sweepAngle = newangle * _animator.phaseY
                         - sliceSpace / 2.0
                     if (sweepAngle < 0.0)
                     {
                         sweepAngle = 0.0
                     }
-                    var endAngle = startAngle + sweepAngle
+                    let endAngle = startAngle + sweepAngle
                     
-                    var path = CGPathCreateMutable()
+                    let path = CGPathCreateMutable()
                     CGPathMoveToPoint(path, nil, circleBox.midX, circleBox.midY)
                     CGPathAddArc(path, nil, circleBox.midX, circleBox.midY, radius, startAngle * ChartUtils.Math.FDEG2RAD, endAngle * ChartUtils.Math.FDEG2RAD, false)
                     CGPathCloseSubpath(path)
@@ -121,13 +121,13 @@ public class PieChartRenderer: ChartDataRendererBase
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
-        var center = _chart.centerCircleBox
+        let center = _chart.centerCircleBox
         
         // get whole the radius
         var r = _chart.radius
-        var rotationAngle = _chart.rotationAngle
+        let rotationAngle = _chart.rotationAngle
         var drawAngles = _chart.drawAngles
         var absoluteAngles = _chart.absoluteAngles
         
@@ -140,32 +140,32 @@ public class PieChartRenderer: ChartDataRendererBase
         
         r -= off; // offset to keep things inside the chart
         
-        var data: ChartData! = _chart.data
+        let data: ChartData! = _chart.data
         if (data === nil)
         {
             return
         }
         
-        var defaultValueFormatter = _chart.valueFormatter
+        let defaultValueFormatter = _chart.valueFormatter
         
         var dataSets = data.dataSets
-        var drawXVals = drawXLabelsEnabled
+        let drawXVals = drawXLabelsEnabled
         
         var cnt = 0
         
         for (var i = 0; i < dataSets.count; i++)
         {
-            var dataSet = dataSets[i] as! PieChartDataSet
+            let dataSet = dataSets[i] as! PieChartDataSet
             
-            var drawYVals = dataSet.isDrawValuesEnabled
+            let drawYVals = dataSet.isDrawValuesEnabled
             
             if (!drawYVals && !drawXVals)
             {
                 continue
             }
             
-            var valueFont = dataSet.valueFont
-            var valueTextColor = dataSet.valueTextColor
+            let valueFont = dataSet.valueFont
+            let valueTextColor = dataSet.valueTextColor
             
             var formatter = dataSet.valueFormatter
             if (formatter === nil)
@@ -183,17 +183,17 @@ public class PieChartRenderer: ChartDataRendererBase
                 }
                 
                 // offset needed to center the drawn text in the slice
-                var offset = drawAngles[cnt] / 2.0
+                let offset = drawAngles[cnt] / 2.0
                 
                 // calculate the text position
-                var x = (r * cos(((rotationAngle + absoluteAngles[cnt] - offset) * _animator.phaseY) * ChartUtils.Math.FDEG2RAD) + center.x)
+                let x = (r * cos(((rotationAngle + absoluteAngles[cnt] - offset) * _animator.phaseY) * ChartUtils.Math.FDEG2RAD) + center.x)
                 var y = (r * sin(((rotationAngle + absoluteAngles[cnt] - offset) * _animator.phaseY) * ChartUtils.Math.FDEG2RAD) + center.y)
                 
-                var value = usePercentValuesEnabled ? entries[j].value / _chart.yValueSum * 100.0 : entries[j].value
+                let value = usePercentValuesEnabled ? entries[j].value / _chart.yValueSum * 100.0 : entries[j].value
                 
-                var val = formatter!.stringFromNumber(value)!
+                let val = formatter!.stringFromNumber(value)!
                 
-                var lineHeight = valueFont.lineHeight
+                let lineHeight = valueFont.lineHeight
                 y -= lineHeight
                 
                 // draw everything, depending on settings
@@ -220,22 +220,22 @@ public class PieChartRenderer: ChartDataRendererBase
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         drawHole(context: context)
         drawCenterText(context: context)
     }
     
     /// draws the hole in the center of the chart and the transparent circle / hole
-    private func drawHole(#context: CGContext)
+    private func drawHole(context context: CGContext)
     {
         if (_chart.drawHoleEnabled)
         {
             CGContextSaveGState(context)
             
-            var radius = _chart.radius
-            var holeRadius = radius * holeRadiusPercent
-            var center = _chart.centerCircleBox
+            let radius = _chart.radius
+            let holeRadius = radius * holeRadiusPercent
+            let center = _chart.centerCircleBox
             
             if (holeColor !== nil && holeColor != UIColor.clearColor())
             {
@@ -246,7 +246,7 @@ public class PieChartRenderer: ChartDataRendererBase
             
             if (transparentCircleRadiusPercent > holeRadiusPercent)
             {
-                var secondHoleRadius = radius * transparentCircleRadiusPercent
+                let secondHoleRadius = radius * transparentCircleRadiusPercent
                 
                 // make transparent
                 CGContextSetFillColorWithColor(context, holeColor!.colorWithAlphaComponent(CGFloat(0x60) / CGFloat(0xFF)).CGColor)
@@ -260,13 +260,13 @@ public class PieChartRenderer: ChartDataRendererBase
     }
     
     /// draws the description text in the center of the pie chart makes most sense when center-hole is enabled
-    private func drawCenterText(#context: CGContext)
+    private func drawCenterText(context context: CGContext)
     {
-        if (drawCenterTextEnabled && centerText != nil && count(centerText) > 0)
+        if (drawCenterTextEnabled && centerText != nil && centerText.characters.count > 0)
         {
-            var center = _chart.centerCircleBox
-            var innerRadius = drawHoleEnabled && holeTransparent ? _chart.radius * holeRadiusPercent : _chart.radius
-            var holeRect = CGRect(x: center.x - innerRadius, y: center.y - innerRadius, width: innerRadius * 2.0, height: innerRadius * 2.0)
+            let center = _chart.centerCircleBox
+            let innerRadius = drawHoleEnabled && holeTransparent ? _chart.radius * holeRadiusPercent : _chart.radius
+            let holeRect = CGRect(x: center.x - innerRadius, y: center.y - innerRadius, width: innerRadius * 2.0, height: innerRadius * 2.0)
             var boundingRect = holeRect
             
             if (centerTextRadiusPercent > 0.0)
@@ -274,15 +274,15 @@ public class PieChartRenderer: ChartDataRendererBase
                 boundingRect = CGRectInset(boundingRect, (boundingRect.width - boundingRect.width * centerTextRadiusPercent) / 2.0, (boundingRect.height - boundingRect.height * centerTextRadiusPercent) / 2.0)
             }
             
-            var centerTextNs = self.centerText as NSString
+            let centerTextNs = self.centerText as NSString
             
-            var paragraphStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
+            let paragraphStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
             paragraphStyle.lineBreakMode = centerTextLineBreakMode
             paragraphStyle.alignment = .Center
             
             let drawingAttrs = [NSFontAttributeName: centerTextFont, NSParagraphStyleAttributeName: paragraphStyle, NSForegroundColorAttributeName: centerTextColor]
             
-            var textBounds = centerTextNs.boundingRectWithSize(boundingRect.size, options: .UsesLineFragmentOrigin | .UsesFontLeading | .TruncatesLastVisibleLine, attributes: drawingAttrs, context: nil)
+            let textBounds = centerTextNs.boundingRectWithSize(boundingRect.size, options: [.UsesLineFragmentOrigin, .UsesFontLeading, .TruncatesLastVisibleLine], attributes: drawingAttrs, context: nil)
             
             var drawingRect = boundingRect
             drawingRect.origin.x += (boundingRect.size.width - textBounds.size.width) / 2.0
@@ -291,18 +291,18 @@ public class PieChartRenderer: ChartDataRendererBase
             
             CGContextSaveGState(context)
 
-            var clippingPath = CGPathCreateWithEllipseInRect(holeRect, nil)
+            let clippingPath = CGPathCreateWithEllipseInRect(holeRect, nil)
             CGContextBeginPath(context)
             CGContextAddPath(context, clippingPath)
             CGContextClip(context)
             
-            centerTextNs.drawWithRect(drawingRect, options: .UsesLineFragmentOrigin | .UsesFontLeading | .TruncatesLastVisibleLine, attributes: drawingAttrs, context: nil)
+            centerTextNs.drawWithRect(drawingRect, options: [.UsesLineFragmentOrigin, .UsesFontLeading, .TruncatesLastVisibleLine], attributes: drawingAttrs, context: nil)
             
             CGContextRestoreGState(context)
         }
     }
     
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
         if (_chart.data === nil)
         {
@@ -311,24 +311,24 @@ public class PieChartRenderer: ChartDataRendererBase
         
         CGContextSaveGState(context)
         
-        var rotationAngle = _chart.rotationAngle
+        let rotationAngle = _chart.rotationAngle
         var angle = CGFloat(0.0)
         
         var drawAngles = _chart.drawAngles
         var absoluteAngles = _chart.absoluteAngles
         
-        var innerRadius = drawHoleEnabled && holeTransparent ? _chart.radius * holeRadiusPercent : 0.0
+        let innerRadius = drawHoleEnabled && holeTransparent ? _chart.radius * holeRadiusPercent : 0.0
         
         for (var i = 0; i < indices.count; i++)
         {
             // get the index to highlight
-            var xIndex = indices[i].xIndex
+            let xIndex = indices[i].xIndex
             if (xIndex >= drawAngles.count)
             {
                 continue
             }
             
-            var set = _chart.data?.getDataSetByIndex(indices[i].dataSetIndex) as! PieChartDataSet!
+            let set = _chart.data?.getDataSetByIndex(indices[i].dataSetIndex) as! PieChartDataSet!
             
             if (set === nil || !set.isHighlightEnabled)
             {
@@ -346,12 +346,12 @@ public class PieChartRenderer: ChartDataRendererBase
             
             angle *= _animator.phaseY
             
-            var sliceDegrees = drawAngles[xIndex]
+            let sliceDegrees = drawAngles[xIndex]
             
-            var shift = set.selectionShift
-            var circleBox = _chart.circleBox
+            let shift = set.selectionShift
+            let circleBox = _chart.circleBox
             
-            var highlighted = CGRect(
+            let highlighted = CGRect(
                 x: circleBox.origin.x - shift,
                 y: circleBox.origin.y - shift,
                 width: circleBox.size.width + shift * 2.0,
@@ -361,15 +361,15 @@ public class PieChartRenderer: ChartDataRendererBase
             
             // redefine the rect that contains the arc so that the highlighted pie is not cut off
             
-            var startAngle = angle + set.sliceSpace / 2.0
+            let startAngle = angle + set.sliceSpace / 2.0
             var sweepAngle = sliceDegrees * _animator.phaseY - set.sliceSpace / 2.0
             if (sweepAngle < 0.0)
             {
                 sweepAngle = 0.0
             }
-            var endAngle = startAngle + sweepAngle
+            let endAngle = startAngle + sweepAngle
             
-            var path = CGPathCreateMutable()
+            let path = CGPathCreateMutable()
             CGPathMoveToPoint(path, nil, highlighted.midX, highlighted.midY)
             CGPathAddArc(path, nil, highlighted.midX, highlighted.midY, highlighted.size.width / 2.0, startAngle * ChartUtils.Math.FDEG2RAD, endAngle * ChartUtils.Math.FDEG2RAD, false)
             CGPathCloseSubpath(path)

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -26,11 +26,11 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         _chart = chart
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
         if (_chart !== nil)
         {
-            var radarData = _chart.data
+            let radarData = _chart.data
             
             if (radarData != nil)
             {
@@ -45,25 +45,25 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    internal func drawDataSet(#context: CGContext, dataSet: RadarChartDataSet)
+    internal func drawDataSet(context context: CGContext, dataSet: RadarChartDataSet)
     {
         CGContextSaveGState(context)
         
-        var sliceangle = _chart.sliceAngle
+        let sliceangle = _chart.sliceAngle
         
         // calculate the factor that is needed for transforming the value to pixels
-        var factor = _chart.factor
+        let factor = _chart.factor
         
-        var center = _chart.centerOffsets
+        let center = _chart.centerOffsets
         var entries = dataSet.yVals
-        var path = CGPathCreateMutable()
+        let path = CGPathCreateMutable()
         var hasMovedToPoint = false
         
         for (var j = 0; j < entries.count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
             
-            var p = ChartUtils.getPosition(center: center, dist: CGFloat(e.value - _chart.chartYMin) * factor, angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
+            let p = ChartUtils.getPosition(center: center, dist: CGFloat(e.value - _chart.chartYMin) * factor, angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
             
             if (p.x.isNaN)
             {
@@ -109,29 +109,29 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
         if (_chart.data === nil)
         {
             return
         }
         
-        var data = _chart.data!
+        let data = _chart.data!
         
-        var defaultValueFormatter = _chart.valueFormatter
+        let defaultValueFormatter = _chart.valueFormatter
         
-        var sliceangle = _chart.sliceAngle
+        let sliceangle = _chart.sliceAngle
         
         // calculate the factor that is needed for transforming the value to pixels
-        var factor = _chart.factor
+        let factor = _chart.factor
         
-        var center = _chart.centerOffsets
+        let center = _chart.centerOffsets
         
-        var yoffset = CGFloat(5.0)
+        let yoffset = CGFloat(5.0)
         
         for (var i = 0, count = data.dataSetCount; i < count; i++)
         {
-            var dataSet = data.getDataSetByIndex(i) as! RadarChartDataSet
+            let dataSet = data.getDataSetByIndex(i) as! RadarChartDataSet
             
             if (!dataSet.isDrawValuesEnabled)
             {
@@ -142,12 +142,12 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
             
             for (var j = 0; j < entries.count; j++)
             {
-                var e = entries[j]
+                let e = entries[j]
                 
-                var p = ChartUtils.getPosition(center: center, dist: CGFloat(e.value) * factor, angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
+                let p = ChartUtils.getPosition(center: center, dist: CGFloat(e.value) * factor, angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
                 
-                var valueFont = dataSet.valueFont
-                var valueTextColor = dataSet.valueTextColor
+                let valueFont = dataSet.valueFont
+                let valueTextColor = dataSet.valueTextColor
                 
                 var formatter = dataSet.valueFormatter
                 if (formatter === nil)
@@ -160,25 +160,25 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         drawWeb(context: context)
     }
     
     private var _webLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawWeb(#context: CGContext)
+    internal func drawWeb(context context: CGContext)
     {
-        var sliceangle = _chart.sliceAngle
+        let sliceangle = _chart.sliceAngle
         
         CGContextSaveGState(context)
         
         // calculate the factor that is needed for transforming the value to
         // pixels
-        var factor = _chart.factor
-        var rotationangle = _chart.rotationAngle
+        let factor = _chart.factor
+        let rotationangle = _chart.rotationAngle
         
-        var center = _chart.centerOffsets
+        let center = _chart.centerOffsets
         
         // draw the web lines that come from the center
         CGContextSetLineWidth(context, _chart.webLineWidth)
@@ -187,7 +187,7 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         
         for (var i = 0, xValCount = _chart.data!.xValCount; i < xValCount; i++)
         {
-            var p = ChartUtils.getPosition(center: center, dist: CGFloat(_chart.yRange) * factor, angle: sliceangle * CGFloat(i) + rotationangle)
+            let p = ChartUtils.getPosition(center: center, dist: CGFloat(_chart.yRange) * factor, angle: sliceangle * CGFloat(i) + rotationangle)
             
             _webLineSegmentsBuffer[0].x = center.x
             _webLineSegmentsBuffer[0].y = center.y
@@ -202,16 +202,16 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextSetStrokeColorWithColor(context, _chart.innerWebColor.CGColor)
         CGContextSetAlpha(context, _chart.webAlpha)
         
-        var labelCount = _chart.yAxis.entryCount
+        let labelCount = _chart.yAxis.entryCount
         
         for (var j = 0; j < labelCount; j++)
         {
             for (var i = 0, xValCount = _chart.data!.xValCount; i < xValCount; i++)
             {
-                var r = CGFloat(_chart.yAxis.entries[j] - _chart.chartYMin) * factor
+                let r = CGFloat(_chart.yAxis.entries[j] - _chart.chartYMin) * factor
 
-                var p1 = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(i) + rotationangle)
-                var p2 = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(i + 1) + rotationangle)
+                let p1 = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(i) + rotationangle)
+                let p2 = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(i + 1) + rotationangle)
                 
                 _webLineSegmentsBuffer[0].x = p1.x
                 _webLineSegmentsBuffer[0].y = p1.y
@@ -227,14 +227,14 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
     
     private var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
 
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
         if (_chart.data === nil)
         {
             return
         }
         
-        var data = _chart.data as! RadarChartData
+        let data = _chart.data as! RadarChartData
         
         CGContextSaveGState(context)
         CGContextSetLineWidth(context, data.highlightLineWidth)
@@ -247,14 +247,14 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
             CGContextSetLineDash(context, 0.0, nil, 0)
         }
         
-        var sliceangle = _chart.sliceAngle
-        var factor = _chart.factor
+        let sliceangle = _chart.sliceAngle
+        let factor = _chart.factor
         
-        var center = _chart.centerOffsets
+        let center = _chart.centerOffsets
         
         for (var i = 0; i < indices.count; i++)
         {
-            var set = _chart.data?.getDataSetByIndex(indices[i].dataSetIndex) as! RadarChartDataSet!
+            let set = _chart.data?.getDataSetByIndex(indices[i].dataSetIndex) as! RadarChartDataSet!
             
             if (set === nil || !set.isHighlightEnabled)
             {
@@ -264,23 +264,23 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
             CGContextSetStrokeColorWithColor(context, set.highlightColor.CGColor)
             
             // get the index to highlight
-            var xIndex = indices[i].xIndex
+            let xIndex = indices[i].xIndex
             
-            var e = set.entryForXIndex(xIndex)
+            let e = set.entryForXIndex(xIndex)
             if (e === nil || e!.xIndex != xIndex)
             {
                 continue
             }
             
-            var j = set.entryIndex(entry: e!, isEqual: true)
-            var y = (e!.value - _chart.chartYMin)
+            let j = set.entryIndex(entry: e!, isEqual: true)
+            let y = (e!.value - _chart.chartYMin)
             
             if (y.isNaN)
             {
                 continue
             }
             
-            var p = ChartUtils.getPosition(center: center, dist: CGFloat(y) * factor,
+            let p = ChartUtils.getPosition(center: center, dist: CGFloat(y) * factor,
                 angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
             
             _highlightPtsBuffer[0] = CGPoint(x: p.x, y: 0.0)

--- a/Charts/Classes/Renderers/ScatterChartRenderer.swift
+++ b/Charts/Classes/Renderers/ScatterChartRenderer.swift
@@ -39,9 +39,9 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         self.delegate = delegate
     }
     
-    public override func drawData(#context: CGContext)
+    public override func drawData(context context: CGContext)
     {
-        var scatterData = delegate!.scatterChartRendererData(self)
+        let scatterData = delegate!.scatterChartRendererData(self)
         
         if (scatterData === nil)
         {
@@ -50,7 +50,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         
         for (var i = 0; i < scatterData.dataSetCount; i++)
         {
-            var set = scatterData.getDataSetByIndex(i)
+            let set = scatterData.getDataSetByIndex(i)
             
             if (set !== nil && set!.isVisible)
             {
@@ -61,29 +61,28 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
     
     private var _lineSegments = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawDataSet(#context: CGContext, dataSet: ScatterChartDataSet)
+    internal func drawDataSet(context context: CGContext, dataSet: ScatterChartDataSet)
     {
-        var trans = delegate!.scatterChartRenderer(self, transformerForAxis: dataSet.axisDependency)
+        let trans = delegate!.scatterChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
-        var phaseX = _animator.phaseX
-        var phaseY = _animator.phaseY
+        let phaseY = _animator.phaseY
         
         var entries = dataSet.yVals
         
-        var shapeSize = dataSet.scatterShapeSize
-        var shapeHalf = shapeSize / 2.0
+        let shapeSize = dataSet.scatterShapeSize
+        let shapeHalf = shapeSize / 2.0
         
         var point = CGPoint()
         
-        var valueToPixelMatrix = trans.valueToPixelMatrix
+        let valueToPixelMatrix = trans.valueToPixelMatrix
         
-        var shape = dataSet.scatterShape
+        let shape = dataSet.scatterShape
         
         CGContextSaveGState(context)
         
         for (var j = 0, count = Int(min(ceil(CGFloat(entries.count) * _animator.phaseX), CGFloat(entries.count))); j < count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
             point.x = CGFloat(e.xIndex)
             point.y = CGFloat(e.value) * phaseY
             point = CGPointApplyAffineTransform(point, valueToPixelMatrix);            
@@ -150,7 +149,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
             {
                 CGContextSetFillColorWithColor(context, dataSet.colorAt(j).CGColor)
                 
-                var customShape = dataSet.customScatterShape
+                let customShape = dataSet.customScatterShape
                 
                 if (customShape === nil)
                 {
@@ -172,15 +171,15 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(#context: CGContext)
+    public override func drawValues(context context: CGContext)
     {
-        var scatterData = delegate!.scatterChartRendererData(self)
+        let scatterData = delegate!.scatterChartRendererData(self)
         if (scatterData === nil)
         {
             return
         }
         
-        var defaultValueFormatter = delegate!.scatterChartDefaultRendererValueFormatter(self)
+        let defaultValueFormatter = delegate!.scatterChartDefaultRendererValueFormatter(self)
         
         // if values are drawn
         if (scatterData.yValCount < Int(ceil(CGFloat(delegate!.scatterChartRendererMaxVisibleValueCount(self)) * viewPortHandler.scaleX)))
@@ -189,15 +188,15 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
             
             for (var i = 0; i < scatterData.dataSetCount; i++)
             {
-                var dataSet = dataSets[i]
+                let dataSet = dataSets[i]
                 
                 if (!dataSet.isDrawValuesEnabled)
                 {
                     continue
                 }
                 
-                var valueFont = dataSet.valueFont
-                var valueTextColor = dataSet.valueTextColor
+                let valueFont = dataSet.valueFont
+                let valueTextColor = dataSet.valueTextColor
                 
                 var formatter = dataSet.valueFormatter
                 if (formatter === nil)
@@ -209,8 +208,8 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
                 
                 var positions = delegate!.scatterChartRenderer(self, transformerForAxis: dataSet.axisDependency).generateTransformedValuesScatter(entries, phaseY: _animator.phaseY)
                 
-                var shapeSize = dataSet.scatterShapeSize
-                var lineHeight = valueFont.lineHeight
+                let shapeSize = dataSet.scatterShapeSize
+                let lineHeight = valueFont.lineHeight
                 
                 for (var j = 0, count = Int(ceil(CGFloat(positions.count) * _animator.phaseX)); j < count; j++)
                 {
@@ -226,9 +225,9 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
                         continue
                     }
                     
-                    var val = entries[j].value
+                    let val = entries[j].value
                     
-                    var text = formatter!.stringFromNumber(val)
+                    let text = formatter!.stringFromNumber(val)
                     
                     ChartUtils.drawText(context: context, text: text!, point: CGPoint(x: positions[j].x, y: positions[j].y - shapeSize - lineHeight), align: .Center, attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor])
                 }
@@ -236,26 +235,26 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(#context: CGContext)
+    public override func drawExtras(context context: CGContext)
     {
         
     }
     
     private var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
     
-    public override func drawHighlighted(#context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
     {
-        var scatterData = delegate!.scatterChartRendererData(self)
-        var chartXMax = delegate!.scatterChartRendererChartXMax(self)
-        var chartXMin = delegate!.scatterChartRendererChartXMin(self)
-        var chartYMax = delegate!.scatterChartRendererChartYMax(self)
-        var chartYMin = delegate!.scatterChartRendererChartYMin(self)
+        let scatterData = delegate!.scatterChartRendererData(self)
+        let chartXMax = delegate!.scatterChartRendererChartXMax(self)
+        let chartXMin = delegate!.scatterChartRendererChartXMin(self)
+        let chartYMax = delegate!.scatterChartRendererChartYMax(self)
+        let chartYMin = delegate!.scatterChartRendererChartYMin(self)
         
         CGContextSaveGState(context)
         
         for (var i = 0; i < indices.count; i++)
         {
-            var set = scatterData.getDataSetByIndex(indices[i].dataSetIndex) as! ScatterChartDataSet!
+            let set = scatterData.getDataSetByIndex(indices[i].dataSetIndex) as! ScatterChartDataSet!
             
             if (set === nil || !set.isHighlightEnabled)
             {
@@ -273,7 +272,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
                 CGContextSetLineDash(context, 0.0, nil, 0)
             }
             
-            var xIndex = indices[i].xIndex; // get the x-position
+            let xIndex = indices[i].xIndex; // get the x-position
             
             if (CGFloat(xIndex) > CGFloat(chartXMax) * _animator.phaseX)
             {
@@ -286,14 +285,14 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
                 continue
             }
             
-            var y = CGFloat(yVal) * _animator.phaseY; // get the y-position
+            let y = CGFloat(yVal) * _animator.phaseY; // get the y-position
             
             _highlightPtsBuffer[0] = CGPoint(x: CGFloat(xIndex), y: CGFloat(chartYMax))
             _highlightPtsBuffer[1] = CGPoint(x: CGFloat(xIndex), y: CGFloat(chartYMin))
             _highlightPtsBuffer[2] = CGPoint(x: CGFloat(chartXMin), y: y)
             _highlightPtsBuffer[3] = CGPoint(x: CGFloat(chartXMax), y: y)
             
-            var trans = delegate!.scatterChartRenderer(self, transformerForAxis: set.axisDependency)
+            let trans = delegate!.scatterChartRenderer(self, transformerForAxis: set.axisDependency)
             
             trans.pointValuesToPixel(&_highlightPtsBuffer)
             

--- a/Charts/Classes/Utils/ChartFillFormatter.swift
+++ b/Charts/Classes/Utils/ChartFillFormatter.swift
@@ -18,6 +18,6 @@ import CoreGraphics
 @objc
 public protocol ChartFillFormatter
 {
-    /// Returns the vertical (y-axis) position where the filled-line of the DataSet should end.
+    /// - returns: the vertical (y-axis) position where the filled-line of the DataSet should end.
     func getFillLinePosition(dataSet dataSet: LineChartDataSet, data: LineChartData, chartMaxY: Double, chartMinY: Double) -> CGFloat
 }

--- a/Charts/Classes/Utils/ChartFillFormatter.swift
+++ b/Charts/Classes/Utils/ChartFillFormatter.swift
@@ -14,7 +14,7 @@
 import Foundation
 import CoreGraphics
 
-/// Protocol for providing a custom logic to where the filling line of a DataSet should end. If setFillEnabled(...) is set to true.
+/// Protocol for providing a custom logic to where the filling line of a DataSet should end. If `setFillEnabled(...)` is set to true.
 @objc
 public protocol ChartFillFormatter
 {

--- a/Charts/Classes/Utils/ChartFillFormatter.swift
+++ b/Charts/Classes/Utils/ChartFillFormatter.swift
@@ -19,5 +19,5 @@ import CoreGraphics
 public protocol ChartFillFormatter
 {
     /// Returns the vertical (y-axis) position where the filled-line of the DataSet should end.
-    func getFillLinePosition(#dataSet: LineChartDataSet, data: LineChartData, chartMaxY: Double, chartMinY: Double) -> CGFloat
+    func getFillLinePosition(dataSet dataSet: LineChartDataSet, data: LineChartData, chartMaxY: Double, chartMinY: Double) -> CGFloat
 }

--- a/Charts/Classes/Utils/ChartTransformer.swift
+++ b/Charts/Classes/Utils/ChartTransformer.swift
@@ -31,10 +31,10 @@ public class ChartTransformer: NSObject
     }
 
     /// Prepares the matrix that transforms values to pixels. Calculates the scale factors from the charts size and offsets.
-    public func prepareMatrixValuePx(#chartXMin: Double, deltaX: CGFloat, deltaY: CGFloat, chartYMin: Double)
+    public func prepareMatrixValuePx(chartXMin chartXMin: Double, deltaX: CGFloat, deltaY: CGFloat, chartYMin: Double)
     {
-        var scaleX = (_viewPortHandler.contentWidth / deltaX)
-        var scaleY = (_viewPortHandler.contentHeight / deltaY)
+        let scaleX = (_viewPortHandler.contentWidth / deltaX)
+        let scaleY = (_viewPortHandler.contentHeight / deltaY)
 
         // setup all matrices
         _matrixValueToPx = CGAffineTransformIdentity
@@ -64,7 +64,7 @@ public class ChartTransformer: NSObject
 
         for (var j = 0; j < entries.count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
             valuePoints.append(CGPoint(x: CGFloat(e.xIndex), y: CGFloat(e.value) * phaseY))
         }
 
@@ -83,7 +83,7 @@ public class ChartTransformer: NSObject
         
         for (var j = 0; j < count; j++)
         {
-            var e = entries[j + from]
+            let e = entries[j + from]
             valuePoints.append(CGPoint(x: CGFloat(e.xIndex - from) * phaseX + CGFloat(from), y: CGFloat(e.value) * phaseY))
         }
         
@@ -102,7 +102,7 @@ public class ChartTransformer: NSObject
 
         for (var j = 0; j < count; j++)
         {
-            var e = entries[j + from]
+            let e = entries[j + from]
             valuePoints.append(CGPoint(x: CGFloat(e.xIndex), y: CGFloat(e.value) * phaseY))
         }
 
@@ -119,7 +119,7 @@ public class ChartTransformer: NSObject
         
         for (var j = 0; j < entries.count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
             valuePoints.append(CGPoint(x: CGFloat(e.xIndex), y: CGFloat(e.high) * phaseY))
         }
         
@@ -134,16 +134,16 @@ public class ChartTransformer: NSObject
         var valuePoints = [CGPoint]()
         valuePoints.reserveCapacity(entries.count)
 
-        var setCount = barData.dataSetCount
-        var space = barData.groupSpace
+        let setCount = barData.dataSetCount
+        let space = barData.groupSpace
 
         for (var j = 0; j < entries.count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
 
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + (e.xIndex * (setCount - 1)) + dataSet) + space * CGFloat(e.xIndex) + space / 2.0
-            var y = e.value
+            let x = CGFloat(e.xIndex + (e.xIndex * (setCount - 1)) + dataSet) + space * CGFloat(e.xIndex) + space / 2.0
+            let y = e.value
             
             valuePoints.append(CGPoint(x: x, y: CGFloat(y) * phaseY))
         }
@@ -159,16 +159,16 @@ public class ChartTransformer: NSObject
         var valuePoints = [CGPoint]()
         valuePoints.reserveCapacity(entries.count)
         
-        var setCount = barData.dataSetCount
-        var space = barData.groupSpace
+        let setCount = barData.dataSetCount
+        let space = barData.groupSpace
         
         for (var j = 0; j < entries.count; j++)
         {
-            var e = entries[j]
+            let e = entries[j]
 
             // calculate the x-position, depending on datasetcount
-            var x = CGFloat(e.xIndex + (e.xIndex * (setCount - 1)) + dataSet) + space * CGFloat(e.xIndex) + space / 2.0
-            var y = e.value
+            let x = CGFloat(e.xIndex + (e.xIndex * (setCount - 1)) + dataSet) + space * CGFloat(e.xIndex) + space / 2.0
+            let y = e.value
             
             valuePoints.append(CGPoint(x: CGFloat(y) * phaseY, y: x))
         }
@@ -182,7 +182,7 @@ public class ChartTransformer: NSObject
     // VERY IMPORTANT: Keep matrix order "value-touch-offset" when transforming.
     public func pointValuesToPixel(inout pts: [CGPoint])
     {
-        var trans = valueToPixelMatrix
+        let trans = valueToPixelMatrix
         for (var i = 0, count = pts.count; i < count; i++)
         {
             pts[i] = CGPointApplyAffineTransform(pts[i], trans)
@@ -239,7 +239,7 @@ public class ChartTransformer: NSObject
     /// transforms multiple rects with all matrices
     public func rectValuesToPixel(inout rects: [CGRect])
     {
-        var trans = valueToPixelMatrix
+        let trans = valueToPixelMatrix
         
         for (var i = 0; i < rects.count; i++)
         {
@@ -250,7 +250,7 @@ public class ChartTransformer: NSObject
     /// Transforms the given array of touch points (pixels) into values on the chart.
     public func pixelsToValue(inout pixels: [CGPoint])
     {
-        var trans = pixelToValueMatrix
+        let trans = pixelToValueMatrix
         
         for (var i = 0; i < pixels.count; i++)
         {

--- a/Charts/Classes/Utils/ChartTransformer.swift
+++ b/Charts/Classes/Utils/ChartTransformer.swift
@@ -264,7 +264,7 @@ public class ChartTransformer: NSObject
         pixel = CGPointApplyAffineTransform(pixel, pixelToValueMatrix)
     }
     
-    /// Returns the x and y values in the chart at the given touch point
+    /// - returns: the x and y values in the chart at the given touch point
     /// (encapsulated in a PointD). This method transforms pixel coordinates to
     /// coordinates / values in the chart.
     public func getValueByTouchPoint(point: CGPoint) -> CGPoint

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -26,7 +26,7 @@ internal class ChartUtils
         internal static let RAD2DEG = 180.0 / M_PI
     }
     
-    internal class func roundToNextSignificant(#number: Double) -> Double
+    internal class func roundToNextSignificant(number number: Double) -> Double
     {
         if (isinf(number) || isnan(number) || number == 0)
         {
@@ -47,7 +47,7 @@ internal class ChartUtils
             return 0
         }
         
-        var i = roundToNextSignificant(number: Double(number))
+        let i = roundToNextSignificant(number: Double(number))
         return Int(ceil(-log10(i))) + 2
     }
     
@@ -71,11 +71,11 @@ internal class ChartUtils
         
         for (var i = 0; i < valsAtIndex.count; i++)
         {
-            var sel = valsAtIndex[i]
+            let sel = valsAtIndex[i]
             
             if (axis == nil || sel.dataSet?.axisDependency == axis)
             {
-                var cdistance = abs(sel.value - value)
+                let cdistance = abs(sel.value - value)
                 if (cdistance < distance)
                 {
                     index = valsAtIndex[i].dataSetIndex
@@ -94,11 +94,11 @@ internal class ChartUtils
         
         for (var i = 0, count = valsAtIndex.count; i < count; i++)
         {
-            var sel = valsAtIndex[i]
+            let sel = valsAtIndex[i]
             
             if (sel.dataSet!.axisDependency == axis)
             {
-                var cdistance = abs(sel.value - val)
+                let cdistance = abs(sel.value - val)
                 if (cdistance < distance)
                 {
                     distance = cdistance
@@ -110,7 +110,7 @@ internal class ChartUtils
     }
     
     /// Calculates the position around a center point, depending on the distance from the center, and the angle of the position around the center.
-    internal class func getPosition(#center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
+    internal class func getPosition(center center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
     {
         return CGPoint(
             x: center.x + dist * cos(angle * Math.FDEG2RAD),
@@ -118,7 +118,7 @@ internal class ChartUtils
         )
     }
     
-    internal class func drawText(#context: CGContext, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [NSObject : AnyObject]?)
+    internal class func drawText(context context: CGContext, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
     {
         if (align == .Center)
         {
@@ -134,7 +134,7 @@ internal class ChartUtils
         UIGraphicsPopContext()
     }
     
-    internal class func drawMultilineText(#context: CGContext, text: String, var knownTextSize: CGSize, point: CGPoint, align: NSTextAlignment, attributes: [NSObject : AnyObject]?, constrainedToSize: CGSize)
+    internal class func drawMultilineText(context context: CGContext, text: String, knownTextSize: CGSize, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?, constrainedToSize: CGSize)
     {
         var rect = CGRect(origin: CGPoint(), size: knownTextSize)
         rect.origin.x += point.x
@@ -154,9 +154,9 @@ internal class ChartUtils
         UIGraphicsPopContext()
     }
     
-    internal class func drawMultilineText(#context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [NSObject : AnyObject]?, constrainedToSize: CGSize)
+    internal class func drawMultilineText(context context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?, constrainedToSize: CGSize)
     {
-        var rect = text.boundingRectWithSize(constrainedToSize, options: .UsesLineFragmentOrigin, attributes: attributes, context: nil)
+        let rect = text.boundingRectWithSize(constrainedToSize, options: .UsesLineFragmentOrigin, attributes: attributes, context: nil)
         drawMultilineText(context: context, text: text, knownTextSize: rect.size, point: point, align: align, attributes: attributes, constrainedToSize: constrainedToSize)
     }
     

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -63,7 +63,7 @@ internal class ChartUtils
         }
     }
 
-    /// Returns the index of the DataSet that contains the closest value on the y-axis. This will return -Integer.MAX_VALUE if failure.
+    /// - returns: the index of the DataSet that contains the closest value on the y-axis. This will return -Integer.MAX_VALUE if failure.
     internal class func closestDataSetIndex(valsAtIndex: [ChartSelectionDetail], value: Double, axis: ChartYAxis.AxisDependency?) -> Int
     {
         var index = -Int.max
@@ -87,7 +87,7 @@ internal class ChartUtils
         return index
     }
     
-    /// Returns the minimum distance from a touch-y-value (in pixels) to the closest y-value (in pixels) that is displayed in the chart.
+    /// - returns: the minimum distance from a touch-y-value (in pixels) to the closest y-value (in pixels) that is displayed in the chart.
     internal class func getMinimumDistance(valsAtIndex: [ChartSelectionDetail], val: Double, axis: ChartYAxis.AxisDependency) -> Double
     {
         var distance = DBL_MAX
@@ -160,7 +160,7 @@ internal class ChartUtils
         drawMultilineText(context: context, text: text, knownTextSize: rect.size, point: point, align: align, attributes: attributes, constrainedToSize: constrainedToSize)
     }
     
-    /// returns an angle between 0.0 < 360.0 (not less than zero, less than 360)
+    /// - returns: an angle between 0.0 < 360.0 (not less than zero, less than 360)
     internal class func normalizedAngleFromAngle(var angle: CGFloat) -> CGFloat
     {
         while (angle < 0.0)

--- a/Charts/Classes/Utils/ChartViewPortHandler.swift
+++ b/Charts/Classes/Utils/ChartViewPortHandler.swift
@@ -57,12 +57,12 @@ public class ChartViewPortHandler: NSObject
         setChartDimens(width: width, height: height)
     }
     
-    public func setChartDimens(#width: CGFloat, height: CGFloat)
+    public func setChartDimens(width width: CGFloat, height: CGFloat)
     {
-        var offsetLeft = self.offsetLeft
-        var offsetTop = self.offsetTop
-        var offsetRight = self.offsetRight
-        var offsetBottom = self.offsetBottom
+        let offsetLeft = self.offsetLeft
+        let offsetTop = self.offsetTop
+        let offsetRight = self.offsetRight
+        let offsetBottom = self.offsetBottom
         
         _chartHeight = height
         _chartWidth = width
@@ -82,7 +82,7 @@ public class ChartViewPortHandler: NSObject
         }
     }
 
-    public func restrainViewPort(#offsetLeft: CGFloat, offsetTop: CGFloat, offsetRight: CGFloat, offsetBottom: CGFloat)
+    public func restrainViewPort(offsetLeft offsetLeft: CGFloat, offsetTop: CGFloat, offsetRight: CGFloat, offsetBottom: CGFloat)
     {
         _contentRect.origin.x = offsetLeft
         _contentRect.origin.y = offsetTop
@@ -154,7 +154,7 @@ public class ChartViewPortHandler: NSObject
     // MARK: - Scaling/Panning etc.
     
     /// Zooms around the specified center
-    public func zoom(#scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
+    public func zoom(scaleX scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         var matrix = CGAffineTransformTranslate(_touchMatrix, x, y)
         matrix = CGAffineTransformScale(matrix, scaleX, scaleY)
@@ -163,13 +163,13 @@ public class ChartViewPortHandler: NSObject
     }
     
     /// Zooms in by 1.4, x and y are the coordinates (in pixels) of the zoom center.
-    public func zoomIn(#x: CGFloat, y: CGFloat) -> CGAffineTransform
+    public func zoomIn(x x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         return zoom(scaleX: 1.4, scaleY: 1.4, x: x, y: y)
     }
     
     /// Zooms out by 0.7, x and y are the coordinates (in pixels) of the zoom center.
-    public func zoomOut(#x: CGFloat, y: CGFloat) -> CGAffineTransform
+    public func zoomOut(x x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         return zoom(scaleX: 0.7, scaleY: 0.7, x: x, y: y)
     }
@@ -184,18 +184,18 @@ public class ChartViewPortHandler: NSObject
     }
     
     /// Centers the viewport around the specified position (x-index and y-value) in the chart.
-    public func centerViewPort(#pt: CGPoint, chart: ChartViewBase)
+    public func centerViewPort(pt pt: CGPoint, chart: ChartViewBase)
     {
         let translateX = pt.x - offsetLeft
         let translateY = pt.y - offsetTop
         
-        var matrix = CGAffineTransformConcat(_touchMatrix, CGAffineTransformMakeTranslation(-translateX, -translateY))
+        let matrix = CGAffineTransformConcat(_touchMatrix, CGAffineTransformMakeTranslation(-translateX, -translateY))
         
         refresh(newMatrix: matrix, chart: chart, invalidate: true)
     }
     
     /// call this method to refresh the graph with a given matrix
-    public func refresh(#newMatrix: CGAffineTransform, chart: ChartViewBase, invalidate: Bool) -> CGAffineTransform
+    public func refresh(newMatrix newMatrix: CGAffineTransform, chart: ChartViewBase, invalidate: Bool) -> CGAffineTransform
     {
         _touchMatrix = newMatrix
         
@@ -208,7 +208,7 @@ public class ChartViewPortHandler: NSObject
     }
     
     /// limits the maximum scale and X translation of the given matrix
-    private func limitTransAndScale(inout #matrix: CGAffineTransform, content: CGRect?)
+    private func limitTransAndScale(inout matrix matrix: CGAffineTransform, content: CGRect?)
     {
         // min scale-x is 1, max is the max CGFloat
         _scaleX = min(max(_minScaleX, matrix.a), _maxScaleX)
@@ -225,11 +225,11 @@ public class ChartViewPortHandler: NSObject
             height = content!.height
         }
         
-        var maxTransX = -width * (_scaleX - 1.0)
-        var newTransX = min(max(matrix.tx, maxTransX - _transOffsetX), _transOffsetX)
+        let maxTransX = -width * (_scaleX - 1.0)
+        let newTransX = min(max(matrix.tx, maxTransX - _transOffsetX), _transOffsetX)
         
-        var maxTransY = height * (_scaleY - 1.0)
-        var newTransY = max(min(matrix.ty, maxTransY + _transOffsetY), -_transOffsetY)
+        let maxTransY = height * (_scaleY - 1.0)
+        let newTransY = max(min(matrix.ty, maxTransY + _transOffsetY), -_transOffsetY)
         
         matrix.tx = newTransX
         matrix.a = _scaleX
@@ -258,7 +258,7 @@ public class ChartViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
     
-    public func setMinMaxScaleX(#minScaleX: CGFloat, maxScaleX: CGFloat)
+    public func setMinMaxScaleX(minScaleX minScaleX: CGFloat, maxScaleX: CGFloat)
     {
         var newMin = minScaleX
         
@@ -318,7 +318,7 @@ public class ChartViewPortHandler: NSObject
         }
     }
     
-    public func isInBounds(#x: CGFloat, y: CGFloat) -> Bool
+    public func isInBounds(x x: CGFloat, y: CGFloat) -> Bool
     {
         if (isInBoundsX(x) && isInBoundsY(y))
         {

--- a/Charts/Classes/Utils/ChartViewPortHandler.swift
+++ b/Charts/Classes/Utils/ChartViewPortHandler.swift
@@ -352,13 +352,13 @@ public class ChartViewPortHandler: NSObject
         return (_contentRect.origin.y + _contentRect.size.height) >= normalizedY ? true : false
     }
     
-    /// returns the current x-scale factor
+    /// - returns: the current x-scale factor
     public var scaleX: CGFloat
     {
         return _scaleX
     }
     
-    /// returns the current y-scale factor
+    /// - returns: the current y-scale factor
     public var scaleY: CGFloat
     {
         return _scaleY
@@ -377,7 +377,7 @@ public class ChartViewPortHandler: NSObject
         }
     }
     
-    /// Returns true if the chart is fully zoomed out on it's y-axis (vertical).
+    /// - returns: true if the chart is fully zoomed out on it's y-axis (vertical).
     public var isFullyZoomedOutY: Bool
     {
         if (_scaleY > _minScaleY || _minScaleY > 1.0)
@@ -390,7 +390,7 @@ public class ChartViewPortHandler: NSObject
         }
     }
     
-    /// Returns true if the chart is fully zoomed out on it's x-axis (horizontal).
+    /// - returns: true if the chart is fully zoomed out on it's x-axis (horizontal).
     public var isFullyZoomedOutX: Bool
     {
         if (_scaleX > _minScaleX || _minScaleX > 1.0)
@@ -415,7 +415,7 @@ public class ChartViewPortHandler: NSObject
         _transOffsetY = offset
     }
     
-    /// Returns true if both drag offsets (x and y) are zero or smaller.
+    /// - returns: true if both drag offsets (x and y) are zero or smaller.
     public var hasNoDragOffset: Bool
     {
         return _transOffsetX <= 0.0 && _transOffsetY <= 0.0 ? true : false

--- a/Charts/Supporting Files/Info.plist
+++ b/Charts/Supporting Files/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.dcg.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
+++ b/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
@@ -378,7 +378,8 @@
 		5B57BBA71A9B26AA0036A6CC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = dcg;
 				TargetAttributes = {
 					5B57BBAE1A9B26AA0036A6CC = {
@@ -524,6 +525,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -588,6 +590,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ChartsDemo;
 				SWIFT_OBJC_BRIDGING_HEADER = "Supporting Files/ChartsDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -602,6 +605,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ChartsDemo;
 				SWIFT_OBJC_BRIDGING_HEADER = "Supporting Files/ChartsDemo-Bridging-Header.h";
 			};

--- a/ChartsDemo/Classes/Components/BalloonMarker.swift
+++ b/ChartsDemo/Classes/Components/BalloonMarker.swift
@@ -42,7 +42,7 @@ public class BalloonMarker: ChartMarker
     
     public override var size: CGSize { return _size; }
     
-    public override func draw(#context: CGContext, point: CGPoint)
+    public override func draw(context context: CGContext, point: CGPoint)
     {
         if (labelns === nil)
         {
@@ -95,9 +95,9 @@ public class BalloonMarker: ChartMarker
         CGContextRestoreGState(context);
     }
     
-    public override func refreshContent(#entry: ChartDataEntry, highlight: ChartHighlight)
+    public override func refreshContent(entry entry: ChartDataEntry, highlight: ChartHighlight)
     {
-        var label = entry.value.description;
+        let label = entry.value.description;
         labelns = label as NSString;
         
         _labelSize = labelns.sizeWithAttributes([NSFontAttributeName: self.font]);

--- a/ChartsDemo/Supporting Files/Info.plist
+++ b/ChartsDemo/Supporting Files/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.dcg.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Hi 

Thank you for your hard word and fantastic ios-charts.

I noted that the latest ios-charts for swift 2.0 cannot compile on XCode7 beta 5 due to the following issue.
The  self.dynamicType.allocWithZone(zone) produce the following error:
'allocWithZone' is unavailable in Swift: use object initializers instead

There are a couple of error occurrences.
1- ChartDataEntry.swift
2- ChartDataSet.swift

// MARK: NSCopying
    
    public func copyWithZone(zone: NSZone) -> AnyObject
    {
     
        let copy = self.dynamicType.allocWithZone(zone) as ChartDataSet
        -------
        --------
        return copy
    }

I would love finding the trick on my own but.. :-(

Kind Regards,
Patrick