### PR TITLE
Changed Release signing configuration to "iOS Developer" to improve Carthage compatibility

### DIFF
--- a/Charts/Charts.xcodeproj/project.pbxproj
+++ b/Charts/Charts.xcodeproj/project.pbxproj
@@ -658,7 +658,7 @@
 		5BA8EC581A9D14DC00CE82E1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
Carthage was failing to build this. I believe that with `iPhone Distribution` you need a special profile to sign this library. It works with simply `iPhone Developer`. This shouldn't be an issue for anyone because the frameworks end up being signed with your application's profile when submitting to Apple.