### PR TITLE
Add ability to turn off antialias for grid lines

### DIFF
--- a/Charts/Classes/Components/ChartAxisBase.swift
+++ b/Charts/Classes/Components/ChartAxisBase.swift
@@ -51,6 +51,9 @@ public class ChartAxisBase: ChartComponentBase
     /// :default: false
     public var drawLimitLinesBehindDataEnabled = false
 
+    /// the flag can be used to turn off the antialias for grid lines
+    public var gridAntialiasEnabled = true
+
     public override init()
     {
         super.init()

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -195,7 +195,11 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         }
         
         CGContextSaveGState(context)
-        
+
+        if (!_xAxis.gridAntialiasEnabled) {
+            CGContextSetShouldAntialias(context, false)
+        }
+
         CGContextSetStrokeColorWithColor(context, _xAxis.gridColor.CGColor)
         CGContextSetLineWidth(context, _xAxis.gridLineWidth)
         if (_xAxis.gridLineDashLengths != nil)

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -244,7 +244,11 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         }
         
         CGContextSaveGState(context)
-        
+
+        if (!_yAxis.gridAntialiasEnabled) {
+            CGContextSetShouldAntialias(context, false)
+        }
+
         CGContextSetStrokeColorWithColor(context, _yAxis.gridColor.CGColor)
         CGContextSetLineWidth(context, _yAxis.gridLineWidth)
         if (_yAxis.gridLineDashLengths != nil)


### PR DESCRIPTION
Hi guys.
If the chart is too small the grid lines become blurred. Turning off antialias really helps.
Please take a look.