### PR TITLE
Issue #280

### DIFF
--- a/Charts/Classes/Data/LineChartDataSet.swift
+++ b/Charts/Classes/Data/LineChartDataSet.swift
@@ -34,6 +34,9 @@ public class LineChartDataSet: LineRadarChartDataSet
     
     public var drawCircleHoleEnabled = true
     
+    // if true, line breaks on void values
+    public var lineBreakerEnabled = false
+    
     public override init()
     {
         super.init()
@@ -101,6 +104,8 @@ public class LineChartDataSet: LineRadarChartDataSet
     public var isDrawCubicEnabled: Bool { return drawCubicEnabled; }
     
     public var isDrawCircleHoleEnabled: Bool { return drawCircleHoleEnabled; }
+    
+    public var isLineBreakerEnabled: Bool { return lineBreakerEnabled; }
     
     // MARK: NSCopying
     

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -381,14 +381,15 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
                     }
                     CGContextSetStrokeColorWithColor(context, dataSet.colorAt(0).CGColor)
                     CGContextStrokeLineSegments(context, _lineSegments, secondValues)
-                
-                    // if drawing filled is enabled
-                    if (dataSet.isDrawFilledEnabled && entries.count > 0)
-                    {
-                        drawLinearFill(context: context, dataSet: dataSet, entries: entries, minx: minx, maxx: maxx, trans: trans)
-                    }
                 }
-           }
+            }
+            
+            // if drawing filled is enabled
+            if (dataSet.isDrawFilledEnabled && entries.count > 0)
+            {
+                drawLinearFill(context: context, dataSet: dataSet, entries: entries, minx: minx, maxx: maxx, trans: trans)
+            }
+
         }
     }
     

--- a/ChartsDemo/Classes/Demos/LineChart1ViewController.m
+++ b/ChartsDemo/Classes/Demos/LineChart1ViewController.m
@@ -16,11 +16,11 @@
 
 @interface LineChart1ViewController () <ChartViewDelegate>
 
-@property (nonatomic, strong) IBOutlet LineChartView *chartView;
-@property (nonatomic, strong) IBOutlet UISlider *sliderX;
-@property (nonatomic, strong) IBOutlet UISlider *sliderY;
-@property (nonatomic, strong) IBOutlet UITextField *sliderTextX;
-@property (nonatomic, strong) IBOutlet UITextField *sliderTextY;
+@property (nonatomic, strong) IBOutlet LineChartView* chartView;
+@property (nonatomic, strong) IBOutlet UISlider* sliderX;
+@property (nonatomic, strong) IBOutlet UISlider* sliderY;
+@property (nonatomic, strong) IBOutlet UITextField* sliderTextX;
+@property (nonatomic, strong) IBOutlet UITextField* sliderTextY;
 
 @end
 
@@ -29,77 +29,89 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     self.title = @"Line Chart 1 Chart";
-    
+
     self.options = @[
-                     @{@"key": @"toggleValues", @"label": @"Toggle Values"},
-                     @{@"key": @"toggleFilled", @"label": @"Toggle Filled"},
-                     @{@"key": @"toggleCircles", @"label": @"Toggle Circles"},
-                     @{@"key": @"toggleCubic", @"label": @"Toggle Cubic"},
-                     @{@"key": @"toggleHighlight", @"label": @"Toggle Highlight"},
-                     @{@"key": @"toggleStartZero", @"label": @"Toggle StartZero"},
-                     @{@"key": @"animateX", @"label": @"Animate X"},
-                     @{@"key": @"animateY", @"label": @"Animate Y"},
-                     @{@"key": @"animateXY", @"label": @"Animate XY"},
-                     @{@"key": @"saveToGallery", @"label": @"Save to Camera Roll"},
-                     @{@"key": @"togglePinchZoom", @"label": @"Toggle PinchZoom"},
-                     @{@"key": @"toggleAutoScaleMinMax", @"label": @"Toggle auto scale min/max"},
-                     ];
-    
+        @{ @"key" : @"toggleValues",
+            @"label" : @"Toggle Values" },
+        @{ @"key" : @"toggleFilled",
+            @"label" : @"Toggle Filled" },
+        @{ @"key" : @"toggleCircles",
+            @"label" : @"Toggle Circles" },
+        @{ @"key" : @"toggleCubic",
+            @"label" : @"Toggle Cubic" },
+        @{ @"key" : @"toggleHighlight",
+            @"label" : @"Toggle Highlight" },
+        @{ @"key" : @"toggleStartZero",
+            @"label" : @"Toggle StartZero" },
+        @{ @"key" : @"animateX",
+            @"label" : @"Animate X" },
+        @{ @"key" : @"animateY",
+            @"label" : @"Animate Y" },
+        @{ @"key" : @"animateXY",
+            @"label" : @"Animate XY" },
+        @{ @"key" : @"saveToGallery",
+            @"label" : @"Save to Camera Roll" },
+        @{ @"key" : @"togglePinchZoom",
+            @"label" : @"Toggle PinchZoom" },
+        @{ @"key" : @"toggleAutoScaleMinMax",
+            @"label" : @"Toggle auto scale min/max" },
+    ];
+
     _chartView.delegate = self;
-    
+
     _chartView.descriptionText = @"";
     _chartView.noDataTextDescription = @"You need to provide data for the chart.";
-    
+
     _chartView.dragEnabled = YES;
     [_chartView setScaleEnabled:YES];
     _chartView.pinchZoomEnabled = YES;
     _chartView.drawGridBackgroundEnabled = NO;
 
     // x-axis limit line
-    ChartLimitLine *llXAxis = [[ChartLimitLine alloc] initWithLimit:10.0 label:@"Index 10"];
+    ChartLimitLine* llXAxis = [[ChartLimitLine alloc] initWithLimit:10.0 label:@"Index 10"];
     llXAxis.lineWidth = 4.0;
-    llXAxis.lineDashLengths = @[@(10.f), @(10.f), @(0.f)];
+    llXAxis.lineDashLengths = @[ @(10.f), @(10.f), @(0.f) ];
     llXAxis.labelPosition = ChartLimitLabelPositionRightBottom;
     llXAxis.valueFont = [UIFont systemFontOfSize:10.f];
-    
+
     [_chartView.xAxis addLimitLine:llXAxis];
-    
-    ChartLimitLine *ll1 = [[ChartLimitLine alloc] initWithLimit:130.0 label:@"Upper Limit"];
+
+    ChartLimitLine* ll1 = [[ChartLimitLine alloc] initWithLimit:130.0 label:@"Upper Limit"];
     ll1.lineWidth = 4.0;
-    ll1.lineDashLengths = @[@5.f, @5.f];
+    ll1.lineDashLengths = @[ @5.f, @5.f ];
     ll1.labelPosition = ChartLimitLabelPositionRightTop;
     ll1.valueFont = [UIFont systemFontOfSize:10.0];
-    
-    ChartLimitLine *ll2 = [[ChartLimitLine alloc] initWithLimit:-30.0 label:@"Lower Limit"];
+
+    ChartLimitLine* ll2 = [[ChartLimitLine alloc] initWithLimit:-30.0 label:@"Lower Limit"];
     ll2.lineWidth = 4.0;
-    ll2.lineDashLengths = @[@5.f, @5.f];
+    ll2.lineDashLengths = @[ @5.f, @5.f ];
     ll2.labelPosition = ChartLimitLabelPositionRightBottom;
     ll2.valueFont = [UIFont systemFontOfSize:10.0];
-    
-    ChartYAxis *leftAxis = _chartView.leftAxis;
+
+    ChartYAxis* leftAxis = _chartView.leftAxis;
     [leftAxis removeAllLimitLines];
     [leftAxis addLimitLine:ll1];
     [leftAxis addLimitLine:ll2];
     leftAxis.customAxisMax = 220.0;
     leftAxis.customAxisMin = -50.0;
     leftAxis.startAtZeroEnabled = NO;
-    leftAxis.gridLineDashLengths = @[@5.f, @5.f];
+    leftAxis.gridLineDashLengths = @[ @5.f, @5.f ];
     leftAxis.drawLimitLinesBehindDataEnabled = YES;
-    
+
     _chartView.rightAxis.enabled = NO;
-    
-    BalloonMarker *marker = [[BalloonMarker alloc] initWithColor:[UIColor colorWithWhite:180/255. alpha:1.0] font:[UIFont systemFontOfSize:12.0] insets: UIEdgeInsetsMake(8.0, 8.0, 20.0, 8.0)];
+
+    BalloonMarker* marker = [[BalloonMarker alloc] initWithColor:[UIColor colorWithWhite:180 / 255. alpha:1.0] font:[UIFont systemFontOfSize:12.0] insets:UIEdgeInsetsMake(8.0, 8.0, 20.0, 8.0)];
     marker.minimumSize = CGSizeMake(80.f, 40.f);
     _chartView.marker = marker;
-    
+
     _chartView.legend.form = ChartLegendFormLine;
-    
+
     _sliderX.value = 44.0;
     _sliderY.value = 100.0;
     [self slidersValueChanged:nil];
-    
+
     [_chartView animateWithXAxisDuration:2.5 easingOption:ChartEasingOptionEaseInOutQuart];
 }
 
@@ -111,128 +123,143 @@
 
 - (void)setDataCount:(int)count range:(double)range
 {
-    NSMutableArray *xVals = [[NSMutableArray alloc] init];
-    
-    for (int i = 0; i < count; i++)
-    {
+    count = 10;
+    NSMutableArray* xVals = [[NSMutableArray alloc] init];
+
+    for (int i = 0; i < count + 5; i++) {
         [xVals addObject:[@(i) stringValue]];
     }
-    
-    NSMutableArray *yVals = [[NSMutableArray alloc] init];
-    
-    for (int i = 0; i < count; i++)
-    {
+
+    NSMutableArray* yVals = [[NSMutableArray alloc] init];
+
+    for (int i = 0; i < count; i++) {
+        NSLog(@"%d", i);
         double mult = (range + 1);
-        double val = (double) (arc4random_uniform(mult)) + 3;
+        double val = (double)(arc4random_uniform(mult)) + 3;
         [yVals addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:i]];
     }
-    
-    LineChartDataSet *set1 = [[LineChartDataSet alloc] initWithYVals:yVals label:@"DataSet 1"];
-    
-    set1.lineDashLengths = @[@5.f, @2.5f];
+
+    //[yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:10]];
+    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:11]];
+    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:12]];
+    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:13]];
+    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:14]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:5]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:6]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:7]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:8]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:9]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:10]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:11]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:12]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:13]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:14]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:15]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:16]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:17]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:18]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:19]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:20]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:21]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:22]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:23]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:24]];
+    ////    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:25]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:26]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:27]];
+    //    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:28]];
+
+    LineChartDataSet* set1 = [[LineChartDataSet alloc] initWithYVals:yVals label:@"DataSet 1"];
+
+    set1.lineDashLengths = @[ @5.f, @2.5f ];
     [set1 setColor:UIColor.blackColor];
     [set1 setCircleColor:UIColor.blackColor];
     set1.lineWidth = 1.0;
     set1.circleRadius = 3.0;
     set1.drawCircleHoleEnabled = NO;
     set1.valueFont = [UIFont systemFontOfSize:9.f];
-    set1.fillAlpha = 65/255.0;
+    set1.fillAlpha = 65 / 255.0;
     set1.fillColor = UIColor.blackColor;
-    
-    NSMutableArray *dataSets = [[NSMutableArray alloc] init];
+    set1.lineBreakerEnabled = YES;
+
+    NSMutableArray* dataSets = [[NSMutableArray alloc] init];
     [dataSets addObject:set1];
-    
-    LineChartData *data = [[LineChartData alloc] initWithXVals:xVals dataSets:dataSets];
-    
+
+    LineChartData* data = [[LineChartData alloc] initWithXVals:xVals dataSets:dataSets];
+
     _chartView.data = data;
 }
 
-- (void)optionTapped:(NSString *)key
+- (void)optionTapped:(NSString*)key
 {
-    if ([key isEqualToString:@"toggleValues"])
-    {
-        for (ChartDataSet *set in _chartView.data.dataSets)
-        {
+    if ([key isEqualToString:@"toggleValues"]) {
+        for (ChartDataSet* set in _chartView.data.dataSets) {
             set.drawValuesEnabled = !set.isDrawValuesEnabled;
         }
-        
+
         [_chartView setNeedsDisplay];
     }
-    
-    if ([key isEqualToString:@"toggleFilled"])
-    {
-        for (LineChartDataSet *set in _chartView.data.dataSets)
-        {
+
+    if ([key isEqualToString:@"toggleFilled"]) {
+        for (LineChartDataSet* set in _chartView.data.dataSets) {
             set.drawFilledEnabled = !set.isDrawFilledEnabled;
         }
-        
+
         [_chartView setNeedsDisplay];
     }
-    
-    if ([key isEqualToString:@"toggleCircles"])
-    {
-        for (LineChartDataSet *set in _chartView.data.dataSets)
-        {
+
+    if ([key isEqualToString:@"toggleCircles"]) {
+        for (LineChartDataSet* set in _chartView.data.dataSets) {
             set.drawCirclesEnabled = !set.isDrawCirclesEnabled;
         }
-        
+
         [_chartView setNeedsDisplay];
     }
-    
-    if ([key isEqualToString:@"toggleCubic"])
-    {
-        for (LineChartDataSet *set in _chartView.data.dataSets)
-        {
+
+    if ([key isEqualToString:@"toggleCubic"]) {
+        for (LineChartDataSet* set in _chartView.data.dataSets) {
             set.drawCubicEnabled = !set.isDrawCubicEnabled;
         }
-        
+
         [_chartView setNeedsDisplay];
     }
-    
-    if ([key isEqualToString:@"toggleHighlight"])
-    {
+
+    if ([key isEqualToString:@"toggleHighlight"]) {
         _chartView.highlightEnabled = !_chartView.isHighlightEnabled;
-        
+
         [_chartView setNeedsDisplay];
     }
-    
-    if ([key isEqualToString:@"toggleStartZero"])
-    {
+
+    if ([key isEqualToString:@"toggleStartZero"]) {
         _chartView.leftAxis.startAtZeroEnabled = !_chartView.leftAxis.isStartAtZeroEnabled;
         _chartView.rightAxis.startAtZeroEnabled = !_chartView.rightAxis.isStartAtZeroEnabled;
-        
+
         [_chartView notifyDataSetChanged];
     }
-    
-    if ([key isEqualToString:@"animateX"])
-    {
+
+    if ([key isEqualToString:@"animateX"]) {
         [_chartView animateWithXAxisDuration:3.0];
     }
-    
-    if ([key isEqualToString:@"animateY"])
-    {
+
+    if ([key isEqualToString:@"animateY"]) {
         [_chartView animateWithYAxisDuration:3.0 easingOption:ChartEasingOptionEaseInCubic];
     }
-    
-    if ([key isEqualToString:@"animateXY"])
-    {
+
+    if ([key isEqualToString:@"animateXY"]) {
         [_chartView animateWithXAxisDuration:3.0 yAxisDuration:3.0];
     }
-    
-    if ([key isEqualToString:@"saveToGallery"])
-    {
+
+    if ([key isEqualToString:@"saveToGallery"]) {
         [_chartView saveToCameraRoll];
     }
-    
-    if ([key isEqualToString:@"togglePinchZoom"])
-    {
+
+    if ([key isEqualToString:@"togglePinchZoom"]) {
         _chartView.pinchZoomEnabled = !_chartView.isPinchZoomEnabled;
-        
+
         [_chartView setNeedsDisplay];
     }
-    
-    if ([key isEqualToString:@"toggleAutoScaleMinMax"])
-    {
+
+    if ([key isEqualToString:@"toggleAutoScaleMinMax"]) {
         _chartView.autoScaleMinMaxEnabled = !_chartView.isAutoScaleMinMaxEnabled;
         [_chartView notifyDataSetChanged];
     }
@@ -244,18 +271,18 @@
 {
     _sliderTextX.text = [@((int)_sliderX.value + 1) stringValue];
     _sliderTextY.text = [@((int)_sliderY.value) stringValue];
-    
-    [self setDataCount:(_sliderX.value + 1) range:_sliderY.value];
+
+    [self setDataCount:(_sliderX.value + 1)range:_sliderY.value];
 }
 
 #pragma mark - ChartViewDelegate
 
-- (void)chartValueSelected:(ChartViewBase * __nonnull)chartView entry:(ChartDataEntry * __nonnull)entry dataSetIndex:(NSInteger)dataSetIndex highlight:(ChartHighlight * __nonnull)highlight
+- (void)chartValueSelected:(ChartViewBase* __nonnull)chartView entry:(ChartDataEntry* __nonnull)entry dataSetIndex:(NSInteger)dataSetIndex highlight:(ChartHighlight* __nonnull)highlight
 {
     NSLog(@"chartValueSelected");
 }
 
-- (void)chartValueNothingSelected:(ChartViewBase * __nonnull)chartView
+- (void)chartValueNothingSelected:(ChartViewBase* __nonnull)chartView
 {
     NSLog(@"chartValueNothingSelected");
 }


### PR DESCRIPTION
To enable this feature needs to set lineBreakerEnabled on lineDataSet.

With this we can have break lines, the only thing we need to do is to jump a index.

For ex:
    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:1]];
    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:2]];
    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:4]];
    [yVals addObject:[[ChartDataEntry alloc] initWithValue:5 xIndex:5]];

I change the first line char example have some example. (This alteration need to be deleted).

I made this pull request to have yours opinion, if you like like it was I go to clean the code.
