### PR TITLE
if only line data exists and no other data, turn _deltaX to 1.0

### DIFF
--- a/Charts/Classes/Charts/CombinedChartView.swift
+++ b/Charts/Classes/Charts/CombinedChartView.swift
@@ -74,6 +74,10 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
 
             _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
         }
+        if (_deltaX == 0.0 && self.lineData?.yValCount > 0)
+        {
+            _deltaX = 1.0
+        }
     }
     
     public override var data: ChartData?


### PR DESCRIPTION
if only line data exists and no other data in combined chart, turn _deltaX to 1.0, just like what LineChartView did

This is for https://github.com/danielgindi/ios-charts/issues/329 and what @jwardle asked in my PR #269