### PR TITLE
Fixed label drawing bug

### DIFF
--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -132,9 +132,11 @@ public class ChartUtils
         }
         
         UIGraphicsPushContext(context)
-        
+        CGContextSaveGState(context)
+
         (text as NSString).drawAtPoint(point, withAttributes: attributes)
         
+        CGContextRestoreGState(context)
         UIGraphicsPopContext()
     }
     


### PR DESCRIPTION
For some reason the Y-Axis labels where disappearing when no data was
displayed in the LineChart.
This could happen, for example, if all currently visible data entries
where nil.

** I am not that familiar with all this CGContext stuff and find it vey
strange, that not calling a method in one renderer (LineChartRenderer)
has an affect on an other renderer (AxisYRenderer), but maybe someone
can explain and/or find a better solution then this one **