### PR TITLE
Fixes xcode beta 5 compile errors

### DIFF
--- a/Charts/Charts.xcodeproj/project.pbxproj
+++ b/Charts/Charts.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06A5D1861B78675500915098 /* UIGraphics+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A5D1851B78675500915098 /* UIGraphics+Extensions.swift */; };
+		06A5D1881B7868AF00915098 /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A5D1871B7868AF00915098 /* CALayer+Extensions.swift */; };
 		55E356531ADC63BF00A57971 /* BubbleChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E356521ADC63BF00A57971 /* BubbleChartView.swift */; };
 		55E356571ADC63CD00A57971 /* BubbleChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E356541ADC63CD00A57971 /* BubbleChartData.swift */; };
 		55E356581ADC63CD00A57971 /* BubbleChartDataEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E356551ADC63CD00A57971 /* BubbleChartDataEntry.swift */; };
@@ -93,6 +95,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		06A5D1851B78675500915098 /* UIGraphics+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIGraphics+Extensions.swift"; sourceTree = "<group>"; };
+		06A5D1871B7868AF00915098 /* CALayer+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		55E356521ADC63BF00A57971 /* BubbleChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartView.swift; sourceTree = "<group>"; };
 		55E356541ADC63CD00A57971 /* BubbleChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartData.swift; sourceTree = "<group>"; };
 		55E356551ADC63CD00A57971 /* BubbleChartDataEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartDataEntry.swift; sourceTree = "<group>"; };
@@ -129,7 +133,7 @@
 		5B6A54901AA66A8D000F57C2 /* ChartDataRendererBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDataRendererBase.swift; sourceTree = "<group>"; };
 		5B6A54921AA66AAB000F57C2 /* CombinedChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedChartRenderer.swift; sourceTree = "<group>"; };
 		5B6A54941AA66AC0000F57C2 /* CandleStickChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CandleStickChartRenderer.swift; sourceTree = "<group>"; };
-		5B6A54961AA66AD2000F57C2 /* BarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartRenderer.swift; sourceTree = "<group>"; };
+		5B6A54961AA66AD2000F57C2 /* BarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarChartRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54981AA66B14000F57C2 /* BarChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartView.swift; sourceTree = "<group>"; };
 		5B6A549A1AA66B2C000F57C2 /* BarLineChartViewBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarLineChartViewBase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A549C1AA66B3C000F57C2 /* CandleStickChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CandleStickChartView.swift; sourceTree = "<group>"; };
@@ -375,6 +379,8 @@
 				5BB6EC1C1ACC28AB006E9C25 /* ChartTransformerHorizontalBarChart.swift */,
 				5BA8EC7C1A9D151C00CE82E1 /* ChartUtils.swift */,
 				5BD8F06C1AB897D500566E05 /* ChartViewPortHandler.swift */,
+				06A5D1851B78675500915098 /* UIGraphics+Extensions.swift */,
+				06A5D1871B7868AF00915098 /* CALayer+Extensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -502,6 +508,7 @@
 				5BA8EC7D1A9D151C00CE82E1 /* ChartViewBase.swift in Sources */,
 				5B6A54DC1AA74516000F57C2 /* PieChartDataSet.swift in Sources */,
 				5B6A54DA1AA74516000F57C2 /* LineRadarChartDataSet.swift in Sources */,
+				06A5D1861B78675500915098 /* UIGraphics+Extensions.swift in Sources */,
 				5B6A54701AA5DB34000F57C2 /* ChartRendererBase.swift in Sources */,
 				5B6A54761AA5DEE3000F57C2 /* ChartXAxisRendererBarChart.swift in Sources */,
 				5B6A54851AA669C9000F57C2 /* ScatterChartRenderer.swift in Sources */,
@@ -522,6 +529,7 @@
 				5B6A54DF1AA74516000F57C2 /* ScatterChartData.swift in Sources */,
 				5B6A54D31AA74516000F57C2 /* CandleChartDataSet.swift in Sources */,
 				5B0032491B6525FC00B6A2FE /* ChartHighlighter.swift in Sources */,
+				06A5D1881B7868AF00915098 /* CALayer+Extensions.swift in Sources */,
 				5B6A54D71AA74516000F57C2 /* ChartDataSet.swift in Sources */,
 				5B00324B1B652BF900B6A2FE /* BarChartHighlighter.swift in Sources */,
 				5B6A54781AA5DEF0000F57C2 /* ChartXAxisRendererRadarChart.swift in Sources */,

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -490,7 +490,7 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
     }
     
     /// draws the grid background
-    internal func drawGridBackground(context context: CGContext)
+    internal func drawGridBackground(context context: CGContext?)
     {
         if (drawGridBackgroundEnabled || drawBordersEnabled)
         {

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -291,7 +291,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     {
         let context = UIGraphicsGetCurrentContext()
         let frame = self.bounds
-        
+
         if (_dataNotSet || _data === nil || _data.yValCount == 0)
         { // check if there is data
             
@@ -319,7 +319,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     }
     
     /// draws the description text in the bottom right corner of the chart
-    internal func drawDescription(context context: CGContext)
+    internal func drawDescription(context context: CGContext?)
     {
         if (descriptionText.lengthOfBytesUsingEncoding(NSUTF16StringEncoding) == 0)
         {
@@ -439,7 +439,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
     // MARK: - Markers
 
     /// draws all MarkerViews on the highlighted positions
-    internal func drawMarkers(context context: CGContext)
+    internal func drawMarkers(context context: CGContext?)
     {
         // if there is no marker view or drawing marker is disabled
         if (marker === nil || !drawMarkers || !valuesToHighlight())
@@ -776,7 +776,7 @@ public class ChartViewBase: UIView, ChartAnimatorDelegate
             }
         }
         
-        layer.renderInContext(UIGraphicsGetCurrentContext())
+        layer.renderInOptionalContext(context)
         
         let image = UIGraphicsGetImageFromCurrentImageContext()
         

--- a/Charts/Classes/Components/ChartMarker.swift
+++ b/Charts/Classes/Components/ChartMarker.swift
@@ -37,7 +37,7 @@ public class ChartMarker: ChartComponentBase
     }
     
     /// Draws the ChartMarker on the given position on the given context
-    public func draw(context context: CGContext, point: CGPoint)
+    public func draw(context context: CGContext?, point: CGPoint)
     {
         let offset = self.offset
         let size = self.size

--- a/Charts/Classes/Data/ChartDataEntry.swift
+++ b/Charts/Classes/Data/ChartDataEntry.swift
@@ -90,11 +90,7 @@ public class ChartDataEntry: NSObject
     
     public func copyWithZone(zone: NSZone) -> AnyObject
     {
-        let copy = self.dynamicType.allocWithZone(zone) as ChartDataEntry
-        copy.value = value
-        copy.xIndex = xIndex
-        copy.data = data
-        return copy
+        return ChartDataEntry(value: value, xIndex: xIndex, data: data)
     }
 }
 

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -484,13 +484,11 @@ public class ChartDataSet: NSObject
     
     public func copyWithZone(zone: NSZone) -> AnyObject
     {
-        let copy = self.dynamicType.allocWithZone(zone) as ChartDataSet
+        let copy = ChartDataSet(yVals: _yVals, label: label)
         copy.colors = colors
-        copy._yVals = _yVals
         copy._yMax = _yMax
         copy._yMin = _yMin
         copy._yValueSum = _yValueSum
-        copy.label = self.label
         return copy
     }
 }

--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -43,7 +43,7 @@ public class BarChartRenderer: ChartDataRendererBase
         self.delegate = delegate
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         let barData = delegate!.barChartRendererData(self)
         
@@ -63,7 +63,7 @@ public class BarChartRenderer: ChartDataRendererBase
         }
     }
     
-    internal func drawDataSet(context context: CGContext, dataSet: BarChartDataSet, index: Int)
+    internal func drawDataSet(context context: CGContext?, dataSet: BarChartDataSet, index: Int)
     {
         CGContextSaveGState(context)
         
@@ -273,7 +273,7 @@ public class BarChartRenderer: ChartDataRendererBase
         trans.rectValueToPixel(&rect, phaseY: _animator.phaseY)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         // if values are drawn
         if (passesCheck())
@@ -448,19 +448,19 @@ public class BarChartRenderer: ChartDataRendererBase
     }
     
     /// Draws a value at the specified x and y position.
-    internal func drawValue(context context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: UIFont, align: NSTextAlignment, color: UIColor)
+    internal func drawValue(context context: CGContext?, value: String, xPos: CGFloat, yPos: CGFloat, font: UIFont, align: NSTextAlignment, color: UIColor)
     {
         ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: color])
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         
     }
     
     private var _highlightArrowPtsBuffer = [CGPoint](count: 3, repeatedValue: CGPoint())
     
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         let barData = delegate!.barChartRendererData(self)
         if (barData === nil)

--- a/Charts/Classes/Renderers/BubbleChartRenderer.swift
+++ b/Charts/Classes/Renderers/BubbleChartRenderer.swift
@@ -38,7 +38,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         self.delegate = delegate
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         let bubbleData = delegate!.bubbleChartRendererData(self)
         
@@ -61,7 +61,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
     private var _pointBuffer = CGPoint()
     private var _sizeBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawDataSet(context context: CGContext, dataSet: BubbleChartDataSet)
+    internal func drawDataSet(context context: CGContext?, dataSet: BubbleChartDataSet)
     {
         let trans = delegate!.bubbleChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
@@ -135,7 +135,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         let bubbleData = delegate!.bubbleChartRendererData(self)
         if (bubbleData === nil)
@@ -203,12 +203,12 @@ public class BubbleChartRenderer: ChartDataRendererBase
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         
     }
     
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         let bubbleData = delegate!.bubbleChartRendererData(self)
         

--- a/Charts/Classes/Renderers/CandleStickChartRenderer.swift
+++ b/Charts/Classes/Renderers/CandleStickChartRenderer.swift
@@ -39,7 +39,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         self.delegate = delegate
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         let candleData = delegate!.candleStickChartRendererCandleData(self)
 
@@ -56,7 +56,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
     private var _bodyRect = CGRect()
     private var _lineSegments = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawDataSet(context context: CGContext, dataSet: CandleChartDataSet)
+    internal func drawDataSet(context context: CGContext?, dataSet: CandleChartDataSet)
     {
         let trans = delegate!.candleStickChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
@@ -169,7 +169,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         let candleData = delegate!.candleStickChartRendererCandleData(self)
         if (candleData === nil)
@@ -240,12 +240,12 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
     }
     
     private var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         let candleData = delegate!.candleStickChartRendererCandleData(self)
         if (candleData === nil)

--- a/Charts/Classes/Renderers/ChartAxisRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartAxisRendererBase.swift
@@ -31,25 +31,25 @@ public class ChartAxisRendererBase: ChartRendererBase
     }
     
     /// Draws the axis labels on the specified context
-    public func renderAxisLabels(context context: CGContext)
+    public func renderAxisLabels(context context: CGContext?)
     {
         fatalError("renderAxisLabels() cannot be called on ChartAxisRendererBase")
     }
     
     /// Draws the grid lines belonging to the axis.
-    public func renderGridLines(context context: CGContext)
+    public func renderGridLines(context context: CGContext?)
     {
         fatalError("renderGridLines() cannot be called on ChartAxisRendererBase")
     }
     
     /// Draws the line that goes alongside the axis.
-    public func renderAxisLine(context context: CGContext)
+    public func renderAxisLine(context context: CGContext?)
     {
         fatalError("renderAxisLine() cannot be called on ChartAxisRendererBase")
     }
     
     /// Draws the LimitLines associated with this axis to the screen.
-    public func renderLimitLines(context context: CGContext)
+    public func renderLimitLines(context context: CGContext?)
     {
         fatalError("renderLimitLines() cannot be called on ChartAxisRendererBase")
     }

--- a/Charts/Classes/Renderers/ChartDataRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartDataRendererBase.swift
@@ -24,22 +24,22 @@ public class ChartDataRendererBase: ChartRendererBase
         _animator = animator
     }
 
-    public func drawData(context context: CGContext)
+    public func drawData(context context: CGContext?)
     {
         fatalError("drawData() cannot be called on ChartDataRendererBase")
     }
     
-    public func drawValues(context context: CGContext)
+    public func drawValues(context context: CGContext?)
     {
         fatalError("drawValues() cannot be called on ChartDataRendererBase")
     }
     
-    public func drawExtras(context context: CGContext)
+    public func drawExtras(context context: CGContext?)
     {
         fatalError("drawExtras() cannot be called on ChartDataRendererBase")
     }
     
-    public func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         fatalError("drawHighlighted() cannot be called on ChartDataRendererBase")
     }

--- a/Charts/Classes/Renderers/ChartLegendRenderer.swift
+++ b/Charts/Classes/Renderers/ChartLegendRenderer.swift
@@ -107,7 +107,7 @@ public class ChartLegendRenderer: ChartRendererBase
         _legend.calculateDimensions(labelFont: _legend.font, viewPortHandler: viewPortHandler)
     }
     
-    public func renderLegend(context context: CGContext)
+    public func renderLegend(context context: CGContext?)
     {
         if (_legend === nil || !_legend.enabled)
         {
@@ -364,7 +364,7 @@ public class ChartLegendRenderer: ChartRendererBase
     private var _formLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
     /// Draws the Legend-form at the given position with the color at the given index.
-    internal func drawForm(context: CGContext, x: CGFloat, y: CGFloat, colorIndex: Int, legend: ChartLegend)
+    internal func drawForm(context: CGContext?, x: CGFloat, y: CGFloat, colorIndex: Int, legend: ChartLegend)
     {
         let formColor = legend.colors[colorIndex]
         
@@ -405,7 +405,7 @@ public class ChartLegendRenderer: ChartRendererBase
     }
 
     /// Draws the provided label at the given position.
-    internal func drawLabel(context: CGContext, x: CGFloat, y: CGFloat, label: String, font: UIFont, textColor: UIColor)
+    internal func drawLabel(context: CGContext?, x: CGFloat, y: CGFloat, label: String, font: UIFont, textColor: UIColor)
     {
         ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .Left, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: textColor])
     }

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -44,7 +44,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         _xAxis.values = xValues
     }
     
-    public override func renderAxisLabels(context context: CGContext)
+    public override func renderAxisLabels(context context: CGContext?)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawLabelsEnabled)
         {
@@ -78,7 +78,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(context context: CGContext)
+    public override func renderAxisLine(context context: CGContext?)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawAxisLineEnabled)
         {
@@ -124,7 +124,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     }
     
     /// draws the x-labels on the specified y-position
-    internal func drawLabels(context context: CGContext, pos: CGFloat)
+    internal func drawLabels(context context: CGContext?, pos: CGFloat)
     {
         let paraStyle = NSParagraphStyle.defaultParagraphStyle().mutableCopy() as! NSMutableParagraphStyle
         paraStyle.alignment = .Center
@@ -187,7 +187,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _gridLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(context context: CGContext)
+    public override func renderGridLines(context context: CGContext?)
     {
         if (!_xAxis.isDrawGridLinesEnabled || !_xAxis.isEnabled)
         {
@@ -233,7 +233,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(context context: CGContext)
+    public override func renderLimitLines(context context: CGContext?)
     {
         var limitLines = _xAxis.limitLines
         

--- a/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
@@ -27,7 +27,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
     }
     
     /// draws the x-labels on the specified y-position
-    internal override func drawLabels(context context: CGContext, pos: CGFloat)
+    internal override func drawLabels(context context: CGContext?, pos: CGFloat)
     {
         if (_chart.data === nil)
         {
@@ -103,7 +103,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
     
     private var _gridLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(context context: CGContext)
+    public override func renderGridLines(context context: CGContext?)
     {
         if (!_xAxis.isDrawGridLinesEnabled || !_xAxis.isEnabled)
         {

--- a/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
@@ -32,7 +32,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
         _xAxis.labelHeight = longestSize.height
     }
 
-    public override func renderAxisLabels(context context: CGContext)
+    public override func renderAxisLabels(context context: CGContext?)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawLabelsEnabled || _chart.data === nil)
         {
@@ -65,7 +65,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     }
 
     /// draws the x-labels on the specified y-position
-    internal func drawLabels(context context: CGContext, pos: CGFloat, align: NSTextAlignment)
+    internal func drawLabels(context context: CGContext?, pos: CGFloat, align: NSTextAlignment)
     {
         let labelFont = _xAxis.labelFont
         let labelTextColor = _xAxis.labelTextColor
@@ -105,7 +105,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     private var _gridLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(context context: CGContext)
+    public override func renderGridLines(context context: CGContext?)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawGridLinesEnabled || _chart.data === nil)
         {
@@ -154,7 +154,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(context context: CGContext)
+    public override func renderAxisLine(context context: CGContext?)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawAxisLineEnabled)
         {
@@ -201,7 +201,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(context context: CGContext)
+    public override func renderLimitLines(context context: CGContext?)
     {
         var limitLines = _xAxis.limitLines
         

--- a/Charts/Classes/Renderers/ChartXAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererRadarChart.swift
@@ -26,7 +26,7 @@ public class ChartXAxisRendererRadarChart: ChartXAxisRenderer
         _chart = chart
     }
     
-    public override func renderAxisLabels(context context: CGContext)
+    public override func renderAxisLabels(context context: CGContext?)
     {
         if (!_xAxis.isEnabled || !_xAxis.isDrawLabelsEnabled)
         {
@@ -60,7 +60,7 @@ public class ChartXAxisRendererRadarChart: ChartXAxisRenderer
         }
     }
     
-    public override func renderLimitLines(context context: CGContext)
+    public override func renderLimitLines(context context: CGContext?)
     {
         /// XAxis LimitLines on RadarChart not yet supported.
     }

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -142,7 +142,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     }
     
     /// draws the y-axis labels to the screen
-    public override func renderAxisLabels(context context: CGContext)
+    public override func renderAxisLabels(context context: CGContext?)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawLabelsEnabled)
         {
@@ -192,7 +192,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(context context: CGContext)
+    public override func renderAxisLine(context context: CGContext?)
     {
         if (!_yAxis.isEnabled || !_yAxis.drawAxisLineEnabled)
         {
@@ -233,7 +233,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     }
     
     /// draws the y-labels on the specified x-position
-    internal func drawYLabels(context context: CGContext, fixedPosition: CGFloat, offset: CGFloat, textAlign: NSTextAlignment)
+    internal func drawYLabels(context context: CGContext?, fixedPosition: CGFloat, offset: CGFloat, textAlign: NSTextAlignment)
     {
         let labelFont = _yAxis.labelFont
         let labelTextColor = _yAxis.labelTextColor
@@ -264,7 +264,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     
     private var _gridLineBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderGridLines(context context: CGContext)
+    public override func renderGridLines(context context: CGContext?)
     {
         if (!_yAxis.isDrawGridLinesEnabled || !_yAxis.isEnabled)
         {
@@ -307,7 +307,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(context context: CGContext)
+    public override func renderLimitLines(context context: CGContext?)
     {
         var limitLines = _yAxis.limitLines
         

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -47,7 +47,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// draws the y-axis labels to the screen
-    public override func renderAxisLabels(context context: CGContext)
+    public override func renderAxisLabels(context context: CGContext?)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawLabelsEnabled)
         {
@@ -104,7 +104,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderAxisLine(context context: CGContext)
+    public override func renderAxisLine(context context: CGContext?)
     {
         if (!_yAxis.isEnabled || !_yAxis.drawAxisLineEnabled)
         {
@@ -145,7 +145,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// draws the y-labels on the specified x-position
-    internal func drawYLabels(context context: CGContext, fixedPosition: CGFloat, positions: [CGPoint], offset: CGFloat)
+    internal func drawYLabels(context context: CGContext?, fixedPosition: CGFloat, positions: [CGPoint], offset: CGFloat)
     {
         let labelFont = _yAxis.labelFont
         let labelTextColor = _yAxis.labelTextColor
@@ -163,7 +163,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         }
     }
 
-    public override func renderGridLines(context context: CGContext)
+    public override func renderGridLines(context context: CGContext?)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawGridLinesEnabled)
         {
@@ -204,7 +204,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public override func renderLimitLines(context context: CGContext)
+    public override func renderLimitLines(context context: CGContext?)
     {
         var limitLines = _yAxis.limitLines
 

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -135,7 +135,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         _yAxis.axisRange = abs(_yAxis.axisMaximum - _yAxis.axisMinimum)
     }
     
-    public override func renderAxisLabels(context context: CGContext)
+    public override func renderAxisLabels(context context: CGContext?)
     {
         if (!_yAxis.isEnabled || !_yAxis.isDrawLabelsEnabled)
         {
@@ -169,7 +169,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         }
     }
     
-    public override func renderLimitLines(context context: CGContext)
+    public override func renderLimitLines(context context: CGContext?)
     {
         var limitLines = _yAxis.limitLines
         

--- a/Charts/Classes/Renderers/CombinedChartRenderer.swift
+++ b/Charts/Classes/Renderers/CombinedChartRenderer.swift
@@ -93,7 +93,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
 
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         for renderer in _renderers
         {
@@ -101,7 +101,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         for renderer in _renderers
         {
@@ -109,7 +109,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         for renderer in _renderers
         {
@@ -117,7 +117,7 @@ public class CombinedChartRenderer: ChartDataRendererBase,
         }
     }
     
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         for renderer in _renderers
         {

--- a/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
+++ b/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
@@ -22,7 +22,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         super.init(delegate: delegate, animator: animator, viewPortHandler: viewPortHandler)
     }
     
-    internal override func drawDataSet(context context: CGContext, dataSet: BarChartDataSet, index: Int)
+    internal override func drawDataSet(context context: CGContext?, dataSet: BarChartDataSet, index: Int)
     {
         CGContextSaveGState(context)
         
@@ -237,7 +237,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         return trans.generateTransformedValuesHorizontalBarChart(entries, dataSet: dataSetIndex, barData: delegate!.barChartRendererData(self)!, phaseY: _animator.phaseY)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         // if values are drawn
         if (passesCheck())

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -40,7 +40,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         self.delegate = delegate
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         let lineData = delegate!.lineChartRendererData(self)
         
@@ -77,7 +77,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    internal func drawDataSet(context context: CGContext, dataSet: LineChartDataSet)
+    internal func drawDataSet(context context: CGContext?, dataSet: LineChartDataSet)
     {
         let entries = dataSet.yVals
         
@@ -111,7 +111,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    internal func drawCubic(context context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry])
+    internal func drawCubic(context context: CGContext?, dataSet: LineChartDataSet, entries: [ChartDataEntry])
     {
         let trans = delegate?.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
@@ -214,7 +214,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    internal func drawCubicFill(context context: CGContext, dataSet: LineChartDataSet, spline: CGMutablePath, matrix: CGAffineTransform, from: Int, to: Int)
+    internal func drawCubicFill(context context: CGContext?, dataSet: LineChartDataSet, spline: CGMutablePath, matrix: CGAffineTransform, from: Int, to: Int)
     {
         CGContextSaveGState(context)
         
@@ -244,7 +244,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
     
     private var _lineSegments = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawLinear(context context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry])
+    internal func drawLinear(context context: CGContext?, dataSet: LineChartDataSet, entries: [ChartDataEntry])
     {
         let trans = delegate!.lineChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         let valueToPixelMatrix = trans.valueToPixelMatrix
@@ -349,7 +349,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    internal func drawLinearFill(context context: CGContext, dataSet: LineChartDataSet, entries: [ChartDataEntry], minx: Int, maxx: Int, trans: ChartTransformer)
+    internal func drawLinearFill(context context: CGContext?, dataSet: LineChartDataSet, entries: [ChartDataEntry], minx: Int, maxx: Int, trans: ChartTransformer)
     {
         CGContextSaveGState(context)
         
@@ -400,7 +400,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         return filled
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         let lineData = delegate!.lineChartRendererData(self)
         if (lineData === nil)
@@ -477,12 +477,12 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         drawCircles(context: context)
     }
     
-    private func drawCircles(context context: CGContext)
+    private func drawCircles(context context: CGContext?)
     {
         let phaseX = _animator.phaseX
         let phaseY = _animator.phaseY
@@ -566,7 +566,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
     
     var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
     
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         let lineData = delegate!.lineChartRendererData(self)
         let chartXMax = delegate!.lineChartRendererChartXMax(self)

--- a/Charts/Classes/Renderers/LineScatterCandleRadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineScatterCandleRadarChartRenderer.swift
@@ -27,7 +27,7 @@ public class LineScatterCandleRadarChartRenderer: ChartDataRendererBase
     /// :param: points
     /// :param: horizontal
     /// :param: vertical
-    public func drawHighlightLines(context context: CGContext, points: UnsafePointer<CGPoint>, horizontal: Bool, vertical: Bool)
+    public func drawHighlightLines(context context: CGContext?, points: UnsafePointer<CGPoint>, horizontal: Bool, vertical: Bool)
     {
         // draw vertical highlight lines
         if vertical

--- a/Charts/Classes/Renderers/PieChartRenderer.swift
+++ b/Charts/Classes/Renderers/PieChartRenderer.swift
@@ -40,7 +40,7 @@ public class PieChartRenderer: ChartDataRendererBase
         _chart = chart
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         if (_chart !== nil)
         {
@@ -59,7 +59,7 @@ public class PieChartRenderer: ChartDataRendererBase
         }
     }
     
-    internal func drawDataSet(context context: CGContext, dataSet: PieChartDataSet)
+    internal func drawDataSet(context context: CGContext?, dataSet: PieChartDataSet)
     {
         var angle = _chart.rotationAngle
         
@@ -121,7 +121,7 @@ public class PieChartRenderer: ChartDataRendererBase
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         let center = _chart.centerCircleBox
         
@@ -220,14 +220,14 @@ public class PieChartRenderer: ChartDataRendererBase
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         drawHole(context: context)
         drawCenterText(context: context)
     }
     
     /// draws the hole in the center of the chart and the transparent circle / hole
-    private func drawHole(context context: CGContext)
+    private func drawHole(context context: CGContext?)
     {
         if (_chart.drawHoleEnabled)
         {
@@ -260,7 +260,7 @@ public class PieChartRenderer: ChartDataRendererBase
     }
     
     /// draws the description text in the center of the pie chart makes most sense when center-hole is enabled
-    private func drawCenterText(context context: CGContext)
+    private func drawCenterText(context context: CGContext?)
     {
         if (drawCenterTextEnabled && centerText != nil && centerText.characters.count > 0)
         {
@@ -302,7 +302,7 @@ public class PieChartRenderer: ChartDataRendererBase
         }
     }
     
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         if (_chart.data === nil)
         {

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -26,7 +26,7 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         _chart = chart
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         if (_chart !== nil)
         {
@@ -45,7 +45,7 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    internal func drawDataSet(context context: CGContext, dataSet: RadarChartDataSet)
+    internal func drawDataSet(context context: CGContext?, dataSet: RadarChartDataSet)
     {
         CGContextSaveGState(context)
         
@@ -109,7 +109,7 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         if (_chart.data === nil)
         {
@@ -160,14 +160,14 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         drawWeb(context: context)
     }
     
     private var _webLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawWeb(context context: CGContext)
+    internal func drawWeb(context context: CGContext?)
     {
         let sliceangle = _chart.sliceAngle
         
@@ -227,7 +227,7 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
     
     private var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
 
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         if (_chart.data === nil)
         {

--- a/Charts/Classes/Renderers/ScatterChartRenderer.swift
+++ b/Charts/Classes/Renderers/ScatterChartRenderer.swift
@@ -39,7 +39,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         self.delegate = delegate
     }
     
-    public override func drawData(context context: CGContext)
+    public override func drawData(context context: CGContext?)
     {
         let scatterData = delegate!.scatterChartRendererData(self)
         
@@ -61,7 +61,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
     
     private var _lineSegments = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    internal func drawDataSet(context context: CGContext, dataSet: ScatterChartDataSet)
+    internal func drawDataSet(context context: CGContext?, dataSet: ScatterChartDataSet)
     {
         let trans = delegate!.scatterChartRenderer(self, transformerForAxis: dataSet.axisDependency)
         
@@ -171,7 +171,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         CGContextRestoreGState(context)
     }
     
-    public override func drawValues(context context: CGContext)
+    public override func drawValues(context context: CGContext?)
     {
         let scatterData = delegate!.scatterChartRendererData(self)
         if (scatterData === nil)
@@ -235,14 +235,14 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         }
     }
     
-    public override func drawExtras(context context: CGContext)
+    public override func drawExtras(context context: CGContext?)
     {
         
     }
     
     private var _highlightPtsBuffer = [CGPoint](count: 4, repeatedValue: CGPoint())
     
-    public override func drawHighlighted(context context: CGContext, indices: [ChartHighlight])
+    public override func drawHighlighted(context context: CGContext?, indices: [ChartHighlight])
     {
         let scatterData = delegate!.scatterChartRendererData(self)
         let chartXMax = delegate!.scatterChartRendererChartXMax(self)

--- a/Charts/Classes/Utils/CALayer+Extensions.swift
+++ b/Charts/Classes/Utils/CALayer+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  CALayer+Extensions.swift
+//  Charts
+//
+//  CALayer+Extensions implementation:
+//    Copyright 2015 Pierre-Marc Airoldi
+//    Licensed under Apache License 2.0
+//
+//  https://github.com/danielgindi/ios-charts
+//
+
+import QuartzCore
+
+extension CALayer {
+    
+    public func renderInOptionalContext(ctx: CGContext?) {
+        
+        guard let ctx = ctx else {
+            return
+        }
+        
+        renderInContext(ctx)
+    }
+}

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -118,7 +118,7 @@ internal class ChartUtils
         )
     }
     
-    internal class func drawText(context context: CGContext, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
+    internal class func drawText(context context: CGContext?, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
     {
         if (align == .Center)
         {
@@ -128,13 +128,13 @@ internal class ChartUtils
         {
             point.x -= text.sizeWithAttributes(attributes).width
         }
-        
+    
         UIGraphicsPushContext(context)
         (text as NSString).drawAtPoint(point, withAttributes: attributes)
         UIGraphicsPopContext()
     }
     
-    internal class func drawMultilineText(context context: CGContext, text: String, knownTextSize: CGSize, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?, constrainedToSize: CGSize)
+    internal class func drawMultilineText(context context: CGContext?, text: String, knownTextSize: CGSize, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?, constrainedToSize: CGSize)
     {
         var rect = CGRect(origin: CGPoint(), size: knownTextSize)
         rect.origin.x += point.x
@@ -154,7 +154,7 @@ internal class ChartUtils
         UIGraphicsPopContext()
     }
     
-    internal class func drawMultilineText(context context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?, constrainedToSize: CGSize)
+    internal class func drawMultilineText(context context: CGContext?, text: String, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?, constrainedToSize: CGSize)
     {
         let rect = text.boundingRectWithSize(constrainedToSize, options: .UsesLineFragmentOrigin, attributes: attributes, context: nil)
         drawMultilineText(context: context, text: text, knownTextSize: rect.size, point: point, align: align, attributes: attributes, constrainedToSize: constrainedToSize)

--- a/Charts/Classes/Utils/UIGraphics+Extensions.swift
+++ b/Charts/Classes/Utils/UIGraphics+Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  UIGraphics+Extensions.swift
+//  Charts
+//
+//  UIGraphics+Extensions implementation:
+//    Copyright 2015 Pierre-Marc Airoldi
+//    Licensed under Apache License 2.0
+//
+//  https://github.com/danielgindi/ios-charts
+//
+
+import UIKit
+
+public func UIGraphicsPushContext(context: CGContext?) {
+    
+    guard let context = context else {
+        return
+    }
+    
+    UIGraphicsPushContext(context)
+}

--- a/ChartsDemo/Classes/Components/BalloonMarker.swift
+++ b/ChartsDemo/Classes/Components/BalloonMarker.swift
@@ -42,7 +42,7 @@ public class BalloonMarker: ChartMarker
     
     public override var size: CGSize { return _size; }
     
-    public override func draw(context context: CGContext, point: CGPoint)
+    public override func draw(context context: CGContext?, point: CGPoint)
     {
         if (labelns === nil)
         {


### PR DESCRIPTION
I know its a lot of changes but this beta made the `UIGraphicsGetCurrentContext()` now return an optional value. So instead of adding `if let` or `guard` everywhere I decided to refactor the methods that took `CGContext` to `CGContext?` and add extensions to methods that didn't take optional values. Hopefully apple moves the 2 methods that I extended to take in optional values as well so the extensions can be removed. (fixes #287)