### PR TITLE
Type bug in PieChartData

### DIFF
--- a/Charts/Classes/Data/Implementations/Standard/PieChartData.swift
+++ b/Charts/Classes/Data/Implementations/Standard/PieChartData.swift
@@ -30,11 +30,11 @@ public class PieChartData: ChartData
         super.init(xVals: xVals, dataSets: dataSets)
     }
 
-    var dataSet: PieChartDataSet?
+    var dataSet: IPieChartDataSet?
     {
         get
         {
-            return dataSets.count > 0 ? dataSets[0] as? PieChartDataSet : nil
+            return dataSets.count > 0 ? dataSets[0] as? IPieChartDataSet : nil
         }
         set
         {


### PR DESCRIPTION
The property dataSet on PieChartData did expect a PieChartDataSet and
tried to convert the result. If the user was using a Interface to
represent the data, the pie chart would fail, because the yValueSum method would return 0.0