### PR TITLE
Fix for cubic line chart fill when charts that don't start at x-index 0 #711

### DIFF
--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -210,8 +210,11 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         
         let fillMin = dataSet.fillFormatter?.getFillLinePosition(dataSet: dataSet, dataProvider: dataProvider) ?? 0.0
         
-        var pt1 = CGPoint(x: CGFloat(to - 1), y: fillMin)
-        var pt2 = CGPoint(x: CGFloat(from), y: fillMin)
+        let xTo = dataSet.entryForIndex(to - 1)?.xIndex ?? 0
+        let xFrom = dataSet.entryForIndex(from)?.xIndex ?? 0
+
+        var pt1 = CGPoint(x: CGFloat(xTo), y: fillMin)
+        var pt2 = CGPoint(x: CGFloat(xFrom), y: fillMin)
         pt1 = CGPointApplyAffineTransform(pt1, matrix)
         pt2 = CGPointApplyAffineTransform(pt2, matrix)
         


### PR DESCRIPTION
Fix for issue #711

Cubic line charts that don’t start at x-index 0 don’t fill correctly
because the fill starts at index 0 (Regular line charts don’t have that
issue). To correct this the index for the fill is taken from the data
entries (similar to regular line chart fill).
Ultimately i think the renderer should be refactored to use a common
code path for filling cubic and regular line charts.