### PR TITLE
add an option to hide/show legends

### DIFF
--- a/Charts/Charts.xcodeproj/project.pbxproj
+++ b/Charts/Charts.xcodeproj/project.pbxproj
@@ -30,8 +30,6 @@
 		5B00324B1B652BF900B6A2FE /* BarChartHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B00324A1B652BF900B6A2FE /* BarChartHighlighter.swift */; };
 		5B00324D1B65351C00B6A2FE /* HorizontalBarChartHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B00324C1B65351C00B6A2FE /* HorizontalBarChartHighlighter.swift */; };
 		5B378F171AD500A4009414A4 /* ChartAnimationEasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B378F161AD500A4009414A4 /* ChartAnimationEasing.swift */; };
-		5B4AC1331C44684E0028D1A6 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B4AC12E1C44684E0028D1A6 /* Realm.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		5B4AC1351C44684E0028D1A6 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B4AC12F1C44684E0028D1A6 /* RealmSwift.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		5B4AC1381C44684E0028D1A6 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B4AC1311C44684E0028D1A6 /* Realm.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		5B4AC13A1C44684E0028D1A6 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B4AC1321C44684E0028D1A6 /* RealmSwift.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		5B4AC1721C4AB2AF0028D1A6 /* ChartBaseDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4AC1711C4AB2AF0028D1A6 /* ChartBaseDataSet.swift */; };
@@ -437,8 +435,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B4AC1351C44684E0028D1A6 /* RealmSwift.framework in Frameworks */,
-				5B4AC1331C44684E0028D1A6 /* Realm.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -239,7 +239,10 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
 
         renderer!.drawValues(context: context)
 
-        _legendRenderer.renderLegend(context: context)
+        if drawLegends {
+            _legendRenderer.renderLegend(context: context)
+        }
+        
         // drawLegend()
 
         drawMarkers(context: context)

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -121,6 +121,9 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     
     private var _interceptTouchEvents = false
     
+    /// if set to true, legends will be drawn
+    public var drawLegends = true
+    
     /// An extra offset to be appended to the viewport's top
     public var extraTopOffset: CGFloat = 0.0
     

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -69,7 +69,9 @@ public class PieChartView: PieRadarChartViewBase
         
         renderer!.drawValues(context: context)
         
-        _legendRenderer.renderLegend(context: context)
+        if drawLegends {
+            _legendRenderer.renderLegend(context: context)
+        }
         
         drawDescription(context: context)
         

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -192,7 +192,9 @@ public class RadarChartView: PieRadarChartViewBase
 
         renderer!.drawValues(context: context)
 
-        _legendRenderer.renderLegend(context: context)
+        if drawLegends {
+            _legendRenderer.renderLegend(context: context)
+        }
 
         drawDescription(context: context)
 

--- a/ChartsDemo/Classes/DemoBaseViewController.m
+++ b/ChartsDemo/Classes/DemoBaseViewController.m
@@ -216,6 +216,7 @@
     chartView.rotationAngle = 0.0;
     chartView.rotationEnabled = YES;
     chartView.highlightPerTapEnabled = YES;
+    chartView.drawLegends = NO;
     
     ChartLegend *l = chartView.legend;
     l.position = ChartLegendPositionRightOfChart;


### PR DESCRIPTION
This pull request adds `drawLegends` property to `ChartViewBase` class. When it is set to `false` chart view will not display legends. The default value is `true`.