### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you want to compile for iOS 7:
 
 #### Can't compile?
 
-* Please note the difference between installing a compiled framework from Cocoapods or Carthage, and copying the source code.
+* Please note the difference between installing a compiled framework from CocoaPods or Carthage, and copying the source code.
 * If you are using Realm, please also `#import <ChartsRealm/ChartsRealm.h>`
 * If you are compiling the source code and want to use Realm, please make sure to include the code from `ChartsRealm` project.
 * Please read the **Usage** section again.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
