### PR TITLE
Fix default value of forceLabelsEnabled

### DIFF
--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -54,7 +54,7 @@ public class ChartYAxis: ChartAxisBase
     public var startAtZeroEnabled = true
     
     /// if true, the set number of y-labels will be forced
-    public var forceLabelsEnabled = true
+    public var forceLabelsEnabled = false
 
     /// the formatter used to customly format the y-labels
     public var valueFormatter: NSNumberFormatter?


### PR DESCRIPTION
I believe the default value should be `false`. It's [false on Android version of the library](https://github.com/PhilJay/MPAndroidChart/blob/2e6bfeb87e2bb0a02fb6350b96a454d77f7c088b/MPChartLib/src/com/github/mikephil/charting/components/YAxis.java#L47). Also I've noticed documentation for `isForceLabelsEnabled` [says](https://github.com/danielgindi/ios-charts/blob/0f33d9fc1e06b0d3685539f3bea5d61bc63000ba/Charts/Classes/Components/ChartYAxis.swift#L238) it's false by default as well.

---

Without the fix:
![without](https://cloud.githubusercontent.com/assets/217368/9863703/2c313fd4-5af7-11e5-98cb-52fb70f5f153.png)

With the fix:
![with fix](https://cloud.githubusercontent.com/assets/217368/9863709/380e9ae0-5af7-11e5-9574-f084d46f7f29.png)

Note that the values on y axis are nicely calculated.

As a temp workaround fix we can do in our code:

```objective-c
self.chartView.leftAxis.labelCount = self.chartView.leftAxis.labelCount;
```
