### PR TITLE
Start of pan gesture should not be cancelled by no drag

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -756,8 +756,10 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                 _closestDataSetToTouch = getDataSetByTouchPoint(recognizer.locationOfTouch(0, inView: self))
                 
                 let translation = recognizer.translationInView(self)
+                let didUserDrag = (self is HorizontalBarChartView) ? translation.y != 0.0 : translation.x != 0.0 
                 
-                if (!performPanChange(translation: translation))
+                // Check to see if user dragged at all and if so, can the chart be dragged by the given amount
+                if (didUserDrag && !performPanChange(translation: translation))
                 {
                     if (_outerScrollView !== nil)
                     {


### PR DESCRIPTION
When checking for the start of a pan, the pan should not be cancelled when the recognizer's translationInView returns 0 in the direction of scrolling. Seems the iPad more easily returns a zero value in the beginning causing the drag to get cancelled immediately even though the actual drag hasn't started because performPanChange() thinks the chart can't be scrolled anymore. So check to see if the drag has vaules that are not actually 0 before calling performPanChange() to prevent immediate pan cancels.