### PR TITLE
be explicit on how to install 'Charts' when using CocoaPods since

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ If you want to compile for iOS 7:
 1. Drag the code itself (.swift files) to your project. As sadly, Swift currently does not support compiling Frameworks for iOS 7.
 2. Make sure that the files are added to the Target membership.
 
+## CocoaPods Install
+
+Add `Pod 'Charts'` to your Podfile. Adding `Pod 'ios-charts'` will not work!!
+
 ## Help
 
 If you like what you see here, and want to support the work being done in this repository, you could:


### PR DESCRIPTION
I noticed many people were confused as how to use CocoaPods to install the framework (myself included). I accidentally added the 'ios-charts' pod instead of 'Charts' and spent 10 minutes trying to figure out why it wasn't working. I think a blurb would help many people out.

It's possible it was a contributing factor to these guys having an issue: #277 #283 #289 (mentioning CocoaPods.org having issues) and definitely the reason #47