### PR TITLE
LineChartRenderer context bug

### DIFF
--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -242,9 +242,7 @@ public class LineChartRenderer: LineRadarChartRenderer
         
         let phaseX = animator.phaseX
         let phaseY = animator.phaseY
-        
-        CGContextSaveGState(context)
-        
+
         guard let
             entryFrom = dataSet.entryForXIndex(self.minX),
             entryTo = dataSet.entryForXIndex(self.maxX)
@@ -254,6 +252,8 @@ public class LineChartRenderer: LineRadarChartRenderer
         let minx = max(dataSet.entryIndex(entry: entryFrom) - diff, 0)
         let maxx = min(max(minx + 2, dataSet.entryIndex(entry: entryTo) + 1), entryCount)
         
+        CGContextSaveGState(context)
+
         // more than 1 color
         if (dataSet.colors.count > 1)
         {


### PR DESCRIPTION
In the LineChartRenderers drawLinear method the Context gets saved before checking for existing data.
This leads to never restoring the context, which causes other chart-components to disappear.

This commit fixes this by saving the context after the check for data.

The bug described above can be seen in the two GIFs below:

### Behaviour with bug:
![chart_bug](https://cloud.githubusercontent.com/assets/9119485/12930787/a2e19e42-cf7a-11e5-9244-9cba12290553.gif)

### Behaviour with fix:
![chart_fixed](https://cloud.githubusercontent.com/assets/9119485/12930796/aef7899e-cf7a-11e5-9305-dd8468e451b8.gif)


Relates to #740