### PR TITLE
Only alow scaling further if the user can still zoom (Fixes #437)

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -726,9 +726,9 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
             let isZoomingOut = (recognizer.scale < 1)
             let canZoomMoreX = isZoomingOut ? _viewPortHandler.canZoomOutMoreX : _viewPortHandler.canZoomInMoreX
             
-            if (_isScaling)
+            if (_isScaling && canZoomMoreX)
             {
-                if (canZoomMoreX || (_gestureScaleAxis == .Both || _gestureScaleAxis == .Y && _scaleYEnabled))
+                if (_gestureScaleAxis == .Both || _gestureScaleAxis == .Y && _scaleYEnabled)
                 {
                     var location = recognizer.locationInView(self)
                     location.x = location.x - _viewPortHandler.offsetLeft

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -725,8 +725,9 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
         {
             let isZoomingOut = (recognizer.scale < 1)
             let canZoomMoreX = isZoomingOut ? _viewPortHandler.canZoomOutMoreX : _viewPortHandler.canZoomInMoreX
+            let canZoomMoreY = isZoomingOut ? _viewPortHandler.canZoomOutMoreY : _viewPortHandler.canZoomInMoreY
             
-            if (_isScaling && canZoomMoreX)
+            if (_isScaling && canZoomMoreX && canZoomMoreY)
             {
                 if (_gestureScaleAxis == .Both || _gestureScaleAxis == .Y && _scaleYEnabled)
                 {

--- a/Charts/Classes/Utils/ChartViewPortHandler.swift
+++ b/Charts/Classes/Utils/ChartViewPortHandler.swift
@@ -457,4 +457,14 @@ public class ChartViewPortHandler: NSObject
     {
         return (_scaleX < _maxScaleX)
     }
+
+    public var canZoomOutMoreY: Bool
+    {
+        return (_scaleY > _minScaleY)
+    }
+    
+    public var canZoomInMoreY: Bool
+    {
+        return (_scaleY < _maxScaleY)
+    }
 }


### PR DESCRIPTION
Trying to fix issue when there's a maximum / minimum scale and the user tries to pinch the chart further, causing it to slide sideways.