### PR TITLE
Refactor: move minOffset to ChartViewBase and assign it with 0 in PieRadarChartViewBase

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -44,9 +44,6 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     
     /// Sets drawing the borders rectangle to true. If this is enabled, there is no point drawing the axis-lines of x- and y-axis.
     public var drawBordersEnabled = false
-
-    /// Sets the minimum offset (padding) around the chart, defaults to 10
-    public var minOffset = CGFloat(10.0)
     
     /// the object representing the labels on the y-axis, this object is prepared
     /// in the pepareYLabels() method

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -113,6 +113,9 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     
     private var _interceptTouchEvents = false
     
+    /// Sets the minimum offset (padding) around the chart, defaults to 10
+    public var minOffset = CGFloat(10.0)
+    
     /// An extra offset to be appended to the viewport's top
     public var extraTopOffset: CGFloat = 0.0
     

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -26,9 +26,6 @@ public class PieRadarChartViewBase: ChartViewBase
     
     /// flag that indicates if rotation is enabled or not
     public var rotationEnabled = true
-    
-    /// Sets the minimum offset (padding) around the chart, defaults to 0.0
-    public var minOffset = CGFloat(0.0)
 
     private var _rotationWithTwoFingers = false
     
@@ -55,6 +52,8 @@ public class PieRadarChartViewBase: ChartViewBase
     internal override func initialize()
     {
         super.initialize()
+        
+        minOffset = CGFloat(0.0)
         
         _tapGestureRecognizer = UITapGestureRecognizer(target: self, action: Selector("tapGestureRecognized:"))
         


### PR DESCRIPTION
I think it's better to put minOffset to ChartViewBase. It's a fundamental property for all chart views
Just assign 0 for PieRadarChartViewBase in initialize()