### PR TITLE
Revert "Reduce to nil check only (Fixes #417)" because of #577

### DIFF
--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -191,7 +191,7 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
         }
         set
         {
-            if newValue == nil
+            if (newValue == nil || newValue?.yValCount == 0)
             {
                 print("Charts: data argument is nil on setData()", terminator: "\n")
                 return


### PR DESCRIPTION
We need to check if yValCount is 0, to prevent drawing.

This reverts commit 062a61bad10bef8c42cba13e2a28db911d4fdf79.