### PR TITLE
combined chart - seems we should use same chartXMin and chartXMax even there is no bubble data

### DIFF
--- a/Charts/Classes/Charts/CombinedChartView.swift
+++ b/Charts/Classes/Charts/CombinedChartView.swift
@@ -67,11 +67,6 @@ public class CombinedChartView: BarLineChartViewBase
                     }
                 }
             }
-            else
-            {
-                _chartXMin = 0.0
-                _chartXMax = Double(_data.xValCount - 1)
-            }
 
             _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
         }


### PR DESCRIPTION
For issue #323 
seems we should use same chartXMin and chartXMax
            _chartXMin = -0.5
            _chartXMax = Double(_data.xVals.count) - 0.5
even there is no bubble data