### PR TITLE
Remove useless parentheses causing swift build error

### DIFF
--- a/Charts/Classes/Animation/ChartAnimationEasing.swift
+++ b/Charts/Classes/Animation/ChartAnimationEasing.swift
@@ -341,7 +341,7 @@ internal struct EasingFunctions
         let s: NSTimeInterval = 1.70158
         var position: NSTimeInterval = elapsed / duration
         position--
-        return CGFloat( (position * position * ((s + 1.0) * position + s) + 1.0) )
+        return CGFloat( position * position * ((s + 1.0) * position + s) + 1.0 )
     }
     
     internal static let EaseInOutBack = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in


### PR DESCRIPTION
Error : ChartAnimationEasing.swift:345:16: Expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions