### PR TITLE
Added a way to change circle hole line width on Line charts.

### DIFF
--- a/Charts/Classes/Data/LineChartDataSet.swift
+++ b/Charts/Classes/Data/LineChartDataSet.swift
@@ -20,6 +20,7 @@ public class LineChartDataSet: LineRadarChartDataSet
     public var circleColors = [UIColor]()
     public var circleHoleColor = UIColor.whiteColor()
     public var circleRadius = CGFloat(8.0)
+    public var circleLineWidth = CGFloat(4.0)
     
     private var _cubicIntensity = CGFloat(0.2)
     

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -487,7 +487,7 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
             
             let circleRadius = dataSet.circleRadius
             let circleDiameter = circleRadius * 2.0
-            let circleHoleDiameter = circleRadius
+            let circleHoleDiameter = circleDiameter - dataSet.circleLineWidth
             let circleHoleRadius = circleHoleDiameter / 2.0
             let isDrawCircleHoleEnabled = dataSet.isDrawCircleHoleEnabled
             


### PR DESCRIPTION
I didn't see any way to modify the width of the circles in the line chart. This is my initial attempt at it. The current method performs a calculation halving the circle diameter. Right now I hard coded it to be the same value for the default radius, but it will look different for current implementations if they use this. 

Needs invalid value checks and maybe a calculation to match previous look of halving diameter.