### PR TITLE
Make the ChartXAxisRenderer more flexible: now possible to overwrite drawing the line or label of the ChartLimitLine

### DIFF
--- a/Charts/Classes/Renderers/ChartAxisRendererBase.swift
+++ b/Charts/Classes/Renderers/ChartAxisRendererBase.swift
@@ -16,7 +16,7 @@ import UIKit
 
 public class ChartAxisRendererBase: ChartRendererBase
 {
-    internal var transformer: ChartTransformer!
+    public var transformer: ChartTransformer!
     
     public override init()
     {

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -295,7 +295,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
     }
     
-    public func renderLimitLineLabel(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint) {
+    public func renderLimitLineLabel(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint, yOffset: CGFloat = 2.0) {
         
         let label = limitLine.label
         
@@ -304,9 +304,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         {
             let labelLineHeight = limitLine.valueFont.lineHeight
             
-            let add = CGFloat(4.0)
             let xOffset: CGFloat = limitLine.lineWidth
-            let yOffset: CGFloat = add / 2.0
             
             if (limitLine.labelPosition == .RightTop)
             {

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -272,10 +272,6 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     public func renderLimitLineLine(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint) {
         
-        guard let context = context else {
-            return
-        }
-        
         _limitLineSegmentsBuffer[0].x = position.x
         _limitLineSegmentsBuffer[0].y = viewPortHandler.contentTop
         _limitLineSegmentsBuffer[1].x = position.x

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -262,7 +262,6 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
             
             renderLimitLineLine(context: context, limitLine: l, position: position)
             renderLimitLineLabel(context: context, limitLine: l, position: position)
-            
         }
         
         CGContextRestoreGState(context)
@@ -270,8 +269,8 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
     
     private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
     
-    public func renderLimitLineLine(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint) {
-        
+    public func renderLimitLineLine(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint)
+    {
         _limitLineSegmentsBuffer[0].x = position.x
         _limitLineSegmentsBuffer[0].y = viewPortHandler.contentTop
         _limitLineSegmentsBuffer[1].x = position.x
@@ -291,8 +290,8 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
     }
     
-    public func renderLimitLineLabel(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint, yOffset: CGFloat = 2.0) {
-        
+    public func renderLimitLineLabel(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint, yOffset: CGFloat = 2.0)
+    {
         let label = limitLine.label
         
         // if drawing the limit-value label is enabled
@@ -344,7 +343,5 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
             }
         }
     }
-    
+
 }
-
-

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -237,8 +237,6 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         CGContextRestoreGState(context)
     }
     
-    private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
-    
     public override func renderLimitLines(context context: CGContext?)
     {
         var limitLines = _xAxis.limitLines
@@ -257,83 +255,102 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         for (var i = 0; i < limitLines.count; i++)
         {
             let l = limitLines[i]
-            
+         
             position.x = CGFloat(l.limit)
             position.y = 0.0
             position = CGPointApplyAffineTransform(position, trans)
             
-            _limitLineSegmentsBuffer[0].x = position.x
-            _limitLineSegmentsBuffer[0].y = viewPortHandler.contentTop
-            _limitLineSegmentsBuffer[1].x = position.x
-            _limitLineSegmentsBuffer[1].y = viewPortHandler.contentBottom
+            renderLimitLineLine(context: context, limitLine: l, position: position)
+            renderLimitLineLabel(context: context, limitLine: l, position: position)
             
-            CGContextSetStrokeColorWithColor(context, l.lineColor.CGColor)
-            CGContextSetLineWidth(context, l.lineWidth)
-            if (l.lineDashLengths != nil)
-            {
-                CGContextSetLineDash(context, l.lineDashPhase, l.lineDashLengths!, l.lineDashLengths!.count)
-            }
-            else
-            {
-                CGContextSetLineDash(context, 0.0, nil, 0)
-            }
-            
-            CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
-            
-            let label = l.label
-            
-            // if drawing the limit-value label is enabled
-            if (label.characters.count > 0)
-            {
-                let labelLineHeight = l.valueFont.lineHeight
-                
-                let add = CGFloat(4.0)
-                let xOffset: CGFloat = l.lineWidth
-                let yOffset: CGFloat = add / 2.0
-                
-                if (l.labelPosition == .RightTop)
-                {
-                    ChartUtils.drawText(context: context,
-                        text: label,
-                        point: CGPoint(
-                            x: position.x + xOffset,
-                            y: viewPortHandler.contentTop + yOffset),
-                        align: .Left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
-                }
-                else if (l.labelPosition == .RightBottom)
-                {
-                    ChartUtils.drawText(context: context,
-                        text: label,
-                        point: CGPoint(
-                            x: position.x + xOffset,
-                            y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
-                        align: .Left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
-                }
-                else if (l.labelPosition == .LeftTop)
-                {
-                    ChartUtils.drawText(context: context,
-                        text: label,
-                        point: CGPoint(
-                            x: position.x - xOffset,
-                            y: viewPortHandler.contentTop + yOffset),
-                        align: .Right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
-                }
-                else
-                {
-                    ChartUtils.drawText(context: context,
-                        text: label,
-                        point: CGPoint(
-                            x: position.x - xOffset,
-                            y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
-                        align: .Right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
-                }
-            }
         }
         
         CGContextRestoreGState(context)
     }
+    
+    private var _limitLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
+    
+    public func renderLimitLineLine(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint) {
+        
+        guard let context = context else {
+            return
+        }
+        
+        _limitLineSegmentsBuffer[0].x = position.x
+        _limitLineSegmentsBuffer[0].y = viewPortHandler.contentTop
+        _limitLineSegmentsBuffer[1].x = position.x
+        _limitLineSegmentsBuffer[1].y = viewPortHandler.contentBottom
+        
+        CGContextSetStrokeColorWithColor(context, limitLine.lineColor.CGColor)
+        CGContextSetLineWidth(context, limitLine.lineWidth)
+        if (limitLine.lineDashLengths != nil)
+        {
+            CGContextSetLineDash(context, limitLine.lineDashPhase, limitLine.lineDashLengths!, limitLine.lineDashLengths!.count)
+        }
+        else
+        {
+            CGContextSetLineDash(context, 0.0, nil, 0)
+        }
+        
+        CGContextStrokeLineSegments(context, _limitLineSegmentsBuffer, 2)
+    }
+    
+    public func renderLimitLineLabel(context context: CGContext?, limitLine: ChartLimitLine, position: CGPoint) {
+        
+        let label = limitLine.label
+        
+        // if drawing the limit-value label is enabled
+        if (label.characters.count > 0)
+        {
+            let labelLineHeight = limitLine.valueFont.lineHeight
+            
+            let add = CGFloat(4.0)
+            let xOffset: CGFloat = limitLine.lineWidth
+            let yOffset: CGFloat = add / 2.0
+            
+            if (limitLine.labelPosition == .RightTop)
+            {
+                ChartUtils.drawText(context: context,
+                    text: label,
+                    point: CGPoint(
+                        x: position.x + xOffset,
+                        y: viewPortHandler.contentTop + yOffset),
+                    align: .Left,
+                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+            }
+            else if (limitLine.labelPosition == .RightBottom)
+            {
+                ChartUtils.drawText(context: context,
+                    text: label,
+                    point: CGPoint(
+                        x: position.x + xOffset,
+                        y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
+                    align: .Left,
+                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+            }
+            else if (limitLine.labelPosition == .LeftTop)
+            {
+                ChartUtils.drawText(context: context,
+                    text: label,
+                    point: CGPoint(
+                        x: position.x - xOffset,
+                        y: viewPortHandler.contentTop + yOffset),
+                    align: .Right,
+                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+            }
+            else
+            {
+                ChartUtils.drawText(context: context,
+                    text: label,
+                    point: CGPoint(
+                        x: position.x - xOffset,
+                        y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
+                    align: .Right,
+                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+            }
+        }
+    }
+    
 }
+
+

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -16,7 +16,7 @@ import Foundation
 import UIKit
 import Darwin
 
-internal class ChartUtils
+public class ChartUtils
 {
     internal struct Math
     {
@@ -118,7 +118,7 @@ internal class ChartUtils
         )
     }
     
-    internal class func drawText(context context: CGContext?, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
+    public class func drawText(context context: CGContext?, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
     {
         if (align == .Center)
         {


### PR DESCRIPTION
Hi Daniel,

I have done a few refactorings of the ChartXAxisRenderer that allow the following:
- Now possible to extend the renderer and overwrite selectively the label or line drawing method for a ChartLimitLine (in my project I needed e.g. to draw a triangle as arrow at the top in one case or a short line at the bottom as well as change the label offset, now easily possible)
- Functionally does the same as before
- I have eased the visibility of ChartAxisRendererBase#transformer (easier syntax when extending ChartXAxisRenderer) and ChartUtils#drawText (possible to call the method from the ChartXAxisRenderer extension).

Thanks!
Cheers,
Patrick