### PR TITLE
Make ChartViewBase's _data optional. (Fixes #771)

### DIFF
--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -42,18 +42,15 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     {
         super.calcMinMax()
         
-        if (_data === nil)
-        {
-            return
-        }
+        guard let data = _data else { return }
         
-        let barData = _data as! BarChartData
+        let barData = data as! BarChartData
         
         // increase deltax by 1 because the bars have a width of 1
         _deltaX += 0.5
         
         // extend xDelta to make space for multiple datasets (if ther are one)
-        _deltaX *= CGFloat(_data.dataSetCount)
+        _deltaX *= CGFloat(data.dataSetCount)
         
         let groupSpace = barData.groupSpace
         _deltaX += CGFloat(barData.xValCount) * groupSpace
@@ -75,12 +72,7 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     /// - returns: the bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
     public func getBarBounds(e: BarChartDataEntry) -> CGRect
     {
-        let set = _data.getDataSetForEntry(e) as! IBarChartDataSet!
-        
-        if (set === nil)
-        {
-            return CGRectNull
-        }
+        guard let set = _data?.getDataSetForEntry(e) as? IBarChartDataSet else { return CGRectNull }
         
         let barspace = set.barSpace
         let y = CGFloat(e.value)
@@ -103,7 +95,7 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     
     public override var lowestVisibleXIndex: Int
     {
-        let step = CGFloat(_data.dataSetCount)
+        let step = CGFloat(_data?.dataSetCount ?? 0)
         let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentLeft, y: _viewPortHandler.contentBottom)
@@ -114,7 +106,7 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
 
     public override var highestVisibleXIndex: Int
     {
-        let step = CGFloat(_data.dataSetCount)
+        let step = CGFloat(_data?.dataSetCount ?? 0)
         let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentRight, y: _viewPortHandler.contentBottom)

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -263,11 +263,6 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     
     public override func notifyDataSetChanged()
     {
-        if _data === nil
-        {
-            return
-        }
-
         calcMinMax()
         
         _leftAxis?._defaultValueFormatter = _defaultValueFormatter
@@ -276,11 +271,14 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         _leftYAxisRenderer?.computeAxis(yMin: _leftAxis.axisMinimum, yMax: _leftAxis.axisMaximum)
         _rightYAxisRenderer?.computeAxis(yMin: _rightAxis.axisMinimum, yMax: _rightAxis.axisMaximum)
         
-        _xAxisRenderer?.computeAxis(xValAverageLength: _data.xValAverageLength, xValues: _data.xVals)
-        
-        if (_legend !== nil)
+        if let data = _data
         {
-            _legendRenderer?.computeLegend(_data)
+            _xAxisRenderer?.computeAxis(xValAverageLength: data.xValAverageLength, xValues: data.xVals)
+
+            if (_legend !== nil)
+            {
+                _legendRenderer?.computeLegend(data)
+            }
         }
         
         calculateOffsets()
@@ -292,21 +290,21 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         if (_autoScaleMinMaxEnabled)
         {
-            _data.calcMinMax(start: lowestVisibleXIndex, end: highestVisibleXIndex)
+            _data?.calcMinMax(start: lowestVisibleXIndex, end: highestVisibleXIndex)
         }
         
         var minLeft = !isnan(_leftAxis.customAxisMin)
             ? _leftAxis.customAxisMin
-            : _data.getYMin(.Left)
+            : _data?.getYMin(.Left) ?? 0
         var maxLeft = !isnan(_leftAxis.customAxisMax)
             ? _leftAxis.customAxisMax
-            : _data.getYMax(.Left)
+            : _data?.getYMax(.Left) ?? 0
         var minRight = !isnan(_rightAxis.customAxisMin)
             ? _rightAxis.customAxisMin
-            : _data.getYMin(.Right)
+            : _data?.getYMin(.Right) ?? 0
         var maxRight = !isnan(_rightAxis.customAxisMax)
             ? _rightAxis.customAxisMax
-            : _data.getYMax(.Right)
+            : _data?.getYMax(.Right) ?? 0
         
         let leftRange = abs(maxLeft - minLeft)
         let rightRange = abs(maxRight - minRight)
@@ -329,7 +327,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         let bottomSpaceLeft = leftRange * Double(_leftAxis.spaceBottom)
         let bottomSpaceRight = rightRange * Double(_rightAxis.spaceBottom)
         
-        _chartXMax = Double(_data.xVals.count - 1)
+        _chartXMax = Double((_data?.xVals.count ?? 0) - 1)
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
         
         // Use the values as they are
@@ -455,7 +453,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         
         if (!_xAxis.isAxisModulusCustom)
         {
-            _xAxis.axisLabelModulus = Int(ceil((CGFloat(_data.xValCount) * _xAxis.labelRotatedWidth) / (_viewPortHandler.contentWidth * _viewPortHandler.touchMatrix.a)))
+            _xAxis.axisLabelModulus = Int(ceil((CGFloat(_data?.xValCount ?? 0) * _xAxis.labelRotatedWidth) / (_viewPortHandler.contentWidth * _viewPortHandler.touchMatrix.a)))
         }
         
         if (_xAxis.axisLabelModulus < 1)
@@ -466,6 +464,8 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     
     public override func getMarkerPosition(entry e: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
     {
+        guard let data = _data else { return CGPointZero }
+
         let dataSetIndex = highlight.dataSetIndex
         var xPos = CGFloat(e.xIndex)
         var yPos = CGFloat(e.value)
@@ -474,7 +474,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         {
             let bd = _data as! BarChartData
             let space = bd.groupSpace
-            let setCount = _data.dataSetCount
+            let setCount = data.dataSetCount
             let i = e.xIndex
             
             if self is HorizontalBarChartView
@@ -519,7 +519,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         // position of the marker depends on selected value index and value
         var pt = CGPoint(x: xPos, y: yPos * _animator.phaseY)
         
-        getTransformer(_data.getDataSetByIndex(dataSetIndex)!.axisDependency).pointValueToPixel(&pt)
+        getTransformer(data.getDataSetByIndex(dataSetIndex)!.axisDependency).pointValueToPixel(&pt)
         
         return pt
     }
@@ -1404,7 +1404,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         let h = getHighlightByTouchPoint(pt)
         if (h !== nil)
         {
-            return _data.getDataSetByIndex(h!.dataSetIndex) as! IBarLineScatterCandleBubbleChartDataSet!
+            return _data?.getDataSetByIndex(h!.dataSetIndex) as! IBarLineScatterCandleBubbleChartDataSet!
         }
         return nil
     }
@@ -1678,6 +1678,10 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         var pt = CGPoint(x: viewPortHandler.contentRight, y: viewPortHandler.contentBottom)
         getTransformer(.Left).pixelToValue(&pt)
-        return (_data != nil && Int(round(pt.x)) >= _data.xValCount) ? _data.xValCount - 1 : Int(round(pt.x))
+        let ptRoundedX = Int(round(pt.x))
+
+        guard let data = _data else { return ptRoundedX }
+
+        return min(data.xValCount - 1, ptRoundedX)
     }
 }

--- a/Charts/Classes/Charts/BubbleChartView.swift
+++ b/Charts/Classes/Charts/BubbleChartView.swift
@@ -24,17 +24,18 @@ public class BubbleChartView: BarLineChartViewBase, BubbleChartDataProvider
     public override func calcMinMax()
     {
         super.calcMinMax()
+        guard let data = _data else { return }
         
-        if (_deltaX == 0.0 && _data.yValCount > 0)
+        if (_deltaX == 0.0 && data.yValCount > 0)
         {
             _deltaX = 1.0
         }
         
         _chartXMin = -0.5
-        _chartXMax = Double(_data.xVals.count) - 0.5
+        _chartXMax = Double(data.xVals.count) - 0.5
         
         if renderer as? BubbleChartRenderer !== nil,
-            let sets = _data.dataSets as? [IBubbleChartDataSet]
+            let sets = data.dataSets as? [IBubbleChartDataSet]
         {
             for set in sets {
                 

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -42,7 +42,7 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     internal var _defaultValueFormatter: NSNumberFormatter = ChartUtils.defaultValueFormatter()
     
     /// object that holds all data that was originally set for the chart, before it was modified or any filtering algorithms had been applied
-    internal var _data: ChartData!
+    internal var _data: ChartData?
     
     /// Flag that indicates if highlighting per tap (touch) is enabled
     private var _highlightPerTapEnabled = true
@@ -191,17 +191,14 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
         }
         set
         {
-            if newValue == nil
-            {
-                print("Charts: data argument is nil on setData()", terminator: "\n")
-                return
-            }
-            
             _offsetsCalculated = false
             _data = newValue
             
             // calculate how many digits are needed
-            calculateFormatter(min: _data.getYMin(), max: _data.getYMax())
+            if let data = _data
+            {
+                calculateFormatter(min: data.getYMin(), max: data.getYMax())
+            }
             
             notifyDataSetChanged()
         }
@@ -218,31 +215,22 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     /// Removes all DataSets (and thereby Entries) from the chart. Does not remove the x-values. Also refreshes the chart by calling setNeedsDisplay().
     public func clearValues()
     {
-        if (_data !== nil)
-        {
-            _data.clearValues()
-        }
+        _data?.clearValues()
         setNeedsDisplay()
     }
     
     /// - returns: true if the chart is empty (meaning it's data object is either null or contains no entries).
     public func isEmpty() -> Bool
     {
-        if (_data == nil)
+        guard let data = _data else { return true }
+
+        if (data.yValCount <= 0)
         {
             return true
         }
         else
         {
-            
-            if (_data.yValCount <= 0)
-            {
-                return true
-            }
-            else
-            {
-                return false
-            }
+            return false
         }
     }
     
@@ -271,15 +259,15 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
         // check if a custom formatter is set or not
         var reference = Double(0.0)
         
-        if (_data == nil || _data.xValCount < 2)
+        if let data = _data where data.xValCount >= 2
+        {
+            reference = fabs(max - min)
+        }
+        else
         {
             let absMin = fabs(min)
             let absMax = fabs(max)
             reference = absMin > absMax ? absMin : absMax
-        }
-        else
-        {
-            reference = fabs(max - min)
         }
         
         let digits = ChartUtils.decimals(reference)
@@ -453,7 +441,13 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     /// Provide -1 as the x-index to undo all highlighting.
     public func highlightValue(xIndex xIndex: Int, dataSetIndex: Int, callDelegate: Bool)
     {
-        if (xIndex < 0 || dataSetIndex < 0 || xIndex >= _data.xValCount || dataSetIndex >= _data.dataSetCount)
+        guard let data = _data else
+        {
+            print("Value not highlighted because data is nil")
+            return
+        }
+
+        if (xIndex < 0 || dataSetIndex < 0 || xIndex >= data.xValCount || dataSetIndex >= data.dataSetCount)
         {
             highlightValue(highlight: nil, callDelegate: callDelegate)
         }
@@ -476,7 +470,7 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
         else
         {
             // set the indices to highlight
-            entry = _data.getEntryForHighlight(h!)
+            entry = _data?.getEntryForHighlight(h!)
             if (entry === nil || entry!.xIndex != h?.xIndex)
             {
                 h = nil
@@ -527,7 +521,7 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
 
             if (xIndex <= Int(_deltaX) && xIndex <= Int(_deltaX * _animator.phaseX))
             {
-                let e = _data.getEntryForHighlight(highlight)
+                let e = _data?.getEntryForHighlight(highlight)
                 if (e === nil || e!.xIndex != highlight.xIndex)
                 {
                     continue
@@ -680,13 +674,13 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     /// - returns: the current y-max value across all DataSets
     public var chartYMax: Double
     {
-        return _data.yMax
+        return _data?.yMax ?? 0.0
     }
 
     /// - returns: the current y-min value across all DataSets
     public var chartYMin: Double
     {
-        return _data.yMin
+        return _data?.yMin ?? 0.0
     }
     
     public var chartXMax: Double
@@ -701,13 +695,13 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     
     public var xValCount: Int
     {
-        return _data.xValCount
+        return _data?.xValCount ?? 0
     }
     
     /// - returns: the total number of (y) values the chart holds (across all DataSets)
     public var valueCount: Int
     {
-        return _data.yValCount
+        return _data?.yValCount ?? 0
     }
     
     /// *Note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)*
@@ -750,14 +744,12 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     /// - returns: the x-value at the given index
     public func getXValue(index: Int) -> String!
     {
-        if (_data == nil || _data.xValCount <= index)
+        guard let data = _data where data.xValCount > index else
         {
             return nil
         }
-        else
-        {
-            return _data.xVals[index]
-        }
+
+        return data.xVals[index]
     }
     
     /// Get all Entry objects at the given index across all DataSets.
@@ -765,9 +757,11 @@ public class ChartViewBase: UIView, ChartDataProvider, ChartAnimatorDelegate
     {
         var vals = [ChartDataEntry]()
         
-        for (var i = 0, count = _data.dataSetCount; i < count; i++)
+        guard let data = _data else { return vals }
+
+        for (var i = 0, count = data.dataSetCount; i < count; i++)
         {
-            let set = _data.getDataSetByIndex(i)
+            let set = data.getDataSetByIndex(i)
             let e = set.entryForXIndex(xIndex)
             if (e !== nil)
             {

--- a/Charts/Classes/Charts/CombinedChartView.swift
+++ b/Charts/Classes/Charts/CombinedChartView.swift
@@ -47,11 +47,12 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
     override func calcMinMax()
     {
         super.calcMinMax()
+        guard let data = _data else { return }
         
         if (self.barData !== nil || self.candleData !== nil || self.bubbleData !== nil)
         {
             _chartXMin = -0.5
-            _chartXMax = Double(_data.xVals.count) - 0.5
+            _chartXMax = Double(data.xVals.count) - 0.5
             
             if (self.bubbleData !== nil)
             {

--- a/Charts/Classes/Charts/HorizontalBarChartView.swift
+++ b/Charts/Classes/Charts/HorizontalBarChartView.swift
@@ -130,7 +130,14 @@ public class HorizontalBarChartView: BarChartView
 
     internal override func calcModulus()
     {
-        _xAxis.axisLabelModulus = Int(ceil((CGFloat(_data.xValCount) * _xAxis.labelRotatedHeight) / (_viewPortHandler.contentHeight * viewPortHandler.touchMatrix.d)))
+        if let data = _data
+        {
+            _xAxis.axisLabelModulus = Int(ceil((CGFloat(data.xValCount) * _xAxis.labelRotatedHeight) / (_viewPortHandler.contentHeight * viewPortHandler.touchMatrix.d)))
+        }
+        else
+        {
+            _xAxis.axisLabelModulus = 1
+        }
         
         if (_xAxis.axisLabelModulus < 1)
         {
@@ -140,9 +147,7 @@ public class HorizontalBarChartView: BarChartView
     
     public override func getBarBounds(e: BarChartDataEntry) -> CGRect
     {
-        let set = _data.getDataSetForEntry(e) as! IBarChartDataSet!
-        
-        if (set === nil)
+        guard let set = _data?.getDataSetForEntry(e) as? IBarChartDataSet else
         {
             return CGRectNull
         }
@@ -186,7 +191,7 @@ public class HorizontalBarChartView: BarChartView
     
     public override var lowestVisibleXIndex: Int
     {
-        let step = CGFloat(_data.dataSetCount)
+        let step = CGFloat(_data?.dataSetCount ?? 0)
         let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentLeft, y: _viewPortHandler.contentBottom)
@@ -197,7 +202,7 @@ public class HorizontalBarChartView: BarChartView
     
     public override var highestVisibleXIndex: Int
     {
-        let step = CGFloat(_data.dataSetCount)
+        let step = CGFloat(_data?.dataSetCount ?? 0)
         let div = (step <= 1.0) ? 1.0 : step + (_data as! BarChartData).groupSpace
         
         var pt = CGPoint(x: _viewPortHandler.contentLeft, y: _viewPortHandler.contentTop)

--- a/Charts/Classes/Charts/LineChartView.swift
+++ b/Charts/Classes/Charts/LineChartView.swift
@@ -27,8 +27,9 @@ public class LineChartView: BarLineChartViewBase, LineChartDataProvider
     internal override func calcMinMax()
     {
         super.calcMinMax()
+        guard let data = _data else { return }
         
-        if (_deltaX == 0.0 && _data.yValCount > 0)
+        if (_deltaX == 0.0 && data.yValCount > 0)
         {
             _deltaX = 1.0
         }

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -140,16 +140,18 @@ public class PieChartView: PieRadarChartViewBase
         _drawAngles = [CGFloat]()
         _absoluteAngles = [CGFloat]()
         
-        _drawAngles.reserveCapacity(_data.yValCount)
-        _absoluteAngles.reserveCapacity(_data.yValCount)
+        guard let data = _data else { return }
+
+        _drawAngles.reserveCapacity(data.yValCount)
+        _absoluteAngles.reserveCapacity(data.yValCount)
         
         let yValueSum = (_data as! PieChartData).yValueSum
         
-        var dataSets = _data.dataSets
+        var dataSets = data.dataSets
 
         var cnt = 0
 
-        for (var i = 0; i < _data.dataSetCount; i++)
+        for (var i = 0; i < data.dataSetCount; i++)
         {
             let set = dataSets[i]
             let entryCount = set.entryCount
@@ -226,7 +228,7 @@ public class PieChartView: PieRadarChartViewBase
     /// - returns: the index of the DataSet this x-index belongs to.
     public func dataSetIndexForIndex(xIndex: Int) -> Int
     {
-        var dataSets = _data.dataSets
+        var dataSets = _data?.dataSets ?? []
         
         for (var i = 0; i < dataSets.count; i++)
         {

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -69,21 +69,16 @@ public class PieRadarChartViewBase: ChartViewBase
     
     internal override func calcMinMax()
     {
-        _deltaX = CGFloat(_data.xVals.count - 1)
+        _deltaX = CGFloat((_data?.xVals.count ?? 0) - 1)
     }
     
     public override func notifyDataSetChanged()
     {
-        if _data === nil
-        {
-            return
-        }
-        
         calcMinMax()
         
-        if (_legend !== nil)
+        if let data = _data where _legend !== nil
         {
-            _legendRenderer.computeLegend(_data)
+            _legendRenderer.computeLegend(data)
         }
         
         calculateOffsets()
@@ -378,9 +373,11 @@ public class PieRadarChartViewBase: ChartViewBase
     {
         var vals = [ChartSelectionDetail]()
         
-        for (var i = 0; i < _data.dataSetCount; i++)
+        guard let data = _data else { return vals }
+
+        for (var i = 0; i < data.dataSetCount; i++)
         {
-            guard let dataSet = _data.getDataSetByIndex(i) else { continue }
+            guard let dataSet = data.getDataSetByIndex(i) else { continue }
             
             if !dataSet.isHighlightEnabled
             {

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -76,15 +76,16 @@ public class RadarChartView: PieRadarChartViewBase
     internal override func calcMinMax()
     {
         super.calcMinMax()
+        guard let data = _data else { return }
         
         let minLeft = !isnan(_yAxis.customAxisMin)
             ? _yAxis.customAxisMin
-            : _data.getYMin(.Left)
+            : data.getYMin(.Left)
         let maxLeft = !isnan(_yAxis.customAxisMax)
             ? _yAxis.customAxisMax
-            : _data.getYMax(.Left)
+            : data.getYMax(.Left)
         
-        _chartXMax = Double(_data.xVals.count) - 1.0
+        _chartXMax = Double(data.xVals.count) - 1.0
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
         
         let leftRange = CGFloat(abs(maxLeft - minLeft))
@@ -100,7 +101,7 @@ public class RadarChartView: PieRadarChartViewBase
             ? _yAxis.customAxisMax
             : (maxLeft + topSpaceLeft)
         
-        _chartXMax = Double(_data.xVals.count) - 1.0
+        _chartXMax = Double(data.xVals.count) - 1.0
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
         
         _yAxis.axisRange = abs(_yAxis.axisMaximum - _yAxis.axisMinimum)
@@ -120,21 +121,16 @@ public class RadarChartView: PieRadarChartViewBase
     
     public override func notifyDataSetChanged()
     {
-        if _data === nil
-        {
-            return
-        }
-        
         calcMinMax()
         
         _yAxis?._defaultValueFormatter = _defaultValueFormatter
         
         _yAxisRenderer?.computeAxis(yMin: _yAxis.axisMinimum, yMax: _yAxis.axisMaximum)
-        _xAxisRenderer?.computeAxis(xValAverageLength: _data.xValAverageLength, xValues: _data.xVals)
+        _xAxisRenderer?.computeAxis(xValAverageLength: data?.xValAverageLength ?? 0, xValues: data?.xVals ?? [])
         
-        if (_legend !== nil && !_legend.isLegendCustom)
+        if let data = _data, legend = _legend where !legend.isLegendCustom
         {
-            _legendRenderer?.computeLegend(_data)
+            _legendRenderer?.computeLegend(data)
         }
         
         calculateOffsets()
@@ -192,7 +188,7 @@ public class RadarChartView: PieRadarChartViewBase
     /// - returns: the angle that each slice in the radar chart occupies.
     public var sliceAngle: CGFloat
     {
-        return 360.0 / CGFloat(_data.xValCount)
+        return 360.0 / CGFloat(_data?.xValCount ?? 0)
     }
 
     public override func indexForAngle(angle: CGFloat) -> Int
@@ -202,7 +198,7 @@ public class RadarChartView: PieRadarChartViewBase
         
         let sliceAngle = self.sliceAngle
         
-        for (var i = 0; i < _data.xValCount; i++)
+        for (var i = 0; i < (_data?.xValCount ?? 0); i++)
         {
             if (sliceAngle * CGFloat(i + 1) - sliceAngle / 2.0 > a)
             {

--- a/Charts/Classes/Charts/ScatterChartView.swift
+++ b/Charts/Classes/Charts/ScatterChartView.swift
@@ -28,8 +28,9 @@ public class ScatterChartView: BarLineChartViewBase, ScatterChartDataProvider
     public override func calcMinMax()
     {
         super.calcMinMax()
+        guard let data = _data else { return }
 
-        if (_deltaX == 0.0 && _data.yValCount > 0)
+        if (_deltaX == 0.0 && data.yValCount > 0)
         {
             _deltaX = 1.0
         }


### PR DESCRIPTION
Changed ChartViewBase's _data property declaration from _data! to _data? to allow for setting the chart's data back to nil. Updated the code base to property handle _data as an optional value.