### PR TITLE
round the float value before we cast to Int

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1708,7 +1708,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         var pt = CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentBottom)
         getTransformer(.Left).pixelToValue(&pt)
-        return (pt.x <= 0.0) ? 0 : Int(pt.x + 1.0)
+        return (pt.x <= 0.0) ? 0 : Int(round(pt.x + 1.0))
     }
     
     /// - returns: the highest x-index (value on the x-axis) that is still visible on the chart.
@@ -1716,7 +1716,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         var pt = CGPoint(x: viewPortHandler.contentRight, y: viewPortHandler.contentBottom)
         getTransformer(.Left).pixelToValue(&pt)
-        return (_data != nil && Int(pt.x) >= _data.xValCount) ? _data.xValCount - 1 : Int(pt.x)
+        return (_data != nil && Int(round(pt.x)) >= _data.xValCount) ? _data.xValCount - 1 : Int(round(pt.x))
     }
 }
 


### PR DESCRIPTION
Old code will cause the visible index incorrect, smaller by 1.

Int() simply cuts the fractional part, which usually isn't the desired behaviour ;) Int(round(f)) does the job

I met this when that the last label should be year 2015, but it actually shows 2014. It turned out that pt.x is 3.9999999999999987, and Int(pt.x) is 3

More information about the casting can be found here:http://stackoverflow.com/questions/24029917/convert-float-to-int-in-swift