### PR TITLE
For #763 proposal: Unify yAxis.axisRange and yAxis.entries value range

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -273,9 +273,6 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         _leftAxis?._defaultValueFormatter = _defaultValueFormatter
         _rightAxis?._defaultValueFormatter = _defaultValueFormatter
         
-        _leftYAxisRenderer?.computeAxis(yMin: _leftAxis.axisMinimum, yMax: _leftAxis.axisMaximum)
-        _rightYAxisRenderer?.computeAxis(yMin: _rightAxis.axisMinimum, yMax: _rightAxis.axisMaximum)
-        
         _xAxisRenderer?.computeAxis(xValAverageLength: _data.xValAverageLength, xValues: _data.xVals)
         
         if (_legend !== nil)
@@ -389,6 +386,37 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         
         _leftAxis.axisRange = abs(_leftAxis.axisMaximum - _leftAxis.axisMinimum)
         _rightAxis.axisRange = abs(_rightAxis.axisMaximum - _rightAxis.axisMinimum)
+        
+        _leftYAxisRenderer?.computeAxis(yMin: _leftAxis.axisMinimum, yMax: _leftAxis.axisMaximum)
+        _rightYAxisRenderer?.computeAxis(yMin: _rightAxis.axisMinimum, yMax: _rightAxis.axisMaximum)
+        
+        if (_leftAxis.entryCount > 0)
+        {
+            if (_leftAxis.entries.first < _leftAxis.axisMinimum)
+            {
+                _leftAxis.axisMinimum = _leftAxis.entries.first!
+            }
+            if (_leftAxis.entries.last > _leftAxis.axisMaximum)
+            {
+                _leftAxis.axisMaximum = _leftAxis.entries.last!
+                
+            }
+            _leftAxis.axisRange = abs(_leftAxis.axisMaximum - _leftAxis.axisMinimum)
+        }
+        
+        if (_rightAxis.entryCount > 0)
+        {
+            if (_rightAxis.entries.first < _rightAxis.axisMinimum)
+            {
+                _rightAxis.axisMinimum = _rightAxis.entries.first!
+            }
+            if (_rightAxis.entries.last > _rightAxis.axisMaximum)
+            {
+                _rightAxis.axisMaximum = _rightAxis.entries.last!
+                
+            }
+            _rightAxis.axisRange = abs(_rightAxis.axisMaximum - _rightAxis.axisMinimum)
+        }
     }
     
     internal override func calculateOffsets()


### PR DESCRIPTION
Here's the proposal for #763, to unify yAxis.axisRange and yAxis.entries value range

to test, change Line LineChart1ViewController.m:
comment out below in ine 85 and 86
```Objective-C
//    leftAxis.customAxisMax = 220.0;
//    leftAxis.customAxisMin = -50.0;
```
set `leftAxis.startAtZeroEnabled = YES;`
replace with below test code in `setDataCount()`
```Objective-C
    for (int i = 0; i < count; i++)
    {
        double mult = (range + 1);
        double val = (double) (arc4random_uniform(mult)) + 3;
        if (i == 0)
            val = 833;
        if (i == 1)
            val = 0.0;
        [yVals addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:i]];
    }
```