### PR TITLE
[Wrong?] for #682: adjust point.y to count text height, in order to draw it in center

### DIFF
--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -125,6 +125,7 @@ public class ChartUtils
         if (align == .Center)
         {
             point.x -= text.sizeWithAttributes(attributes).width / 2.0
+            point.y -= text.sizeWithAttributes(attributes).height / 2.0
         }
         else if (align == .Right)
         {


### PR DESCRIPTION
for #682: adjust point.y to count text height, in order to draw it in center

Seems we forgot to calculate y or by purpose ? @danielgindi 

I see 
```swift
ChartUtils.drawText(context: context, text: noDataText, point: CGPoint(x: frame.width / 2.0, y: frame.height / 2.0), align: .Center, attributes: [NSFontAttributeName: infoFont, NSForegroundColorAttributeName: infoTextColor])
```
get the center point, but later it just adjust x.