### PR TITLE
Fixes a crash caused by NaNs in CombinedChartView with empty data set

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1716,6 +1716,9 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         var pt = CGPoint(x: viewPortHandler.contentRight, y: viewPortHandler.contentBottom)
         getTransformer(.Left).pixelToValue(&pt)
+        
+        if (isnan(pt.x)) { return 0 }
+        
         return (_data != nil && Int(round(pt.x)) >= _data.xValCount) ? _data.xValCount - 1 : Int(round(pt.x))
     }
 }

--- a/Charts/Classes/Highlight/ChartHighlighter.swift
+++ b/Charts/Classes/Highlight/ChartHighlighter.swift
@@ -57,6 +57,8 @@ internal class ChartHighlighter
         // take any transformer to determine the x-axis value
         _chart?.getTransformer(ChartYAxis.AxisDependency.Left).pixelToValue(&pt)
         
+        if (isnan(pt.x)) { return 0 }
+        
         return Int(round(pt.x))
     }
     


### PR DESCRIPTION
Fixes a crash caused by NaNs in CombinedChartView when an empty dataset is passed in.

Also fixes a simlar NaN-related crash when such a chart is touched.

A minimal view controller to reproduce is:

```
import UIKit
import Charts

class InformationViewController: UIViewController {
    @IBOutlet weak var chartView: CombinedChartView!

    override func viewDidLoad() {
        let xAxisData = [NSDate]()
        let bar1Data = BarChartDataSet(yVals: [BarChartDataEntry]())
        let bar2Data = BarChartDataSet(yVals: [BarChartDataEntry]())

        chartView.xAxis.labelPosition = .Bottom
        chartView.descriptionText = ""
        chartView.animate(xAxisDuration: 0.5, yAxisDuration: 1.0)

        let combinedData = CombinedChartData(xVals: xAxisData)
        combinedData.barData = BarChartData(xVals: xAxisData, dataSets: [bar1Data, bar2Data])

        chartView.data = combinedData
    }
}
```