### PR TITLE
add highlight circle for radar chart

### DIFF
--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -37,6 +37,19 @@ public class RadarChartView: PieRadarChartViewBase
     /// flag indicating if the web lines should be drawn or not
     public var drawWeb = true
     
+    /// flag indicating if highlight circle should be drawn or not
+    public var drawHighlightCircle = true
+    
+    public var circleFillColor = UIColor.whiteColor()
+    
+    public var circleInnerRadius = CGFloat(3.0)
+    
+    public var circleOuterRadius = CGFloat(4.0)
+    
+    public var circleStrokeWidth = CGFloat(2.0)
+    
+    public var circleStrokeAlpha = CGFloat(0.3)
+    
     /// modulus that determines how many labels and web-lines are skipped before the next is drawn
     private var _skipWebLineCount = 0
     

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -281,7 +281,54 @@ public class RadarChartRenderer: LineScatterCandleRadarChartRenderer
             
             // draw the lines
             drawHighlightLines(context: context, point: _highlightPointBuffer, set: set)
+            
+            if (_chart.drawHighlightCircle)
+            {
+                let p = ChartUtils.getPosition(center: center, dist: CGFloat(y) * factor,
+                    angle: sliceangle * CGFloat(j) + _chart.rotationAngle)
+                
+                if (!p.x.isNaN && !p.y.isNaN)
+                {
+                    highlightDataDot(context: context, atPoint: p, innerRadius: _chart.circleInnerRadius, outerRadius: _chart.circleOuterRadius, fillColor: _chart.circleFillColor, strokeColor: set.colorAt(0), strokeWidth: _chart.circleStrokeWidth, strokeAlpha: _chart.circleStrokeAlpha)
+                }
+            }
         }
+        
+        CGContextRestoreGState(context)
+    }
+    
+    internal func highlightDataDot(context context:CGContext, atPoint point:CGPoint, innerRadius:CGFloat, outerRadius:CGFloat, fillColor:UIColor, strokeColor:UIColor, strokeWidth: CGFloat, strokeAlpha: CGFloat) {
+        // draw inner filled dot
+        let innerPath = CGPathCreateMutable()
+        
+        CGPathAddArc(innerPath, nil, CGFloat(point.x), CGFloat(point.y), innerRadius, CGFloat(0), CGFloat(M_PI*2), true)
+        CGPathCloseSubpath(innerPath)
+        
+        CGContextSaveGState(context)
+        
+        CGContextSetFillColorWithColor(context, fillColor.CGColor)
+        CGContextSetAlpha(context, CGFloat(1.0))
+        
+        CGContextBeginPath(context)
+        CGContextAddPath(context, innerPath)
+        CGContextFillPath(context)
+        
+        CGContextRestoreGState(context)
+        
+        // draw outer stroke dot
+        let outerPath = CGPathCreateMutable()
+        CGPathAddArc(outerPath, nil, CGFloat(point.x), CGFloat(point.y), outerRadius, CGFloat(0), CGFloat(M_PI*2), true)
+        CGPathCloseSubpath(outerPath)
+        
+        CGContextSaveGState(context)
+        
+        CGContextSetStrokeColorWithColor(context, strokeColor.CGColor)
+        CGContextSetLineWidth(context, strokeWidth)
+        CGContextSetAlpha(context, strokeAlpha)
+        
+        CGContextBeginPath(context)
+        CGContextAddPath(context, outerPath)
+        CGContextStrokePath(context)
         
         CGContextRestoreGState(context)
     }


### PR DESCRIPTION
For #138 
Add highlight circle for radar chart. It combined an inner filled circle and an outer stroke circle. inner circle fill color, inner circle radius, outer circle radius, stroke width and alpha can be customised.

I notice `drawHighlightLines` is in `LineScatterCandleRadarChartRenderer` now, no longer in the radar chart renderer. I am not sure if draw highlight circle should be here.

Since there are several properties can be asked to customized, I create new properties for radar chart view. 

Let me know if we want to add more customizable properties or it's too many, as well as if the structure needs to be improved.