### PR TITLE
Fixed drag offset panning bug

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -928,7 +928,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         
         if (gestureRecognizer == _panGestureRecognizer)
         {
-            if (_dataNotSet || !_dragEnabled || !self.hasNoDragOffset ||
+            if (_dataNotSet || !_dragEnabled || self.hasNoDragOffset ||
                 (self.isFullyZoomedOut && !self.isHighlightPerDragEnabled))
             {
                 return false


### PR DESCRIPTION
Fixed a bug where panning was disabled in BarLineChart if a drag offset
was set

Could also be merged manually since it is only one line/“!”