### PR TITLE
Allow graphs with a single axis

### DIFF
--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -138,9 +138,9 @@ public class ChartYAxis: ChartAxisBase
         {
             _labelCount = 25
         }
-        if (_labelCount < 2)
+        if (_labelCount < max(1, Int(self.customAxisMin)))
         {
-            _labelCount = 2
+            _labelCount = max(1, Int(self.customAxisMin))
         }
     
         forceLabelsEnabled = force


### PR DESCRIPTION
This allows for the following graph:

<img width="527" alt="screenshot 2015-09-14 17 21 48" src="https://cloud.githubusercontent.com/assets/54970/9865026/4c8501ea-5b05-11e5-829e-42a323102e90.png">

As opposed to the current behavior, which results in this:

<img width="535" alt="screenshot 2015-09-14 17 24 10" src="https://cloud.githubusercontent.com/assets/54970/9865031/6c994806-5b05-11e5-9ebd-a1ba1675bc0b.png">

Which I do not want, since the values in this case are always integral.
