### PR TITLE
BUGFIX:fix xAxis labels of bar chart

### DIFF
--- a/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
@@ -92,7 +92,7 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
                     else if (i == 0)
                     { // avoid clipping of the first
                         let width = label!.sizeWithAttributes(labelAttrs).width
-                        position.x += width / 2.0
+                        position.x = viewPortHandler.offsetLeft + (width / 2.0)
                     }
                 }
                 


### PR DESCRIPTION
code review

For bar chart view,```position.x``` of the first label is located horizontally at center of first bar group,and this will lead wrong display.
