### PR TITLE
remove getSelectionDetailsAtIndex in PieRadarChartViewBase chartXMin, seems not relevant

### DIFF
--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -368,7 +368,6 @@ public class PieRadarChartViewBase: ChartViewBase
     
     public override var chartXMin: Double
     {
-        getSelectionDetailsAtIndex(1);
         return 0.0
     }
     


### PR DESCRIPTION
I am having some time to upgrade my library, I see getSelectionDetailsAtIndex is called in chartXMin, but seems it has nothing to do with it. Correct me if I am wrong.
@danielgindi needs your review carefully. I assume no properties are changed after  calling getSelectionDetailsAtIndex