### PR TITLE
Use nil coalescing in ChartDataSet's entryCount (Fixes #631)

### DIFF
--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -153,7 +153,7 @@ public class ChartDataSet: NSObject
         return yValueSum / Double(valueCount)
     }
     
-    public var entryCount: Int { return _yVals!.count; }
+    public var entryCount: Int { return _yVals?.count ?? 0 }
     
     public func yValForXIndex(x: Int) -> Double
     {


### PR DESCRIPTION
The force unwrapping in entryCount caused a crash when yVals was nil. Now entryCount returns 0.

#631