### PR TITLE
add the ability to choose whether to clip the chart when rendering

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -185,9 +185,8 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
             }
         }
         
-        // make sure the graph values and grid cannot be drawn outside the content-rect
+        // make sure the limit lines and grid lines and grid cannot be drawn outside the content-rect
         CGContextSaveGState(context)
-
         CGContextClipToRect(context, _viewPortHandler.contentRect)
         
         if (_xAxis.isDrawLimitLinesBehindDataEnabled)
@@ -207,7 +206,30 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         _leftYAxisRenderer?.renderGridLines(context: context)
         _rightYAxisRenderer?.renderGridLines(context: context)
         
+        CGContextRestoreGState(context)
+        
+        // push another context make sure the graph values and highlight cannot be drawn outside the content-rect if needs to clip
+        if (clipChartToRect)
+        {
+            CGContextSaveGState(context)
+            CGContextClipToRect(context, _viewPortHandler.contentRect)
+        }
+        
         renderer?.drawData(context: context)
+        
+        // if highlighting is enabled
+        if (valuesToHighlight())
+        {
+            renderer?.drawHighlighted(context: context, indices: _indicesToHighlight)
+        }
+        
+        if (clipChartToRect)
+        {
+            CGContextRestoreGState(context)
+        }
+        
+        CGContextSaveGState(context)
+        CGContextClipToRect(context, _viewPortHandler.contentRect)
         
         if (!_xAxis.isDrawLimitLinesBehindDataEnabled)
         {
@@ -221,13 +243,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         {
             _rightYAxisRenderer?.renderLimitLines(context: context)
         }
-
-        // if highlighting is enabled
-        if (valuesToHighlight())
-        {
-            renderer?.drawHighlighted(context: context, indices: _indicesToHighlight)
-        }
-
+        
         // Removes clipping rectangle
         CGContextRestoreGState(context)
         

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -73,6 +73,9 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     /// description text that appears in the bottom right corner of the chart
     public var descriptionText = "Description"
     
+    /// flag that indicates if we need to clip the rect when rendering chart
+    public var clipChartToRect = true
+    
     /// flag that indicates if the chart has been fed with data yet
     internal var _dataNotSet = true
     


### PR DESCRIPTION
Kind of feeling we will need the ability to choose whether to clip the contentRect.

Currently we will clip the contentRect, but sometimes, if the user customize the highlight shape, or have bigger shape close to the boundary, it will be cut.

The default is to clip as current implementation.