### PR TITLE
fix highlight while panning at default scale Fix issue #520

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -763,8 +763,8 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         {
             stopDeceleration()
             
-            if !_dataNotSet && _dragEnabled &&
-                (!self.hasNoDragOffset || !self.isFullyZoomedOut || self.isHighlightPerDragEnabled)
+            if !_dataNotSet && _dragEnabled && self.isHighlightPerDragEnabled &&
+                (!self.hasNoDragOffset || !self.isFullyZoomedOut)
             {
                 _isDragging = true
                 


### PR DESCRIPTION
For issue #520:
self.isHighlightPerDragEnabled is making the whole if condition true in old code, so will lead to _isDragging = true

Correct me if I missed anything or misunderstood