### PR TITLE
Replace features deprecated in Swift 2.2

### DIFF
--- a/Charts/Charts.xcodeproj/project.pbxproj
+++ b/Charts/Charts.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		06AEE7A71BDC3F8B009875AE /* Charts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8EC401A9D14DC00CE82E1 /* Charts.framework */; };
 		06AEE7AE1BDC3FC6009875AE /* LineChartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AEE7AD1BDC3FC6009875AE /* LineChartTests.swift */; };
 		06AEE7C21BDC4277009875AE /* FBSnapshotTestCase.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 06AEE7C11BDC4277009875AE /* FBSnapshotTestCase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4C1990631CA23395008996A6 /* BarChartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC77DC51C0A991A00C27BCF /* BarChartTests.swift */; };
 		5597263B1BDABBDB00E05E59 /* Charts.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B680D3C1A9D1AD90026A057 /* Charts.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5597263C1BDABC0500E05E59 /* ChartDefaultXAxisValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6654D51BB0A86F00890030 /* ChartDefaultXAxisValueFormatter.swift */; };
 		5597263D1BDABC0500E05E59 /* ChartFillFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6654D61BB0A86F00890030 /* ChartFillFormatter.swift */; };
@@ -355,7 +356,6 @@
 		A52C5C8D1BAC5D1200594CDD /* ChartTransformerHorizontalBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6EC1C1ACC28AB006E9C25 /* ChartTransformerHorizontalBarChart.swift */; };
 		A52C5C8E1BAC5D1200594CDD /* ChartUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA8EC7C1A9D151C00CE82E1 /* ChartUtils.swift */; };
 		A52C5C8F1BAC5D1200594CDD /* ChartViewPortHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD8F06C1AB897D500566E05 /* ChartViewPortHandler.swift */; };
-		DDC77DC61C0A991A00C27BCF /* BarChartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC77DC51C0A991A00C27BCF /* BarChartTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -387,17 +387,17 @@
 		06AEE7AD1BDC3FC6009875AE /* LineChartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChartTests.swift; sourceTree = "<group>"; };
 		06AEE7C11BDC4277009875AE /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSnapshotTestCase.framework; path = Carthage/Build/iOS/FBSnapshotTestCase.framework; sourceTree = "<group>"; };
 		55E356521ADC63BF00A57971 /* BubbleChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartView.swift; sourceTree = "<group>"; };
-		55E3565A1ADC63EB00A57971 /* BubbleChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartRenderer.swift; sourceTree = "<group>"; };
+		55E3565A1ADC63EB00A57971 /* BubbleChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BubbleChartRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B0032441B6524AD00B6A2FE /* ChartHighlight.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartHighlight.swift; sourceTree = "<group>"; };
 		5B0032461B6524D300B6A2FE /* ChartRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartRange.swift; sourceTree = "<group>"; };
-		5B0032481B6525FC00B6A2FE /* ChartHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartHighlighter.swift; sourceTree = "<group>"; };
-		5B00324A1B652BF900B6A2FE /* BarChartHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartHighlighter.swift; sourceTree = "<group>"; };
+		5B0032481B6525FC00B6A2FE /* ChartHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartHighlighter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B00324A1B652BF900B6A2FE /* BarChartHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarChartHighlighter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B00324C1B65351C00B6A2FE /* HorizontalBarChartHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalBarChartHighlighter.swift; sourceTree = "<group>"; };
-		5B378F161AD500A4009414A4 /* ChartAnimationEasing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAnimationEasing.swift; sourceTree = "<group>"; };
-		5B4AC1711C4AB2AF0028D1A6 /* ChartBaseDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartBaseDataSet.swift; sourceTree = "<group>"; };
+		5B378F161AD500A4009414A4 /* ChartAnimationEasing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartAnimationEasing.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B4AC1711C4AB2AF0028D1A6 /* ChartBaseDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartBaseDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B4AC1C91C58A2B90028D1A6 /* ChartFill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartFill.swift; sourceTree = "<group>"; };
 		5B4AC1CC1C58F55B0028D1A6 /* LineRadarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineRadarChartRenderer.swift; sourceTree = "<group>"; };
-		5B4BCD3F1AA9C4930063F019 /* ChartTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartTransformer.swift; sourceTree = "<group>"; };
+		5B4BCD3F1AA9C4930063F019 /* ChartTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartTransformer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6556F61AB72BA000FFBFD3 /* ChartComponentBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartComponentBase.swift; sourceTree = "<group>"; };
 		5B6654D51BB0A86F00890030 /* ChartDefaultXAxisValueFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDefaultXAxisValueFormatter.swift; sourceTree = "<group>"; };
 		5B6654D61BB0A86F00890030 /* ChartFillFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartFillFormatter.swift; sourceTree = "<group>"; };
@@ -407,22 +407,22 @@
 		5B6A546D1AA5D2DC000F57C2 /* ChartAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAnimator.swift; sourceTree = "<group>"; };
 		5B6A546F1AA5DB34000F57C2 /* ChartRendererBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartRendererBase.swift; sourceTree = "<group>"; };
 		5B6A54711AA5DCA8000F57C2 /* ChartAxisRendererBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisRendererBase.swift; sourceTree = "<group>"; };
-		5B6A54731AA5DEDC000F57C2 /* ChartXAxisRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartXAxisRenderer.swift; sourceTree = "<group>"; };
+		5B6A54731AA5DEDC000F57C2 /* ChartXAxisRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartXAxisRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54751AA5DEE3000F57C2 /* ChartXAxisRendererBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartXAxisRendererBarChart.swift; sourceTree = "<group>"; };
 		5B6A54771AA5DEF0000F57C2 /* ChartXAxisRendererRadarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartXAxisRendererRadarChart.swift; sourceTree = "<group>"; };
-		5B6A547B1AA5DF02000F57C2 /* ChartXAxisRendererHorizontalBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartXAxisRendererHorizontalBarChart.swift; sourceTree = "<group>"; };
-		5B6A547D1AA5DF1A000F57C2 /* ChartYAxisRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartYAxisRenderer.swift; sourceTree = "<group>"; };
-		5B6A547F1AA5DF28000F57C2 /* ChartYAxisRendererHorizontalBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartYAxisRendererHorizontalBarChart.swift; sourceTree = "<group>"; };
-		5B6A54811AA5DF34000F57C2 /* ChartYAxisRendererRadarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartYAxisRendererRadarChart.swift; sourceTree = "<group>"; };
+		5B6A547B1AA5DF02000F57C2 /* ChartXAxisRendererHorizontalBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartXAxisRendererHorizontalBarChart.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B6A547D1AA5DF1A000F57C2 /* ChartYAxisRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartYAxisRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B6A547F1AA5DF28000F57C2 /* ChartYAxisRendererHorizontalBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartYAxisRendererHorizontalBarChart.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B6A54811AA5DF34000F57C2 /* ChartYAxisRendererRadarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartYAxisRendererRadarChart.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54841AA669C9000F57C2 /* ScatterChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScatterChartRenderer.swift; sourceTree = "<group>"; };
 		5B6A54861AA669F4000F57C2 /* RadarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadarChartRenderer.swift; sourceTree = "<group>"; };
 		5B6A54881AA66A1A000F57C2 /* PieChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieChartRenderer.swift; sourceTree = "<group>"; };
 		5B6A548A1AA66A3D000F57C2 /* LineChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChartRenderer.swift; sourceTree = "<group>"; };
-		5B6A548C1AA66A60000F57C2 /* ChartLegendRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartLegendRenderer.swift; sourceTree = "<group>"; };
-		5B6A548E1AA66A7A000F57C2 /* HorizontalBarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalBarChartRenderer.swift; sourceTree = "<group>"; };
+		5B6A548C1AA66A60000F57C2 /* ChartLegendRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartLegendRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B6A548E1AA66A7A000F57C2 /* HorizontalBarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = HorizontalBarChartRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54901AA66A8D000F57C2 /* ChartDataRendererBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDataRendererBase.swift; sourceTree = "<group>"; };
 		5B6A54921AA66AAB000F57C2 /* CombinedChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedChartRenderer.swift; sourceTree = "<group>"; };
-		5B6A54941AA66AC0000F57C2 /* CandleStickChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CandleStickChartRenderer.swift; sourceTree = "<group>"; };
+		5B6A54941AA66AC0000F57C2 /* CandleStickChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CandleStickChartRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54961AA66AD2000F57C2 /* BarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarChartRenderer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54981AA66B14000F57C2 /* BarChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartView.swift; sourceTree = "<group>"; };
 		5B6A549A1AA66B2C000F57C2 /* BarLineChartViewBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarLineChartViewBase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -431,25 +431,25 @@
 		5B6A54A01AA66B6A000F57C2 /* HorizontalBarChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalBarChartView.swift; sourceTree = "<group>"; };
 		5B6A54A21AA66B7C000F57C2 /* LineChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChartView.swift; sourceTree = "<group>"; };
 		5B6A54A41AA66B92000F57C2 /* PieChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieChartView.swift; sourceTree = "<group>"; };
-		5B6A54A61AA66BA7000F57C2 /* PieRadarChartViewBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieRadarChartViewBase.swift; sourceTree = "<group>"; };
+		5B6A54A61AA66BA7000F57C2 /* PieRadarChartViewBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PieRadarChartViewBase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5B6A54A81AA66BBA000F57C2 /* RadarChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadarChartView.swift; sourceTree = "<group>"; };
 		5B6A54AA1AA66BC8000F57C2 /* ScatterChartView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScatterChartView.swift; sourceTree = "<group>"; };
 		5B8E0AAD1C63737400438BAF /* ChartDefaultFillFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDefaultFillFormatter.swift; sourceTree = "<group>"; };
 		5B8FE2B01B68FFF900910C9E /* LineScatterCandleRadarChartRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineScatterCandleRadarChartRenderer.swift; sourceTree = "<group>"; };
 		5BA8EC401A9D14DC00CE82E1 /* Charts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Charts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BA8EC441A9D14DC00CE82E1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		5BA8EC671A9D151C00CE82E1 /* ChartViewBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartViewBase.swift; sourceTree = "<group>"; };
+		5BA8EC671A9D151C00CE82E1 /* ChartViewBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartViewBase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5BA8EC6A1A9D151C00CE82E1 /* ChartAxisBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartAxisBase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		5BA8EC6B1A9D151C00CE82E1 /* ChartLegend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartLegend.swift; sourceTree = "<group>"; };
+		5BA8EC6B1A9D151C00CE82E1 /* ChartLegend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartLegend.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5BA8EC6C1A9D151C00CE82E1 /* ChartLimitLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartLimitLine.swift; sourceTree = "<group>"; };
-		5BA8EC6D1A9D151C00CE82E1 /* ChartXAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartXAxis.swift; sourceTree = "<group>"; };
-		5BA8EC6E1A9D151C00CE82E1 /* ChartYAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartYAxis.swift; sourceTree = "<group>"; };
-		5BA8EC751A9D151C00CE82E1 /* ChartDataApproximatorFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDataApproximatorFilter.swift; sourceTree = "<group>"; };
+		5BA8EC6D1A9D151C00CE82E1 /* ChartXAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartXAxis.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5BA8EC6E1A9D151C00CE82E1 /* ChartYAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartYAxis.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5BA8EC751A9D151C00CE82E1 /* ChartDataApproximatorFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartDataApproximatorFilter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5BA8EC761A9D151C00CE82E1 /* ChartDataBaseFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDataBaseFilter.swift; sourceTree = "<group>"; };
 		5BA8EC791A9D151C00CE82E1 /* ChartColorTemplates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartColorTemplates.swift; sourceTree = "<group>"; };
 		5BA8EC7B1A9D151C00CE82E1 /* ChartSelectionDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartSelectionDetail.swift; sourceTree = "<group>"; };
-		5BA8EC7C1A9D151C00CE82E1 /* ChartUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartUtils.swift; sourceTree = "<group>"; };
-		5BAAA8551BB08E1D00B20D4D /* CombinedHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedHighlighter.swift; sourceTree = "<group>"; };
+		5BA8EC7C1A9D151C00CE82E1 /* ChartUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartUtils.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5BAAA8551BB08E1D00B20D4D /* CombinedHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CombinedHighlighter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5BB6EC1C1ACC28AB006E9C25 /* ChartTransformerHorizontalBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartTransformerHorizontalBarChart.swift; sourceTree = "<group>"; };
 		5BBBD9E01C80976300D01235 /* ZoomChartViewJob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZoomChartViewJob.swift; sourceTree = "<group>"; };
 		5BCAA7491C7CAA4E00F83F3B /* ChartViewPortJob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartViewPortJob.swift; sourceTree = "<group>"; };
@@ -466,22 +466,22 @@
 		5BD4C57B1BCDBF6C00462351 /* ScatterChartDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScatterChartDataProvider.swift; sourceTree = "<group>"; };
 		5BD8F06C1AB897D500566E05 /* ChartViewPortHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartViewPortHandler.swift; sourceTree = "<group>"; };
 		659400871BF463C1004F9C27 /* BarChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartData.swift; sourceTree = "<group>"; };
-		659400881BF463C1004F9C27 /* BarChartDataEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartDataEntry.swift; sourceTree = "<group>"; };
-		659400891BF463C1004F9C27 /* BarChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartDataSet.swift; sourceTree = "<group>"; };
+		659400881BF463C1004F9C27 /* BarChartDataEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarChartDataEntry.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		659400891BF463C1004F9C27 /* BarChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BarChartDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6594008A1BF463C1004F9C27 /* BarLineScatterCandleBubbleChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarLineScatterCandleBubbleChartData.swift; sourceTree = "<group>"; };
 		6594008B1BF463C1004F9C27 /* BarLineScatterCandleBubbleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarLineScatterCandleBubbleChartDataSet.swift; sourceTree = "<group>"; };
 		6594008C1BF463C1004F9C27 /* BubbleChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartData.swift; sourceTree = "<group>"; };
 		6594008D1BF463C1004F9C27 /* BubbleChartDataEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartDataEntry.swift; sourceTree = "<group>"; };
-		6594008E1BF463C1004F9C27 /* BubbleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartDataSet.swift; sourceTree = "<group>"; };
+		6594008E1BF463C1004F9C27 /* BubbleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BubbleChartDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6594008F1BF463C1004F9C27 /* CandleChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CandleChartData.swift; sourceTree = "<group>"; };
 		659400901BF463C1004F9C27 /* CandleChartDataEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CandleChartDataEntry.swift; sourceTree = "<group>"; };
-		659400911BF463C1004F9C27 /* CandleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CandleChartDataSet.swift; sourceTree = "<group>"; };
-		659400921BF463C1004F9C27 /* ChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
+		659400911BF463C1004F9C27 /* CandleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CandleChartDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		659400921BF463C1004F9C27 /* ChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartData.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		659400931BF463C1004F9C27 /* ChartDataEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDataEntry.swift; sourceTree = "<group>"; };
-		659400941BF463C1004F9C27 /* ChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartDataSet.swift; sourceTree = "<group>"; };
+		659400941BF463C1004F9C27 /* ChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ChartDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		659400951BF463C1004F9C27 /* CombinedChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinedChartData.swift; sourceTree = "<group>"; };
 		659400961BF463C1004F9C27 /* LineChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChartData.swift; sourceTree = "<group>"; };
-		659400971BF463C1004F9C27 /* LineChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChartDataSet.swift; sourceTree = "<group>"; };
+		659400971BF463C1004F9C27 /* LineChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LineChartDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		659400981BF463C1004F9C27 /* LineRadarChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineRadarChartDataSet.swift; sourceTree = "<group>"; };
 		659400991BF463C1004F9C27 /* LineScatterCandleRadarChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineScatterCandleRadarChartDataSet.swift; sourceTree = "<group>"; };
 		6594009A1BF463C1004F9C27 /* PieChartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieChartData.swift; sourceTree = "<group>"; };
@@ -501,7 +501,7 @@
 		65F06F991BE8136F0074498D /* ILineRadarChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ILineRadarChartDataSet.swift; sourceTree = "<group>"; };
 		65F06F9D1BE814800074498D /* IScatterChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IScatterChartDataSet.swift; sourceTree = "<group>"; };
 		65F06FA01BE815220074498D /* IBubbleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IBubbleChartDataSet.swift; sourceTree = "<group>"; };
-		65F06FA31BE816050074498D /* ILineChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ILineChartDataSet.swift; sourceTree = "<group>"; };
+		65F06FA31BE816050074498D /* ILineChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ILineChartDataSet.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		65F06FA61BE817560074498D /* ICandleChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ICandleChartDataSet.swift; sourceTree = "<group>"; };
 		65F06FA91BE818AA0074498D /* IBarChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IBarChartDataSet.swift; sourceTree = "<group>"; };
 		65F06FAC1BE826010074498D /* IPieChartDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPieChartDataSet.swift; sourceTree = "<group>"; };
@@ -1014,7 +1014,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DDC77DC61C0A991A00C27BCF /* BarChartTests.swift in Sources */,
+				4C1990631CA23395008996A6 /* BarChartTests.swift in Sources */,
 				06AEE7AE1BDC3FC6009875AE /* LineChartTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Charts/Classes/Animation/ChartAnimationEasing.swift
+++ b/Charts/Classes/Animation/ChartAnimationEasing.swift
@@ -142,7 +142,8 @@ internal struct EasingFunctions
         {
             return 0.5 * position * position
         }
-        return -0.5 * ((--position) * (position - 2.0) - 1.0)
+        position -= 1
+        return -0.5 * ((position) * (position - 2.0) - 1.0)
     }
     
     internal static let EaseInCubic = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
@@ -152,7 +153,7 @@ internal struct EasingFunctions
     
     internal static let EaseOutCubic = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
         var position = CGFloat(elapsed / duration)
-        position--
+        position -= 1
         return (position * position * position + 1.0)
     }
     
@@ -173,7 +174,7 @@ internal struct EasingFunctions
     
     internal static let EaseOutQuart = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
         var position = CGFloat(elapsed / duration)
-        position--
+        position -= 1
         return -(position * position * position * position - 1.0)
     }
     
@@ -194,7 +195,7 @@ internal struct EasingFunctions
     
     internal static let EaseOutQuint = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
         var position = CGFloat(elapsed / duration)
-        position--
+        position -= 1
         return (position * position * position * position * position + 1.0)
     }
     
@@ -249,7 +250,8 @@ internal struct EasingFunctions
         {
             return CGFloat( 0.5 * pow(2.0, 10.0 * (position - 1.0)) )
         }
-        return CGFloat( 0.5 * (-pow(2.0, -10.0 * --position) + 2.0) )
+        position -= 1
+        return CGFloat( 0.5 * (-pow(2.0, -10.0 * position) + 2.0) )
     }
     
     internal static let EaseInCirc = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
@@ -259,7 +261,7 @@ internal struct EasingFunctions
     
     internal static let EaseOutCirc = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
         var position = CGFloat(elapsed / duration)
-        position--
+        position -= 1
         return CGFloat( sqrt(1 - position * position) )
     }
     
@@ -340,7 +342,7 @@ internal struct EasingFunctions
     internal static let EaseOutBack = { (elapsed: NSTimeInterval, duration: NSTimeInterval) -> CGFloat in
         let s: NSTimeInterval = 1.70158
         var position: NSTimeInterval = elapsed / duration
-        position--
+        position -= 1
         return CGFloat( position * position * ((s + 1.0) * position + s) + 1.0 )
     }
     

--- a/Charts/Classes/Animation/ChartAnimator.swift
+++ b/Charts/Classes/Animation/ChartAnimator.swift
@@ -195,7 +195,7 @@ public class ChartAnimator: NSObject
         
         if (_enabledX || _enabledY)
         {
-            _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
+            _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
             _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
         }
     }
@@ -261,7 +261,7 @@ public class ChartAnimator: NSObject
         {
             if _displayLink === nil
             {
-                _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
+                _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
                 _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }
@@ -305,7 +305,7 @@ public class ChartAnimator: NSObject
         {
             if _displayLink === nil
             {
-                _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
+                _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
                 _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }

--- a/Charts/Classes/Animation/ChartAnimator.swift
+++ b/Charts/Classes/Animation/ChartAnimator.swift
@@ -195,7 +195,7 @@ public class ChartAnimator: NSObject
         
         if (_enabledX || _enabledY)
         {
-            _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
+            _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
             _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
         }
     }
@@ -261,7 +261,7 @@ public class ChartAnimator: NSObject
         {
             if _displayLink === nil
             {
-                _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
+                _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
                 _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }
@@ -305,7 +305,7 @@ public class ChartAnimator: NSObject
         {
             if _displayLink === nil
             {
-                _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
+                _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
                 _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -855,31 +855,32 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         }
     }
     
-    private func performPanChange(var translation translation: CGPoint) -> Bool
+    private func performPanChange(translation translation: CGPoint) -> Bool
     {
+        var translationVar = translation
         if (isAnyAxisInverted && _closestDataSetToTouch !== nil
             && getAxis(_closestDataSetToTouch.axisDependency).isInverted)
         {
             if (self is HorizontalBarChartView)
             {
-                translation.x = -translation.x
+                translationVar.x = -translationVar.x
             }
             else
             {
-                translation.y = -translation.y
+                translationVar.y = -translationVar.y
             }
         }
         
         let originalMatrix = _viewPortHandler.touchMatrix
         
-        var matrix = CGAffineTransformMakeTranslation(translation.x, translation.y)
+        var matrix = CGAffineTransformMakeTranslation(translationVar.x, translationVar.y)
         matrix = CGAffineTransformConcat(originalMatrix, matrix)
         
         matrix = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
         
         if (delegate !== nil)
         {
-            delegate?.chartTranslated?(self, dX: translation.x, dY: translation.y)
+            delegate?.chartTranslated?(self, dX: translationVar.x, dY: translationVar.y)
         }
         
         // Did we managed to actually drag or did we reach the edge?
@@ -1642,11 +1643,12 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     /// (encapsulated in a `CGPoint`). This method transforms pixel coordinates to
     /// coordinates / values in the chart. This is the opposite method to
     /// `getPixelsForValues(...)`.
-    public func getValueByTouchPoint(var pt pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGPoint
+    public func getValueByTouchPoint(pt pt: CGPoint, axis: ChartYAxis.AxisDependency) -> CGPoint
     {
-        getTransformer(axis).pixelToValue(&pt)
+        var ptVar = pt
+        getTransformer(axis).pixelToValue(&ptVar)
 
-        return pt
+        return ptVar
     }
 
     /// Transforms the given chart values into pixels. This is the opposite

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -117,10 +117,10 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         
         self.highlighter = ChartHighlighter(chart: self)
         
-        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.tapGestureRecognized(_:)))
-        _doubleTapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.doubleTapGestureRecognized(_:)))
+        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: Selector("tapGestureRecognized:"))
+        _doubleTapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: Selector("doubleTapGestureRecognized:"))
         _doubleTapGestureRecognizer.nsuiNumberOfTapsRequired = 2
-        _panGestureRecognizer = NSUIPanGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.panGestureRecognized(_:)))
+        _panGestureRecognizer = NSUIPanGestureRecognizer(target: self, action: Selector("panGestureRecognized:"))
         
         _panGestureRecognizer.delegate = self
         
@@ -132,7 +132,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         _panGestureRecognizer.enabled = _dragEnabled
 
         #if !os(tvOS)
-            _pinchGestureRecognizer = NSUIPinchGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.pinchGestureRecognized(_:)))
+            _pinchGestureRecognizer = NSUIPinchGestureRecognizer(target: self, action: Selector("pinchGestureRecognized:"))
             _pinchGestureRecognizer.delegate = self
             self.addGestureRecognizer(_pinchGestureRecognizer)
             _pinchGestureRecognizer.enabled = _pinchZoomEnabled || _scaleXEnabled || _scaleYEnabled
@@ -840,7 +840,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
                     _decelerationLastTime = CACurrentMediaTime()
                     _decelerationVelocity = recognizer.velocityInView(self)
                     
-                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(BarLineChartViewBase.decelerationLoop))
+                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: Selector("decelerationLoop"))
                     _decelerationDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
                 }
                 

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -117,10 +117,10 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         
         self.highlighter = ChartHighlighter(chart: self)
         
-        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: Selector("tapGestureRecognized:"))
-        _doubleTapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: Selector("doubleTapGestureRecognized:"))
+        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.tapGestureRecognized(_:)))
+        _doubleTapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.doubleTapGestureRecognized(_:)))
         _doubleTapGestureRecognizer.nsuiNumberOfTapsRequired = 2
-        _panGestureRecognizer = NSUIPanGestureRecognizer(target: self, action: Selector("panGestureRecognized:"))
+        _panGestureRecognizer = NSUIPanGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.panGestureRecognized(_:)))
         
         _panGestureRecognizer.delegate = self
         
@@ -132,7 +132,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         _panGestureRecognizer.enabled = _dragEnabled
 
         #if !os(tvOS)
-            _pinchGestureRecognizer = NSUIPinchGestureRecognizer(target: self, action: Selector("pinchGestureRecognized:"))
+            _pinchGestureRecognizer = NSUIPinchGestureRecognizer(target: self, action: #selector(BarLineChartViewBase.pinchGestureRecognized(_:)))
             _pinchGestureRecognizer.delegate = self
             self.addGestureRecognizer(_pinchGestureRecognizer)
             _pinchGestureRecognizer.enabled = _pinchZoomEnabled || _scaleXEnabled || _scaleYEnabled
@@ -840,7 +840,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
                     _decelerationLastTime = CACurrentMediaTime()
                     _decelerationVelocity = recognizer.velocityInView(self)
                     
-                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: Selector("decelerationLoop"))
+                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(BarLineChartViewBase.decelerationLoop))
                     _decelerationDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
                 }
                 

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -521,7 +521,7 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
             return
         }
 
-        for (var i = 0, count = _indicesToHighlight.count; i < count; i++)
+        for (var i = 0, count = _indicesToHighlight.count; i < count; i += 1)
         {
             let highlight = _indicesToHighlight[i]
             let xIndex = highlight.xIndex
@@ -766,7 +766,7 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
         
         guard let data = _data else { return vals }
 
-        for (var i = 0, count = data.dataSetCount; i < count; i++)
+        for (var i = 0, count = data.dataSetCount; i < count; i += 1)
         {
             let set = data.getDataSetByIndex(i)
             let e = set.entryForXIndex(xIndex)

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -521,7 +521,8 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
             return
         }
 
-        for (var i = 0, count = _indicesToHighlight.count; i < count; i += 1)
+        let count = _indicesToHighlight.count
+        for i in 0 ..< count
         {
             let highlight = _indicesToHighlight[i]
             let xIndex = highlight.xIndex
@@ -766,7 +767,8 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
         
         guard let data = _data else { return vals }
 
-        for (var i = 0, count = data.dataSetCount; i < count; i += 1)
+        let count = data.dataSetCount
+        for i in 0 ..< count
         {
             let set = data.getDataSetByIndex(i)
             let e = set.entryForXIndex(xIndex)

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -186,12 +186,12 @@ public class PieChartView: PieRadarChartViewBase
 
         var cnt = 0
 
-        for (var i = 0; i < data.dataSetCount; i++)
+        for (var i = 0; i < data.dataSetCount; i += 1)
         {
             let set = dataSets[i]
             let entryCount = set.entryCount
 
-            for (var j = 0; j < entryCount; j++)
+            for (var j = 0; j < entryCount; j += 1)
             {
                 guard let e = set.entryForIndex(j) else { continue }
                 
@@ -206,7 +206,7 @@ public class PieChartView: PieRadarChartViewBase
                     _absoluteAngles.append(_absoluteAngles[cnt - 1] + _drawAngles[cnt])
                 }
 
-                cnt++
+                cnt += 1
             }
         }
     }
@@ -220,7 +220,7 @@ public class PieChartView: PieRadarChartViewBase
             return false
         }
         
-        for (var i = 0; i < _indicesToHighlight.count; i++)
+        for (var i = 0; i < _indicesToHighlight.count; i += 1)
         {
             // check if the xvalue for the given dataset needs highlight
             if (_indicesToHighlight[i].xIndex == xIndex
@@ -249,7 +249,7 @@ public class PieChartView: PieRadarChartViewBase
     {
         // take the current angle of the chart into consideration
         let a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
-        for (var i = 0; i < _absoluteAngles.count; i++)
+        for (var i = 0; i < _absoluteAngles.count; i += 1)
         {
             if (_absoluteAngles[i] > a)
             {
@@ -265,7 +265,7 @@ public class PieChartView: PieRadarChartViewBase
     {
         var dataSets = _data?.dataSets ?? []
         
-        for (var i = 0; i < dataSets.count; i++)
+        for (var i = 0; i < dataSets.count; i += 1)
         {
             if (dataSets[i].entryForXIndex(xIndex) !== nil)
             {

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -186,12 +186,12 @@ public class PieChartView: PieRadarChartViewBase
 
         var cnt = 0
 
-        for (var i = 0; i < data.dataSetCount; i += 1)
+        for i in 0 ..< data.dataSetCount
         {
             let set = dataSets[i]
             let entryCount = set.entryCount
 
-            for (var j = 0; j < entryCount; j += 1)
+            for j in 0 ..< entryCount
             {
                 guard let e = set.entryForIndex(j) else { continue }
                 
@@ -220,7 +220,7 @@ public class PieChartView: PieRadarChartViewBase
             return false
         }
         
-        for (var i = 0; i < _indicesToHighlight.count; i += 1)
+        for i in 0 ..< _indicesToHighlight.count
         {
             // check if the xvalue for the given dataset needs highlight
             if (_indicesToHighlight[i].xIndex == xIndex
@@ -249,7 +249,7 @@ public class PieChartView: PieRadarChartViewBase
     {
         // take the current angle of the chart into consideration
         let a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
-        for (var i = 0; i < _absoluteAngles.count; i += 1)
+        for i in 0 ..< _absoluteAngles.count
         {
             if (_absoluteAngles[i] > a)
             {
@@ -265,7 +265,7 @@ public class PieChartView: PieRadarChartViewBase
     {
         var dataSets = _data?.dataSets ?? []
         
-        for (var i = 0; i < dataSets.count; i += 1)
+        for i in 0 ..< dataSets.count
         {
             if (dataSets[i].entryForXIndex(xIndex) !== nil)
             {

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -60,12 +60,12 @@ public class PieRadarChartViewBase: ChartViewBase
     {
         super.initialize()
         
-        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: Selector("tapGestureRecognized:"))
+        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(PieRadarChartViewBase.tapGestureRecognized(_:)))
         
         self.addGestureRecognizer(_tapGestureRecognizer)
 
         #if !os(tvOS)
-            _rotationGestureRecognizer = NSUIRotationGestureRecognizer(target: self, action: Selector("rotationGestureRecognized:"))
+            _rotationGestureRecognizer = NSUIRotationGestureRecognizer(target: self, action: #selector(PieRadarChartViewBase.rotationGestureRecognized(_:)))
             self.addGestureRecognizer(_rotationGestureRecognizer)
             _rotationGestureRecognizer.enabled = rotationWithTwoFingers
         #endif
@@ -543,7 +543,7 @@ public class PieRadarChartViewBase: ChartViewBase
             if _decelerationAngularVelocity != 0.0
             {
                 _decelerationLastTime = CACurrentMediaTime()
-                _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: Selector("decelerationLoop"))
+                _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(PieRadarChartViewBase.decelerationLoop))
                 _decelerationDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }
@@ -946,7 +946,7 @@ public class PieRadarChartViewBase: ChartViewBase
                 if (_decelerationAngularVelocity != 0.0)
                 {
                     _decelerationLastTime = CACurrentMediaTime()
-                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: Selector("decelerationLoop"))
+                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(PieRadarChartViewBase.decelerationLoop))
                     _decelerationDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
                 }
             }

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -378,7 +378,7 @@ public class PieRadarChartViewBase: ChartViewBase
         
         guard let data = _data else { return vals }
 
-        for (var i = 0; i < data.dataSetCount; i++)
+        for (var i = 0; i < data.dataSetCount; i += 1)
         {
             guard let dataSet = data.getDataSetByIndex(i) else { continue }
             
@@ -695,13 +695,13 @@ public class PieRadarChartViewBase: ChartViewBase
         _velocitySamples.append(AngularVelocitySample(time: currentTime, angle: angleForPoint(x: touchLocation.x, y: touchLocation.y)))
         
         // Remove samples older than our sample time - 1 seconds
-        for (var i = 0, count = _velocitySamples.count; i < count - 2; i++)
+        for (var i = 0, count = _velocitySamples.count; i < count - 2; i += 1)
         {
             if (currentTime - _velocitySamples[i].time > 1.0)
             {
                 _velocitySamples.removeAtIndex(0)
-                i--
-                count--
+                i -= 1
+                count -= 1
             }
             else
             {
@@ -722,7 +722,7 @@ public class PieRadarChartViewBase: ChartViewBase
         
         // Look for a sample that's closest to the latest sample, but not the same, so we can deduce the direction
         var beforeLastSample = firstSample
-        for (var i = _velocitySamples.count - 1; i >= 0; i--)
+        for (var i = _velocitySamples.count - 1; i >= 0; i -= 1)
         {
             beforeLastSample = _velocitySamples[i]
             if (beforeLastSample.angle != lastSample.angle)

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -60,12 +60,12 @@ public class PieRadarChartViewBase: ChartViewBase
     {
         super.initialize()
         
-        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(PieRadarChartViewBase.tapGestureRecognized(_:)))
+        _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: Selector("tapGestureRecognized:"))
         
         self.addGestureRecognizer(_tapGestureRecognizer)
 
         #if !os(tvOS)
-            _rotationGestureRecognizer = NSUIRotationGestureRecognizer(target: self, action: #selector(PieRadarChartViewBase.rotationGestureRecognized(_:)))
+            _rotationGestureRecognizer = NSUIRotationGestureRecognizer(target: self, action: Selector("rotationGestureRecognized:"))
             self.addGestureRecognizer(_rotationGestureRecognizer)
             _rotationGestureRecognizer.enabled = rotationWithTwoFingers
         #endif
@@ -543,7 +543,7 @@ public class PieRadarChartViewBase: ChartViewBase
             if _decelerationAngularVelocity != 0.0
             {
                 _decelerationLastTime = CACurrentMediaTime()
-                _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(PieRadarChartViewBase.decelerationLoop))
+                _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: Selector("decelerationLoop"))
                 _decelerationDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }
@@ -946,7 +946,7 @@ public class PieRadarChartViewBase: ChartViewBase
                 if (_decelerationAngularVelocity != 0.0)
                 {
                     _decelerationLastTime = CACurrentMediaTime()
-                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(PieRadarChartViewBase.decelerationLoop))
+                    _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: Selector("decelerationLoop"))
                     _decelerationDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
                 }
             }

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -378,7 +378,7 @@ public class PieRadarChartViewBase: ChartViewBase
         
         guard let data = _data else { return vals }
 
-        for (var i = 0; i < data.dataSetCount; i += 1)
+        for i in 0 ..< data.dataSetCount
         {
             guard let dataSet = data.getDataSetByIndex(i) else { continue }
             
@@ -695,7 +695,9 @@ public class PieRadarChartViewBase: ChartViewBase
         _velocitySamples.append(AngularVelocitySample(time: currentTime, angle: angleForPoint(x: touchLocation.x, y: touchLocation.y)))
         
         // Remove samples older than our sample time - 1 seconds
-        for (var i = 0, count = _velocitySamples.count; i < count - 2; i += 1)
+        var count = _velocitySamples.count
+        var i = 0
+        while i < count - 2
         {
             if (currentTime - _velocitySamples[i].time > 1.0)
             {
@@ -707,6 +709,8 @@ public class PieRadarChartViewBase: ChartViewBase
             {
                 break
             }
+            
+            i += 1
         }
     }
     
@@ -722,7 +726,7 @@ public class PieRadarChartViewBase: ChartViewBase
         
         // Look for a sample that's closest to the latest sample, but not the same, so we can deduce the direction
         var beforeLastSample = firstSample
-        for (var i = _velocitySamples.count - 1; i >= 0; i -= 1)
+        for i in _velocitySamples.count.stride(through: 0, by: -1)
         {
             beforeLastSample = _velocitySamples[i]
             if (beforeLastSample.angle != lastSample.angle)

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -198,7 +198,7 @@ public class RadarChartView: PieRadarChartViewBase
         
         let sliceAngle = self.sliceAngle
         
-        for (var i = 0; i < (_data?.xValCount ?? 0); i++)
+        for (var i = 0; i < (_data?.xValCount ?? 0); i += 1)
         {
             if (sliceAngle * CGFloat(i + 1) - sliceAngle / 2.0 > a)
             {

--- a/Charts/Classes/Charts/RadarChartView.swift
+++ b/Charts/Classes/Charts/RadarChartView.swift
@@ -198,7 +198,7 @@ public class RadarChartView: PieRadarChartViewBase
         
         let sliceAngle = self.sliceAngle
         
-        for (var i = 0; i < (_data?.xValCount ?? 0); i += 1)
+        for i in 0 ..< (_data?.xValCount ?? 0)
         {
             if (sliceAngle * CGFloat(i + 1) - sliceAngle / 2.0 > a)
             {

--- a/Charts/Classes/Components/ChartAxisBase.swift
+++ b/Charts/Classes/Components/ChartAxisBase.swift
@@ -78,7 +78,7 @@ public class ChartAxisBase: ChartComponentBase
     /// Removes the specified ChartLimitLine from the axis.
     public func removeLimitLine(line: ChartLimitLine)
     {
-        for (var i = 0; i < _limitLines.count; i++)
+        for (var i = 0; i < _limitLines.count; i += 1)
         {
             if (_limitLines[i] === line)
             {

--- a/Charts/Classes/Components/ChartAxisBase.swift
+++ b/Charts/Classes/Components/ChartAxisBase.swift
@@ -78,7 +78,7 @@ public class ChartAxisBase: ChartComponentBase
     /// Removes the specified ChartLimitLine from the axis.
     public func removeLimitLine(line: ChartLimitLine)
     {
-        for (var i = 0; i < _limitLines.count; i += 1)
+        for i in 0 ..< _limitLines.count
         {
             if (_limitLines[i] === line)
             {

--- a/Charts/Classes/Components/ChartLegend.swift
+++ b/Charts/Classes/Components/ChartLegend.swift
@@ -124,7 +124,7 @@ public class ChartLegend: ChartComponentBase
         var maxH = CGFloat(0.0)
         
         var labels = self.labels
-        for (var i = 0; i < labels.count; i += 1)
+        for i in 0 ..< labels.count
         {
             if (labels[i] == nil)
             {
@@ -160,7 +160,8 @@ public class ChartLegend: ChartComponentBase
         var height = CGFloat(0.0)
         
         var labels = self.labels
-        for (var i = 0, count = labels.count; i < count; i += 1)
+        let count = labels.count
+        for i in 0 ..< count
         {
             if (labels[i] != nil)
             {
@@ -276,7 +277,7 @@ public class ChartLegend: ChartComponentBase
             var requiredWidth: CGFloat = 0.0
             var stackedStartIndex: Int = -1
             
-            for (var i = 0; i < labelCount; i += 1)
+            for i in 0 ..< labelCount
             {
                 let drawingForm = colors[i] != nil
                 

--- a/Charts/Classes/Components/ChartLegend.swift
+++ b/Charts/Classes/Components/ChartLegend.swift
@@ -124,7 +124,7 @@ public class ChartLegend: ChartComponentBase
         var maxH = CGFloat(0.0)
         
         var labels = self.labels
-        for (var i = 0; i < labels.count; i++)
+        for (var i = 0; i < labels.count; i += 1)
         {
             if (labels[i] == nil)
             {
@@ -160,7 +160,7 @@ public class ChartLegend: ChartComponentBase
         var height = CGFloat(0.0)
         
         var labels = self.labels
-        for (var i = 0, count = labels.count; i < count; i++)
+        for (var i = 0, count = labels.count; i < count; i += 1)
         {
             if (labels[i] != nil)
             {
@@ -276,7 +276,7 @@ public class ChartLegend: ChartComponentBase
             var requiredWidth: CGFloat = 0.0
             var stackedStartIndex: Int = -1
             
-            for (var i = 0; i < labelCount; i++)
+            for (var i = 0; i < labelCount; i += 1)
             {
                 let drawingForm = colors[i] != nil
                 

--- a/Charts/Classes/Components/ChartXAxis.swift
+++ b/Charts/Classes/Components/ChartXAxis.swift
@@ -111,7 +111,7 @@ public class ChartXAxis: ChartAxisBase
     {
         var longest = ""
         
-        for (var i = 0; i < values.count; i++)
+        for (var i = 0; i < values.count; i += 1)
         {
             let text = values[i]
             

--- a/Charts/Classes/Components/ChartXAxis.swift
+++ b/Charts/Classes/Components/ChartXAxis.swift
@@ -111,7 +111,7 @@ public class ChartXAxis: ChartAxisBase
     {
         var longest = ""
         
-        for (var i = 0; i < values.count; i += 1)
+        for i in 0 ..< values.count
         {
             let text = values[i]
             

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -244,7 +244,7 @@ public class ChartYAxis: ChartAxisBase
     {
         var longest = ""
         
-        for (var i = 0; i < entries.count; i += 1)
+        for i in 0 ..< entries.count
         {
             let text = getFormattedLabel(i)
             

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -244,7 +244,7 @@ public class ChartYAxis: ChartAxisBase
     {
         var longest = ""
         
-        for (var i = 0; i < entries.count; i++)
+        for (var i = 0; i < entries.count; i += 1)
         {
             let text = getFormattedLabel(i)
             

--- a/Charts/Classes/Data/Implementations/ChartBaseDataSet.swift
+++ b/Charts/Classes/Data/Implementations/ChartBaseDataSet.swift
@@ -306,7 +306,8 @@ public class ChartBaseDataSet: NSObject, IChartDataSet
     {
         var desc = description + ":"
         
-        for (var i = 0, count = self.entryCount; i < count; i += 1)
+        let count = self.entryCount
+        for i in 0 ..< count
         {
             desc += "\n" + (self.entryForIndex(i)?.description ?? "")
         }

--- a/Charts/Classes/Data/Implementations/ChartBaseDataSet.swift
+++ b/Charts/Classes/Data/Implementations/ChartBaseDataSet.swift
@@ -306,7 +306,7 @@ public class ChartBaseDataSet: NSObject, IChartDataSet
     {
         var desc = description + ":"
         
-        for (var i = 0, count = self.entryCount; i < count; i++)
+        for (var i = 0, count = self.entryCount; i < count; i += 1)
         {
             desc += "\n" + (self.entryForIndex(i)?.description ?? "")
         }

--- a/Charts/Classes/Data/Implementations/ChartBaseDataSet.swift
+++ b/Charts/Classes/Data/Implementations/ChartBaseDataSet.swift
@@ -165,13 +165,14 @@ public class ChartBaseDataSet: NSObject, IChartDataSet
     
     /// - returns: the color at the given index of the DataSet's color array.
     /// This prevents out-of-bounds by performing a modulus on the color index, so colours will repeat themselves.
-    public func colorAt(var index: Int) -> NSUIColor
+    public func colorAt(index: Int) -> NSUIColor
     {
-        if (index < 0)
+        var indexVar = index
+        if (indexVar < 0)
         {
-            index = 0
+            indexVar = 0
         }
-        return colors[index % colors.count]
+        return colors[indexVar % colors.count]
     }
     
     /// Resets all colors of this DataSet and recreates the colors array.
@@ -265,13 +266,14 @@ public class ChartBaseDataSet: NSObject, IChartDataSet
     }
     
     /// - returns: the color at the specified index that is used for drawing the values inside the chart. Uses modulus internally.
-    public func valueTextColorAt(var index: Int) -> NSUIColor
+    public func valueTextColorAt(index: Int) -> NSUIColor
     {
-        if (index < 0)
+        var indexVar = index
+        if (indexVar < 0)
         {
-            index = 0
+            indexVar = 0
         }
-        return valueColors[index % valueColors.count]
+        return valueColors[indexVar % valueColors.count]
     }
     
     /// the font for the value-text labels

--- a/Charts/Classes/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Charts/Classes/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -69,7 +69,7 @@ public class BarChartDataEntry: ChartDataEntry
         while (index > stackIndex && index >= 0)
         {
             remainder += values![index]
-            index--
+            index -= 1
         }
         
         return remainder

--- a/Charts/Classes/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/BarChartDataSet.swift
@@ -52,7 +52,7 @@ public class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartD
     {
         _entryCountStacks = 0
         
-        for (var i = 0; i < yVals.count; i += 1)
+        for i in 0 ..< yVals.count
         {
             let vals = yVals[i].values
             
@@ -70,7 +70,7 @@ public class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartD
     /// calculates the maximum stacksize that occurs in the Entries array of this DataSet
     private func calcStackSize(yVals: [BarChartDataEntry]!)
     {
-        for (var i = 0; i < yVals.count; i += 1)
+        for i in 0 ..< yVals.count
         {
             if let vals = yVals[i].values
             {
@@ -108,34 +108,36 @@ public class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartD
         _yMin = DBL_MAX
         _yMax = -DBL_MAX
         
-        for (var i = start; i <= endValue; i += 1)
-        {
-            if let e = _yVals[i] as? BarChartDataEntry
+        if start <= endValue {
+            for i in start ... endValue
             {
-                if !e.value.isNaN
+                if let e = _yVals[i] as? BarChartDataEntry
                 {
-                    if e.values == nil
+                    if !e.value.isNaN
                     {
-                        if e.value < _yMin
+                        if e.values == nil
                         {
-                            _yMin = e.value
+                            if e.value < _yMin
+                            {
+                                _yMin = e.value
+                            }
+                            
+                            if e.value > _yMax
+                            {
+                                _yMax = e.value
+                            }
                         }
-                        
-                        if e.value > _yMax
+                        else
                         {
-                            _yMax = e.value
-                        }
-                    }
-                    else
-                    {
-                        if -e.negativeSum < _yMin
-                        {
-                            _yMin = -e.negativeSum
-                        }
-                        
-                        if e.positiveSum > _yMax
-                        {
-                            _yMax = e.positiveSum
+                            if -e.negativeSum < _yMin
+                            {
+                                _yMin = -e.negativeSum
+                            }
+                            
+                            if e.positiveSum > _yMax
+                            {
+                                _yMax = e.positiveSum
+                            }
                         }
                     }
                 }

--- a/Charts/Classes/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/BarChartDataSet.swift
@@ -52,13 +52,13 @@ public class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartD
     {
         _entryCountStacks = 0
         
-        for (var i = 0; i < yVals.count; i++)
+        for (var i = 0; i < yVals.count; i += 1)
         {
             let vals = yVals[i].values
             
             if (vals == nil)
             {
-                _entryCountStacks++
+                _entryCountStacks += 1
             }
             else
             {
@@ -70,7 +70,7 @@ public class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartD
     /// calculates the maximum stacksize that occurs in the Entries array of this DataSet
     private func calcStackSize(yVals: [BarChartDataEntry]!)
     {
-        for (var i = 0; i < yVals.count; i++)
+        for (var i = 0; i < yVals.count; i += 1)
         {
             if let vals = yVals[i].values
             {
@@ -108,7 +108,7 @@ public class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartD
         _yMin = DBL_MAX
         _yMax = -DBL_MAX
         
-        for (var i = start; i <= endValue; i++)
+        for (var i = start; i <= endValue; i += 1)
         {
             if let e = _yVals[i] as? BarChartDataEntry
             {

--- a/Charts/Classes/Data/Implementations/Standard/BubbleChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/BubbleChartDataSet.swift
@@ -55,41 +55,43 @@ public class BubbleChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBubble
         _yMin = yMin(entries[start])
         _yMax = yMax(entries[start])
         
-        for (var i = start; i <= endValue; i += 1)
-        {
-            let entry = entries[i]
-
-            let ymin = yMin(entry)
-            let ymax = yMax(entry)
-            
-            if (ymin < _yMin)
+        if start <= endValue {
+            for i in start ... endValue
             {
-                _yMin = ymin
-            }
-            
-            if (ymax > _yMax)
-            {
-                _yMax = ymax
-            }
-            
-            let xmin = xMin(entry)
-            let xmax = xMax(entry)
-            
-            if (xmin < _xMin)
-            {
-                _xMin = xmin
-            }
-            
-            if (xmax > _xMax)
-            {
-                _xMax = xmax
-            }
-
-            let size = largestSize(entry)
-            
-            if (size > _maxSize)
-            {
-                _maxSize = size
+                let entry = entries[i]
+                
+                let ymin = yMin(entry)
+                let ymax = yMax(entry)
+                
+                if (ymin < _yMin)
+                {
+                    _yMin = ymin
+                }
+                
+                if (ymax > _yMax)
+                {
+                    _yMax = ymax
+                }
+                
+                let xmin = xMin(entry)
+                let xmax = xMax(entry)
+                
+                if (xmin < _xMin)
+                {
+                    _xMin = xmin
+                }
+                
+                if (xmax > _xMax)
+                {
+                    _xMax = xmax
+                }
+                
+                let size = largestSize(entry)
+                
+                if (size > _maxSize)
+                {
+                    _maxSize = size
+                }
             }
         }
     }

--- a/Charts/Classes/Data/Implementations/Standard/BubbleChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/BubbleChartDataSet.swift
@@ -55,7 +55,7 @@ public class BubbleChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBubble
         _yMin = yMin(entries[start])
         _yMax = yMax(entries[start])
         
-        for (var i = start; i <= endValue; i++)
+        for (var i = start; i <= endValue; i += 1)
         {
             let entry = entries[i]
 

--- a/Charts/Classes/Data/Implementations/Standard/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/CandleChartDataSet.swift
@@ -58,18 +58,20 @@ public class CandleChartDataSet: LineScatterCandleRadarChartDataSet, ICandleChar
         _yMin = DBL_MAX
         _yMax = -DBL_MAX
         
-        for (var i = start; i <= endValue; i += 1)
-        {
-            let e = entries[i]
-            
-            if (e.low < _yMin)
+        if start <= endValue {
+            for i in start ... endValue
             {
-                _yMin = e.low
-            }
-            
-            if (e.high > _yMax)
-            {
-                _yMax = e.high
+                let e = entries[i]
+                
+                if (e.low < _yMin)
+                {
+                    _yMin = e.low
+                }
+                
+                if (e.high > _yMax)
+                {
+                    _yMax = e.high
+                }
             }
         }
     }

--- a/Charts/Classes/Data/Implementations/Standard/CandleChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/CandleChartDataSet.swift
@@ -58,7 +58,7 @@ public class CandleChartDataSet: LineScatterCandleRadarChartDataSet, ICandleChar
         _yMin = DBL_MAX
         _yMax = -DBL_MAX
         
-        for (var i = start; i <= endValue; i++)
+        for (var i = start; i <= endValue; i += 1)
         {
             let e = entries[i]
             

--- a/Charts/Classes/Data/Implementations/Standard/ChartData.swift
+++ b/Charts/Classes/Data/Implementations/Standard/ChartData.swift
@@ -106,7 +106,7 @@ public class ChartData: NSObject
         
         var sum = 1
         
-        for (var i = 0; i < _xVals.count; i++)
+        for (var i = 0; i < _xVals.count; i += 1)
         {
             sum += _xVals[i] == nil ? 0 : (_xVals[i]!).characters.count
         }
@@ -128,7 +128,7 @@ public class ChartData: NSObject
             return
         }
         
-        for (var i = 0; i < dataSets.count; i++)
+        for (var i = 0; i < dataSets.count; i += 1)
         {
             if (dataSets[i].entryCount > _xVals.count)
             {
@@ -162,7 +162,7 @@ public class ChartData: NSObject
             _yMin = DBL_MAX
             _yMax = -DBL_MAX
             
-            for (var i = 0; i < _dataSets.count; i++)
+            for (var i = 0; i < _dataSets.count; i += 1)
             {
                 _dataSets[i].calcMinMax(start: start, end: end)
                 
@@ -250,7 +250,7 @@ public class ChartData: NSObject
         
         var count = 0
         
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             count += _dataSets[i].entryCount
         }
@@ -370,7 +370,7 @@ public class ChartData: NSObject
     {
         if (ignorecase)
         {
-            for (var i = 0; i < dataSets.count; i++)
+            for (var i = 0; i < dataSets.count; i += 1)
             {
                 if (dataSets[i].label == nil)
                 {
@@ -384,7 +384,7 @@ public class ChartData: NSObject
         }
         else
         {
-            for (var i = 0; i < dataSets.count; i++)
+            for (var i = 0; i < dataSets.count; i += 1)
             {
                 if (label == dataSets[i].label)
                 {
@@ -407,7 +407,7 @@ public class ChartData: NSObject
     {
         var types = [String]()
         
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             if (dataSets[i].label == nil)
             {
@@ -556,7 +556,7 @@ public class ChartData: NSObject
             return false
         }
         
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             if (_dataSets[i] === dataSet)
             {
@@ -707,7 +707,7 @@ public class ChartData: NSObject
             return nil
         }
         
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             let set = _dataSets[i]
             
@@ -723,7 +723,7 @@ public class ChartData: NSObject
     /// - returns: the index of the provided DataSet inside the DataSets array of this data object. -1 if the DataSet was not found.
     public func indexOfDataSet(dataSet: IChartDataSet) -> Int
     {
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             if (_dataSets[i] === dataSet)
             {
@@ -772,14 +772,14 @@ public class ChartData: NSObject
         
         var clrcnt = 0
         
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             clrcnt += _dataSets[i].colors.count
         }
         
         var colors = [NSUIColor]()
         
-        for (var i = 0; i < _dataSets.count; i++)
+        for (var i = 0; i < _dataSets.count; i += 1)
         {
             let clrs = _dataSets[i].colors
             
@@ -797,7 +797,7 @@ public class ChartData: NSObject
     {
         var xvals = [String]()
         
-        for (var i = from; i < to; i++)
+        for (var i = from; i < to; i += 1)
         {
             xvals.append(String(i))
         }

--- a/Charts/Classes/Data/Implementations/Standard/ChartData.swift
+++ b/Charts/Classes/Data/Implementations/Standard/ChartData.swift
@@ -106,7 +106,7 @@ public class ChartData: NSObject
         
         var sum = 1
         
-        for (var i = 0; i < _xVals.count; i += 1)
+        for i in 0 ..< _xVals.count
         {
             sum += _xVals[i] == nil ? 0 : (_xVals[i]!).characters.count
         }
@@ -128,7 +128,7 @@ public class ChartData: NSObject
             return
         }
         
-        for (var i = 0; i < dataSets.count; i += 1)
+        for i in 0 ..< dataSets.count
         {
             if (dataSets[i].entryCount > _xVals.count)
             {
@@ -162,7 +162,7 @@ public class ChartData: NSObject
             _yMin = DBL_MAX
             _yMax = -DBL_MAX
             
-            for (var i = 0; i < _dataSets.count; i += 1)
+            for i in 0 ..< _dataSets.count
             {
                 _dataSets[i].calcMinMax(start: start, end: end)
                 
@@ -250,7 +250,7 @@ public class ChartData: NSObject
         
         var count = 0
         
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             count += _dataSets[i].entryCount
         }
@@ -370,7 +370,7 @@ public class ChartData: NSObject
     {
         if (ignorecase)
         {
-            for (var i = 0; i < dataSets.count; i += 1)
+            for i in 0 ..< dataSets.count
             {
                 if (dataSets[i].label == nil)
                 {
@@ -384,7 +384,7 @@ public class ChartData: NSObject
         }
         else
         {
-            for (var i = 0; i < dataSets.count; i += 1)
+            for i in 0 ..< dataSets.count
             {
                 if (label == dataSets[i].label)
                 {
@@ -407,7 +407,7 @@ public class ChartData: NSObject
     {
         var types = [String]()
         
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             if (dataSets[i].label == nil)
             {
@@ -556,7 +556,7 @@ public class ChartData: NSObject
             return false
         }
         
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             if (_dataSets[i] === dataSet)
             {
@@ -707,7 +707,7 @@ public class ChartData: NSObject
             return nil
         }
         
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             let set = _dataSets[i]
             
@@ -723,7 +723,7 @@ public class ChartData: NSObject
     /// - returns: the index of the provided DataSet inside the DataSets array of this data object. -1 if the DataSet was not found.
     public func indexOfDataSet(dataSet: IChartDataSet) -> Int
     {
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             if (_dataSets[i] === dataSet)
             {
@@ -772,14 +772,14 @@ public class ChartData: NSObject
         
         var clrcnt = 0
         
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             clrcnt += _dataSets[i].colors.count
         }
         
         var colors = [NSUIColor]()
         
-        for (var i = 0; i < _dataSets.count; i += 1)
+        for i in 0 ..< _dataSets.count
         {
             let clrs = _dataSets[i].colors
             
@@ -797,9 +797,11 @@ public class ChartData: NSObject
     {
         var xvals = [String]()
         
-        for (var i = from; i < to; i += 1)
-        {
-            xvals.append(String(i))
+        if from < to {
+            for i in from ..< to
+            {
+                xvals.append(String(i))
+            }
         }
         
         return xvals

--- a/Charts/Classes/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/ChartDataSet.swift
@@ -98,19 +98,21 @@ public class ChartDataSet: ChartBaseDataSet
         _yMin = DBL_MAX
         _yMax = -DBL_MAX
         
-        for (var i = start; i <= endValue; i += 1)
-        {
-            let e = _yVals[i]
-            
-            if (!e.value.isNaN)
+        if start <= endValue {
+            for i in start ... endValue
             {
-                if (e.value < _yMin)
+                let e = _yVals[i]
+                
+                if (!e.value.isNaN)
                 {
-                    _yMin = e.value
-                }
-                if (e.value > _yMax)
-                {
-                    _yMax = e.value
+                    if (e.value < _yMin)
+                    {
+                        _yMin = e.value
+                    }
+                    if (e.value > _yMax)
+                    {
+                        _yMax = e.value
+                    }
                 }
             }
         }
@@ -189,7 +191,7 @@ public class ChartDataSet: ChartBaseDataSet
                 }
                 
                 high = _yVals.count
-                for (; m < high; m += 1)
+                while m < high
                 {
                     entry = _yVals[m]
                     if (entry.xIndex == x)
@@ -200,6 +202,8 @@ public class ChartDataSet: ChartBaseDataSet
                     {
                         break
                     }
+                    
+                    m += 1
                 }
             }
             
@@ -281,7 +285,7 @@ public class ChartDataSet: ChartBaseDataSet
     /// - parameter e: the entry to search for
     public override func entryIndex(entry e: ChartDataEntry) -> Int
     {
-        for (var i = 0; i < _yVals.count; i += 1)
+        for i in 0 ..< _yVals.count
         {
             if _yVals[i] === e
             {
@@ -384,7 +388,7 @@ public class ChartDataSet: ChartBaseDataSet
     {
         var removed = false
         
-        for (var i = 0; i < _yVals.count; i += 1)
+        for i in 0 ..< _yVals.count
         {
             if (_yVals[i] === entry)
             {

--- a/Charts/Classes/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/ChartDataSet.swift
@@ -98,7 +98,7 @@ public class ChartDataSet: ChartBaseDataSet
         _yMin = DBL_MAX
         _yMax = -DBL_MAX
         
-        for (var i = start; i <= endValue; i++)
+        for (var i = start; i <= endValue; i += 1)
         {
             let e = _yVals[i]
             
@@ -185,11 +185,11 @@ public class ChartDataSet: ChartBaseDataSet
             {
                 while (m > 0 && _yVals[m - 1].xIndex == x)
                 {
-                    m--
+                    m -= 1
                 }
                 
                 high = _yVals.count
-                for (; m < high; m++)
+                for (; m < high; m += 1)
                 {
                     entry = _yVals[m]
                     if (entry.xIndex == x)
@@ -235,7 +235,7 @@ public class ChartDataSet: ChartBaseDataSet
             {
                 while (m > 0 && _yVals[m - 1].xIndex == x)
                 {
-                    m--
+                    m -= 1
                 }
                 
                 return m
@@ -281,7 +281,7 @@ public class ChartDataSet: ChartBaseDataSet
     /// - parameter e: the entry to search for
     public override func entryIndex(entry e: ChartDataEntry) -> Int
     {
-        for (var i = 0; i < _yVals.count; i++)
+        for (var i = 0; i < _yVals.count; i += 1)
         {
             if _yVals[i] === e
             {
@@ -364,7 +364,7 @@ public class ChartDataSet: ChartBaseDataSet
             var closestIndex = entryIndex(xIndex: e.xIndex, rounding: .Closest)
             if _yVals[closestIndex].xIndex < e.xIndex
             {
-                closestIndex++
+                closestIndex += 1
             }
             _yVals.insert(e, atIndex: closestIndex)
             
@@ -384,7 +384,7 @@ public class ChartDataSet: ChartBaseDataSet
     {
         var removed = false
         
-        for (var i = 0; i < _yVals.count; i++)
+        for (var i = 0; i < _yVals.count; i += 1)
         {
             if (_yVals[i] === entry)
             {

--- a/Charts/Classes/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/LineChartDataSet.swift
@@ -83,15 +83,16 @@ public class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     
     /// - returns: the color at the given index of the DataSet's circle-color array.
     /// Performs a IndexOutOfBounds check by modulus.
-    public func getCircleColor(var index: Int) -> NSUIColor?
+    public func getCircleColor(index: Int) -> NSUIColor?
     {
+        var indexVar = index
         let size = circleColors.count
-        index = index % size
-        if (index >= size)
+        indexVar = indexVar % size
+        if (indexVar >= size)
         {
             return nil
         }
-        return circleColors[index]
+        return circleColors[indexVar]
     }
     
     /// Sets the one and ONLY color that should be used for this DataSet.

--- a/Charts/Classes/Data/Interfaces/IChartDataSet.swift
+++ b/Charts/Classes/Data/Interfaces/IChartDataSet.swift
@@ -143,7 +143,7 @@ public protocol IChartDataSet
     
     /// - returns: the color at the given index of the DataSet's color array.
     /// This prevents out-of-bounds by performing a modulus on the color index, so colours will repeat themselves.
-    func colorAt(var index: Int) -> NSUIColor
+    func colorAt(index: Int) -> NSUIColor
     
     func resetColors()
     
@@ -166,7 +166,7 @@ public protocol IChartDataSet
     var valueTextColor: NSUIColor { get set }
     
     /// - returns: the color at the specified index that is used for drawing the values inside the chart. Uses modulus internally.
-    func valueTextColorAt(var index: Int) -> NSUIColor
+    func valueTextColorAt(index: Int) -> NSUIColor
     
     /// the font for the value-text labels
     var valueFont: NSUIFont { get set }

--- a/Charts/Classes/Data/Interfaces/ILineChartDataSet.swift
+++ b/Charts/Classes/Data/Interfaces/ILineChartDataSet.swift
@@ -45,7 +45,7 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     
     /// - returns: the color at the given index of the DataSet's circle-color array.
     /// Performs a IndexOutOfBounds check by modulus.
-    func getCircleColor(var index: Int) -> NSUIColor?
+    func getCircleColor(index: Int) -> NSUIColor?
     
     /// Sets the one and ONLY color that should be used for this DataSet.
     /// Internally, this recreates the colors array and adds the specified color.

--- a/Charts/Classes/Filters/ChartDataApproximatorFilter.swift
+++ b/Charts/Classes/Filters/ChartDataApproximatorFilter.swift
@@ -110,7 +110,7 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
         
         // create a new array with series, only take the kept ones
         var reducedEntries = [ChartDataEntry]()
-        for (var i = 0; i < entries.count; i += 1)
+        for i in 0 ..< entries.count
         {
             if (keep[i])
             {
@@ -143,15 +143,17 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
         let firstEntry = entries[start]
         let lastEntry = entries[end]
         
-        for (var i = start + 1; i < end; i += 1)
-        {
-            let dist = calcAngleBetweenLines(firstEntry, end1: lastEntry, start2: firstEntry, end2: entries[i])
-            
-            // keep the point with the greatest distance
-            if (dist > distMax)
+        if start + 1 < end {
+            for i in start + 1 ..< end
             {
-                distMax = dist
-                maxDistIndex = i
+                let dist = calcAngleBetweenLines(firstEntry, end1: lastEntry, start2: firstEntry, end2: entries[i])
+                
+                // keep the point with the greatest distance
+                if (dist > distMax)
+                {
+                    distMax = dist
+                    maxDistIndex = i
+                }
             }
         }
         

--- a/Charts/Classes/Filters/ChartDataApproximatorFilter.swift
+++ b/Charts/Classes/Filters/ChartDataApproximatorFilter.swift
@@ -110,7 +110,7 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
         
         // create a new array with series, only take the kept ones
         var reducedEntries = [ChartDataEntry]()
-        for (var i = 0; i < entries.count; i++)
+        for (var i = 0; i < entries.count; i += 1)
         {
             if (keep[i])
             {
@@ -143,7 +143,7 @@ public class ChartDataApproximatorFilter: ChartDataBaseFilter
         let firstEntry = entries[start]
         let lastEntry = entries[end]
         
-        for (var i = start + 1; i < end; i++)
+        for (var i = start + 1; i < end; i += 1)
         {
             let dist = calcAngleBetweenLines(firstEntry, end1: lastEntry, start2: firstEntry, end2: entries[i])
             

--- a/Charts/Classes/Highlight/BarChartHighlighter.swift
+++ b/Charts/Classes/Highlight/BarChartHighlighter.swift
@@ -219,7 +219,8 @@ public class BarChartHighlighter: ChartHighlighter
         var ranges = [ChartRange]()
         ranges.reserveCapacity(values!.count)
         
-        for (var i = 0, count = values!.count; i < count; i += 1)
+        let count = values!.count
+        for i in 0 ..< count
         {
             let value = values![i]
             

--- a/Charts/Classes/Highlight/BarChartHighlighter.swift
+++ b/Charts/Classes/Highlight/BarChartHighlighter.swift
@@ -161,7 +161,7 @@ public class BarChartHighlighter: ChartHighlighter
             }
             else
             {
-                stackIndex++
+                stackIndex += 1
             }
         }
         
@@ -219,7 +219,7 @@ public class BarChartHighlighter: ChartHighlighter
         var ranges = [ChartRange]()
         ranges.reserveCapacity(values!.count)
         
-        for (var i = 0, count = values!.count; i < count; i++)
+        for (var i = 0, count = values!.count; i < count; i += 1)
         {
             let value = values![i]
             

--- a/Charts/Classes/Highlight/ChartHighlighter.swift
+++ b/Charts/Classes/Highlight/ChartHighlighter.swift
@@ -87,30 +87,32 @@ public class ChartHighlighter : NSObject
         var vals = [ChartSelectionDetail]()
         var pt = CGPoint()
         
-        for (var i = 0, dataSetCount = self.chart?.data?.dataSetCount; i < dataSetCount; i += 1)
-        {
-            let dataSet = self.chart!.data!.getDataSetByIndex(i)
-            
-            // dont include datasets that cannot be highlighted
-            if !dataSet.isHighlightEnabled
+        if let dataSetCount = self.chart?.data?.dataSetCount {
+            for i in 0 ..< dataSetCount
             {
-                continue
-            }
-            
-            // extract all y-values from all DataSets at the given x-index
-            let yVal: Double = dataSet.yValForXIndex(xIndex)
-            if yVal.isNaN
-            {
-                continue
-            }
-            
-            pt.y = CGFloat(yVal)
-            
-            self.chart!.getTransformer(dataSet.axisDependency).pointValueToPixel(&pt)
-            
-            if !pt.y.isNaN
-            {
-                vals.append(ChartSelectionDetail(value: Double(pt.y), dataSetIndex: i, dataSet: dataSet))
+                let dataSet = self.chart!.data!.getDataSetByIndex(i)
+                
+                // dont include datasets that cannot be highlighted
+                if !dataSet.isHighlightEnabled
+                {
+                    continue
+                }
+                
+                // extract all y-values from all DataSets at the given x-index
+                let yVal: Double = dataSet.yValForXIndex(xIndex)
+                if yVal.isNaN
+                {
+                    continue
+                }
+                
+                pt.y = CGFloat(yVal)
+                
+                self.chart!.getTransformer(dataSet.axisDependency).pointValueToPixel(&pt)
+                
+                if !pt.y.isNaN
+                {
+                    vals.append(ChartSelectionDetail(value: Double(pt.y), dataSetIndex: i, dataSet: dataSet))
+                }
             }
         }
         

--- a/Charts/Classes/Highlight/ChartHighlighter.swift
+++ b/Charts/Classes/Highlight/ChartHighlighter.swift
@@ -87,7 +87,7 @@ public class ChartHighlighter : NSObject
         var vals = [ChartSelectionDetail]()
         var pt = CGPoint()
         
-        for (var i = 0, dataSetCount = self.chart?.data?.dataSetCount; i < dataSetCount; i++)
+        for (var i = 0, dataSetCount = self.chart?.data?.dataSetCount; i < dataSetCount; i += 1)
         {
             let dataSet = self.chart!.data!.getDataSetByIndex(i)
             

--- a/Charts/Classes/Highlight/CombinedHighlighter.swift
+++ b/Charts/Classes/Highlight/CombinedHighlighter.swift
@@ -31,9 +31,9 @@ public class CombinedHighlighter: ChartHighlighter
             
             var pt = CGPoint()
             
-            for var i = 0; i < dataObjects.count; i++
+            for var i = 0; i < dataObjects.count; i += 1
             {
-                for var j = 0; j < dataObjects[i].dataSetCount; j++
+                for var j = 0; j < dataObjects[i].dataSetCount; j += 1
                 {
                     let dataSet = dataObjects[i].getDataSetByIndex(j)
                     

--- a/Charts/Classes/Highlight/CombinedHighlighter.swift
+++ b/Charts/Classes/Highlight/CombinedHighlighter.swift
@@ -31,9 +31,9 @@ public class CombinedHighlighter: ChartHighlighter
             
             var pt = CGPoint()
             
-            for var i = 0; i < dataObjects.count; i += 1
+            for i in 0 ..< dataObjects.count
             {
-                for var j = 0; j < dataObjects[i].dataSetCount; j += 1
+                for j in 0 ..< dataObjects[i].dataSetCount
                 {
                     let dataSet = dataObjects[i].getDataSetByIndex(j)
                     

--- a/Charts/Classes/Jobs/AnimatedViewPortJob.swift
+++ b/Charts/Classes/Jobs/AnimatedViewPortJob.swift
@@ -70,7 +70,7 @@ public class AnimatedViewPortJob: ChartViewPortJob
         
         updateAnimationPhase(_startTime)
         
-        _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
+        _displayLink = NSUIDisplayLink(target: self, selector: #selector(AnimatedViewPortJob.animationLoop))
         _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
     }
     

--- a/Charts/Classes/Jobs/AnimatedViewPortJob.swift
+++ b/Charts/Classes/Jobs/AnimatedViewPortJob.swift
@@ -70,7 +70,7 @@ public class AnimatedViewPortJob: ChartViewPortJob
         
         updateAnimationPhase(_startTime)
         
-        _displayLink = NSUIDisplayLink(target: self, selector: #selector(AnimatedViewPortJob.animationLoop))
+        _displayLink = NSUIDisplayLink(target: self, selector: Selector("animationLoop"))
         _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
     }
     

--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -33,7 +33,7 @@ public class BarChartRenderer: ChartDataRendererBase
     {
         guard let dataProvider = dataProvider, barData = dataProvider.barData else { return }
         
-        for (var i = 0; i < barData.dataSetCount; i += 1)
+        for i in 0 ..< barData.dataSetCount
         {
             guard let set = barData.getDataSetByIndex(i) else { continue }
             
@@ -76,7 +76,8 @@ public class BarChartRenderer: ChartDataRendererBase
         var y: Double
         
         // do the drawing
-        for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
+        let count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX))
+        for j in 0 ..< count
         {
             guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
             
@@ -180,7 +181,7 @@ public class BarChartRenderer: ChartDataRendererBase
                 }
                 
                 // fill the stack
-                for (var k = 0; k < vals!.count; k += 1)
+                for k in 0 ..< vals!.count
                 {
                     let value = vals![k]
                     
@@ -280,7 +281,8 @@ public class BarChartRenderer: ChartDataRendererBase
             var posOffset: CGFloat
             var negOffset: CGFloat
             
-            for (var dataSetIndex = 0, count = barData.dataSetCount; dataSetIndex < count; dataSetIndex += 1)
+            let count = barData.dataSetCount
+            for dataSetIndex in 0 ..< count
             {
                 guard let dataSet = dataSets[dataSetIndex] as? IBarChartDataSet else { continue }
                 
@@ -315,7 +317,8 @@ public class BarChartRenderer: ChartDataRendererBase
                 // if only single values are drawn (sum)
                 if (!dataSet.isStacked)
                 {
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
+                    let count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX))
+                    for j in 0 ..< count
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -354,7 +357,8 @@ public class BarChartRenderer: ChartDataRendererBase
                 {
                     // if we have stacks
                     
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
+                    let count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX))
+                    for j in 0 ..< count
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -394,7 +398,7 @@ public class BarChartRenderer: ChartDataRendererBase
                             var posY = 0.0
                             var negY = -e.negativeSum
                             
-                            for (var k = 0; k < vals.count; k += 1)
+                            for k in 0 ..< vals.count
                             {
                                 let value = vals[k]
                                 var y: Double
@@ -415,7 +419,7 @@ public class BarChartRenderer: ChartDataRendererBase
                             
                             trans.pointValuesToPixel(&transformed)
                             
-                            for (var k = 0; k < transformed.count; k += 1)
+                            for k in 0 ..< transformed.count
                             {
                                 let x = valuePoint.x
                                 let y = transformed[k].y + (vals[k] >= 0 ? posOffset : negOffset)
@@ -472,7 +476,7 @@ public class BarChartRenderer: ChartDataRendererBase
         let drawHighlightArrowEnabled = dataProvider.isDrawHighlightArrowEnabled
         var barRect = CGRect()
         
-        for (var i = 0; i < indices.count; i += 1)
+        for i in 0 ..< indices.count
         {
             let h = indices[i]
             let index = h.xIndex

--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -33,7 +33,7 @@ public class BarChartRenderer: ChartDataRendererBase
     {
         guard let dataProvider = dataProvider, barData = dataProvider.barData else { return }
         
-        for (var i = 0; i < barData.dataSetCount; i++)
+        for (var i = 0; i < barData.dataSetCount; i += 1)
         {
             guard let set = barData.getDataSetByIndex(i) else { continue }
             
@@ -76,7 +76,7 @@ public class BarChartRenderer: ChartDataRendererBase
         var y: Double
         
         // do the drawing
-        for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j++)
+        for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
         {
             guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
             
@@ -180,7 +180,7 @@ public class BarChartRenderer: ChartDataRendererBase
                 }
                 
                 // fill the stack
-                for (var k = 0; k < vals!.count; k++)
+                for (var k = 0; k < vals!.count; k += 1)
                 {
                     let value = vals![k]
                     
@@ -280,7 +280,7 @@ public class BarChartRenderer: ChartDataRendererBase
             var posOffset: CGFloat
             var negOffset: CGFloat
             
-            for (var dataSetIndex = 0, count = barData.dataSetCount; dataSetIndex < count; dataSetIndex++)
+            for (var dataSetIndex = 0, count = barData.dataSetCount; dataSetIndex < count; dataSetIndex += 1)
             {
                 guard let dataSet = dataSets[dataSetIndex] as? IBarChartDataSet else { continue }
                 
@@ -315,7 +315,7 @@ public class BarChartRenderer: ChartDataRendererBase
                 // if only single values are drawn (sum)
                 if (!dataSet.isStacked)
                 {
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j++)
+                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -354,7 +354,7 @@ public class BarChartRenderer: ChartDataRendererBase
                 {
                     // if we have stacks
                     
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j++)
+                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -394,7 +394,7 @@ public class BarChartRenderer: ChartDataRendererBase
                             var posY = 0.0
                             var negY = -e.negativeSum
                             
-                            for (var k = 0; k < vals.count; k++)
+                            for (var k = 0; k < vals.count; k += 1)
                             {
                                 let value = vals[k]
                                 var y: Double
@@ -415,7 +415,7 @@ public class BarChartRenderer: ChartDataRendererBase
                             
                             trans.pointValuesToPixel(&transformed)
                             
-                            for (var k = 0; k < transformed.count; k++)
+                            for (var k = 0; k < transformed.count; k += 1)
                             {
                                 let x = valuePoint.x
                                 let y = transformed[k].y + (vals[k] >= 0 ? posOffset : negOffset)
@@ -472,7 +472,7 @@ public class BarChartRenderer: ChartDataRendererBase
         let drawHighlightArrowEnabled = dataProvider.isDrawHighlightArrowEnabled
         var barRect = CGRect()
         
-        for (var i = 0; i < indices.count; i++)
+        for (var i = 0; i < indices.count; i += 1)
         {
             let h = indices[i]
             let index = h.xIndex

--- a/Charts/Classes/Renderers/BubbleChartRenderer.swift
+++ b/Charts/Classes/Renderers/BubbleChartRenderer.swift
@@ -89,7 +89,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
         let maxBubbleHeight: CGFloat = abs(viewPortHandler.contentBottom - viewPortHandler.contentTop)
         let referenceSize: CGFloat = min(maxBubbleHeight, maxBubbleWidth)
         
-        for (var j = minx; j < maxx; j++)
+        for (var j = minx; j < maxx; j += 1)
         {
             guard let entry = dataSet.entryForIndex(j) as? BubbleChartDataEntry else { continue }
             
@@ -174,7 +174,7 @@ public class BubbleChartRenderer: ChartDataRendererBase
                 let minx = max(dataSet.entryIndex(entry: entryFrom), 0)
                 let maxx = min(dataSet.entryIndex(entry: entryTo) + 1, entryCount)
                 
-                for (var j = minx; j < maxx; j++)
+                for (var j = minx; j < maxx; j += 1)
                 {
                     guard let e = dataSet.entryForIndex(j) as? BubbleChartDataEntry else { break }
                     

--- a/Charts/Classes/Renderers/CandleStickChartRenderer.swift
+++ b/Charts/Classes/Renderers/CandleStickChartRenderer.swift
@@ -71,7 +71,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSetLineWidth(context, dataSet.shadowWidth)
         
-        for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
+        for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
         {
             // get the entry
             guard let e = dataSet.entryForIndex(j) as? CandleChartDataEntry else { continue }
@@ -262,7 +262,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
             
             var pt = CGPoint()
             
-            for (var i = 0; i < dataSets.count; i++)
+            for (var i = 0; i < dataSets.count; i += 1)
             {
                 let dataSet = dataSets[i]
                 
@@ -286,7 +286,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
                 let lineHeight = valueFont.lineHeight
                 let yOffset: CGFloat = lineHeight + 5.0
                 
-                for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
+                for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
                 {
                     guard let e = dataSet.entryForIndex(j) as? CandleChartDataEntry else { break }
                     
@@ -333,7 +333,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var i = 0; i < indices.count; i++)
+        for (var i = 0; i < indices.count; i += 1)
         {
             let xIndex = indices[i].xIndex; // get the x-position
             

--- a/Charts/Classes/Renderers/CandleStickChartRenderer.swift
+++ b/Charts/Classes/Renderers/CandleStickChartRenderer.swift
@@ -71,173 +71,177 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSetLineWidth(context, dataSet.shadowWidth)
         
-        for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
-        {
-            // get the entry
-            guard let e = dataSet.entryForIndex(j) as? CandleChartDataEntry else { continue }
-            
-            let xIndex = e.xIndex
-            
-            if (xIndex < minx || xIndex >= maxx)
+        let count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
+        
+        if minx < count {
+            for j in minx ..< count
             {
-                continue
-            }
-            
-            let open = e.open
-            let close = e.close
-            let high = e.high
-            let low = e.low
-            
-            if (showCandleBar)
-            {
-                // calculate the shadow
+                // get the entry
+                guard let e = dataSet.entryForIndex(j) as? CandleChartDataEntry else { continue }
                 
-                _shadowPoints[0].x = CGFloat(xIndex)
-                _shadowPoints[1].x = CGFloat(xIndex)
-                _shadowPoints[2].x = CGFloat(xIndex)
-                _shadowPoints[3].x = CGFloat(xIndex)
+                let xIndex = e.xIndex
                 
-                if (open > close)
+                if (xIndex < minx || xIndex >= maxx)
                 {
-                    _shadowPoints[0].y = CGFloat(high) * phaseY
-                    _shadowPoints[1].y = CGFloat(open) * phaseY
-                    _shadowPoints[2].y = CGFloat(low) * phaseY
-                    _shadowPoints[3].y = CGFloat(close) * phaseY
-                }
-                else if (open < close)
-                {
-                    _shadowPoints[0].y = CGFloat(high) * phaseY
-                    _shadowPoints[1].y = CGFloat(close) * phaseY
-                    _shadowPoints[2].y = CGFloat(low) * phaseY
-                    _shadowPoints[3].y = CGFloat(open) * phaseY
-                }
-                else
-                {
-                    _shadowPoints[0].y = CGFloat(high) * phaseY
-                    _shadowPoints[1].y = CGFloat(open) * phaseY
-                    _shadowPoints[2].y = CGFloat(low) * phaseY
-                    _shadowPoints[3].y = _shadowPoints[1].y
+                    continue
                 }
                 
-                trans.pointValuesToPixel(&_shadowPoints)
+                let open = e.open
+                let close = e.close
+                let high = e.high
+                let low = e.low
                 
-                // draw the shadows
-                
-                var shadowColor: NSUIColor! = nil
-                if (dataSet.shadowColorSameAsCandle)
+                if (showCandleBar)
                 {
+                    // calculate the shadow
+                    
+                    _shadowPoints[0].x = CGFloat(xIndex)
+                    _shadowPoints[1].x = CGFloat(xIndex)
+                    _shadowPoints[2].x = CGFloat(xIndex)
+                    _shadowPoints[3].x = CGFloat(xIndex)
+                    
                     if (open > close)
                     {
-                        shadowColor = dataSet.decreasingColor ?? dataSet.colorAt(j)
+                        _shadowPoints[0].y = CGFloat(high) * phaseY
+                        _shadowPoints[1].y = CGFloat(open) * phaseY
+                        _shadowPoints[2].y = CGFloat(low) * phaseY
+                        _shadowPoints[3].y = CGFloat(close) * phaseY
                     }
                     else if (open < close)
                     {
-                        shadowColor = dataSet.increasingColor ?? dataSet.colorAt(j)
+                        _shadowPoints[0].y = CGFloat(high) * phaseY
+                        _shadowPoints[1].y = CGFloat(close) * phaseY
+                        _shadowPoints[2].y = CGFloat(low) * phaseY
+                        _shadowPoints[3].y = CGFloat(open) * phaseY
                     }
                     else
                     {
-                        shadowColor = dataSet.neutralColor ?? dataSet.colorAt(j)
+                        _shadowPoints[0].y = CGFloat(high) * phaseY
+                        _shadowPoints[1].y = CGFloat(open) * phaseY
+                        _shadowPoints[2].y = CGFloat(low) * phaseY
+                        _shadowPoints[3].y = _shadowPoints[1].y
                     }
-                }
-                
-                if (shadowColor === nil)
-                {
-                    shadowColor = dataSet.shadowColor ?? dataSet.colorAt(j);
-                }
-                
-                CGContextSetStrokeColorWithColor(context, shadowColor.CGColor)
-                CGContextStrokeLineSegments(context, _shadowPoints, 4)
-                
-                // calculate the body
-                
-                _bodyRect.origin.x = CGFloat(xIndex) - 0.5 + barSpace
-                _bodyRect.origin.y = CGFloat(close) * phaseY
-                _bodyRect.size.width = (CGFloat(xIndex) + 0.5 - barSpace) - _bodyRect.origin.x
-                _bodyRect.size.height = (CGFloat(open) * phaseY) - _bodyRect.origin.y
-                
-                trans.rectValueToPixel(&_bodyRect)
-                
-                // draw body differently for increasing and decreasing entry
-                
-                if (open > close)
-                {
-                    let color = dataSet.decreasingColor ?? dataSet.colorAt(j)
                     
-                    if (dataSet.isDecreasingFilled)
-                    {
-                        CGContextSetFillColorWithColor(context, color.CGColor)
-                        CGContextFillRect(context, _bodyRect)
-                    }
-                    else
-                    {
-                        CGContextSetStrokeColorWithColor(context, color.CGColor)
-                        CGContextStrokeRect(context, _bodyRect)
-                    }
-                }
-                else if (open < close)
-                {
-                    let color = dataSet.increasingColor ?? dataSet.colorAt(j)
+                    trans.pointValuesToPixel(&_shadowPoints)
                     
-                    if (dataSet.isIncreasingFilled)
+                    // draw the shadows
+                    
+                    var shadowColor: NSUIColor! = nil
+                    if (dataSet.shadowColorSameAsCandle)
                     {
-                        CGContextSetFillColorWithColor(context, color.CGColor)
-                        CGContextFillRect(context, _bodyRect)
+                        if (open > close)
+                        {
+                            shadowColor = dataSet.decreasingColor ?? dataSet.colorAt(j)
+                        }
+                        else if (open < close)
+                        {
+                            shadowColor = dataSet.increasingColor ?? dataSet.colorAt(j)
+                        }
+                        else
+                        {
+                            shadowColor = dataSet.neutralColor ?? dataSet.colorAt(j)
+                        }
+                    }
+                    
+                    if (shadowColor === nil)
+                    {
+                        shadowColor = dataSet.shadowColor ?? dataSet.colorAt(j);
+                    }
+                    
+                    CGContextSetStrokeColorWithColor(context, shadowColor.CGColor)
+                    CGContextStrokeLineSegments(context, _shadowPoints, 4)
+                    
+                    // calculate the body
+                    
+                    _bodyRect.origin.x = CGFloat(xIndex) - 0.5 + barSpace
+                    _bodyRect.origin.y = CGFloat(close) * phaseY
+                    _bodyRect.size.width = (CGFloat(xIndex) + 0.5 - barSpace) - _bodyRect.origin.x
+                    _bodyRect.size.height = (CGFloat(open) * phaseY) - _bodyRect.origin.y
+                    
+                    trans.rectValueToPixel(&_bodyRect)
+                    
+                    // draw body differently for increasing and decreasing entry
+                    
+                    if (open > close)
+                    {
+                        let color = dataSet.decreasingColor ?? dataSet.colorAt(j)
+                        
+                        if (dataSet.isDecreasingFilled)
+                        {
+                            CGContextSetFillColorWithColor(context, color.CGColor)
+                            CGContextFillRect(context, _bodyRect)
+                        }
+                        else
+                        {
+                            CGContextSetStrokeColorWithColor(context, color.CGColor)
+                            CGContextStrokeRect(context, _bodyRect)
+                        }
+                    }
+                    else if (open < close)
+                    {
+                        let color = dataSet.increasingColor ?? dataSet.colorAt(j)
+                        
+                        if (dataSet.isIncreasingFilled)
+                        {
+                            CGContextSetFillColorWithColor(context, color.CGColor)
+                            CGContextFillRect(context, _bodyRect)
+                        }
+                        else
+                        {
+                            CGContextSetStrokeColorWithColor(context, color.CGColor)
+                            CGContextStrokeRect(context, _bodyRect)
+                        }
                     }
                     else
                     {
+                        let color = dataSet.neutralColor ?? dataSet.colorAt(j)
+                        
                         CGContextSetStrokeColorWithColor(context, color.CGColor)
                         CGContextStrokeRect(context, _bodyRect)
                     }
                 }
                 else
                 {
-                    let color = dataSet.neutralColor ?? dataSet.colorAt(j)
+                    _rangePoints[0].x = CGFloat(xIndex)
+                    _rangePoints[0].y = CGFloat(high) * phaseY
+                    _rangePoints[1].x = CGFloat(xIndex)
+                    _rangePoints[1].y = CGFloat(low) * phaseY
                     
-                    CGContextSetStrokeColorWithColor(context, color.CGColor)
-                    CGContextStrokeRect(context, _bodyRect)
+                    _openPoints[0].x = CGFloat(xIndex) - 0.5 + barSpace
+                    _openPoints[0].y = CGFloat(open) * phaseY
+                    _openPoints[1].x = CGFloat(xIndex)
+                    _openPoints[1].y = CGFloat(open) * phaseY
+                    
+                    _closePoints[0].x = CGFloat(xIndex) + 0.5 - barSpace
+                    _closePoints[0].y = CGFloat(close) * phaseY
+                    _closePoints[1].x = CGFloat(xIndex)
+                    _closePoints[1].y = CGFloat(close) * phaseY
+                    
+                    trans.pointValuesToPixel(&_rangePoints)
+                    trans.pointValuesToPixel(&_openPoints)
+                    trans.pointValuesToPixel(&_closePoints)
+                    
+                    // draw the ranges
+                    var barColor: NSUIColor! = nil
+                    
+                    if (open > close)
+                    {
+                        barColor = dataSet.decreasingColor ?? dataSet.colorAt(j)
+                    }
+                    else if (open < close)
+                    {
+                        barColor = dataSet.increasingColor ?? dataSet.colorAt(j)
+                    }
+                    else
+                    {
+                        barColor = dataSet.neutralColor ?? dataSet.colorAt(j)
+                    }
+                    
+                    CGContextSetStrokeColorWithColor(context, barColor.CGColor)
+                    CGContextStrokeLineSegments(context, _rangePoints, 2)
+                    CGContextStrokeLineSegments(context, _openPoints, 2)
+                    CGContextStrokeLineSegments(context, _closePoints, 2)
                 }
-            }
-            else
-            {
-                _rangePoints[0].x = CGFloat(xIndex)
-                _rangePoints[0].y = CGFloat(high) * phaseY
-                _rangePoints[1].x = CGFloat(xIndex)
-                _rangePoints[1].y = CGFloat(low) * phaseY
-
-                _openPoints[0].x = CGFloat(xIndex) - 0.5 + barSpace
-                _openPoints[0].y = CGFloat(open) * phaseY
-                _openPoints[1].x = CGFloat(xIndex)
-                _openPoints[1].y = CGFloat(open) * phaseY
-
-                _closePoints[0].x = CGFloat(xIndex) + 0.5 - barSpace
-                _closePoints[0].y = CGFloat(close) * phaseY
-                _closePoints[1].x = CGFloat(xIndex)
-                _closePoints[1].y = CGFloat(close) * phaseY
-                
-                trans.pointValuesToPixel(&_rangePoints)
-                trans.pointValuesToPixel(&_openPoints)
-                trans.pointValuesToPixel(&_closePoints)
-                
-                // draw the ranges
-                var barColor: NSUIColor! = nil
-                
-                if (open > close)
-                {
-                    barColor = dataSet.decreasingColor ?? dataSet.colorAt(j)
-                }
-                else if (open < close)
-                {
-                    barColor = dataSet.increasingColor ?? dataSet.colorAt(j)
-                }
-                else
-                {
-                    barColor = dataSet.neutralColor ?? dataSet.colorAt(j)
-                }
-                
-                CGContextSetStrokeColorWithColor(context, barColor.CGColor)
-                CGContextStrokeLineSegments(context, _rangePoints, 2)
-                CGContextStrokeLineSegments(context, _openPoints, 2)
-                CGContextStrokeLineSegments(context, _closePoints, 2)
             }
         }
         
@@ -262,7 +266,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
             
             var pt = CGPoint()
             
-            for (var i = 0; i < dataSets.count; i += 1)
+            for i in 0 ..< dataSets.count
             {
                 let dataSet = dataSets[i]
                 
@@ -286,32 +290,35 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
                 let lineHeight = valueFont.lineHeight
                 let yOffset: CGFloat = lineHeight + 5.0
                 
-                for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
-                {
-                    guard let e = dataSet.entryForIndex(j) as? CandleChartDataEntry else { break }
-                    
-                    pt.x = CGFloat(e.xIndex)
-                    pt.y = CGFloat(e.high) * phaseY
-                    pt = CGPointApplyAffineTransform(pt, valueToPixelMatrix)
-                    
-                    if (!viewPortHandler.isInBoundsRight(pt.x))
+                let count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
+                if minx < count {
+                    for j in minx ..< count
                     {
-                        break
+                        guard let e = dataSet.entryForIndex(j) as? CandleChartDataEntry else { break }
+                        
+                        pt.x = CGFloat(e.xIndex)
+                        pt.y = CGFloat(e.high) * phaseY
+                        pt = CGPointApplyAffineTransform(pt, valueToPixelMatrix)
+                        
+                        if (!viewPortHandler.isInBoundsRight(pt.x))
+                        {
+                            break
+                        }
+                        
+                        if (!viewPortHandler.isInBoundsLeft(pt.x) || !viewPortHandler.isInBoundsY(pt.y))
+                        {
+                            continue
+                        }
+                        
+                        ChartUtils.drawText(
+                            context: context,
+                            text: formatter.stringFromNumber(e.high)!,
+                            point: CGPoint(
+                                x: pt.x,
+                                y: pt.y - yOffset),
+                            align: .Center,
+                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: dataSet.valueTextColorAt(j)])
                     }
-                    
-                    if (!viewPortHandler.isInBoundsLeft(pt.x) || !viewPortHandler.isInBoundsY(pt.y))
-                    {
-                        continue
-                    }
-                    
-                    ChartUtils.drawText(
-                        context: context,
-                        text: formatter.stringFromNumber(e.high)!,
-                        point: CGPoint(
-                            x: pt.x,
-                            y: pt.y - yOffset),
-                        align: .Center,
-                        attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: dataSet.valueTextColorAt(j)])
                 }
             }
         }
@@ -333,7 +340,7 @@ public class CandleStickChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var i = 0; i < indices.count; i += 1)
+        for i in 0 ..< indices.count
         {
             let xIndex = indices[i].xIndex; // get the x-position
             

--- a/Charts/Classes/Renderers/ChartLegendRenderer.swift
+++ b/Charts/Classes/Renderers/ChartLegendRenderer.swift
@@ -221,7 +221,7 @@ public class ChartLegendRenderer: ChartRendererBase
                 if (posX == originPosX && legendPosition == .BelowChartCenter && lineIndex < calculatedLineSizes.count)
                 {
                     posX += (direction == .RightToLeft ? calculatedLineSizes[lineIndex].width : -calculatedLineSizes[lineIndex].width) / 2.0
-                    lineIndex++
+                    lineIndex += 1
                 }
                 
                 let drawingForm = colors[i] != nil

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -38,7 +38,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         
         let max = Int(round(xValAverageLength + Double(xAxis.spaceBetweenLabels)))
         
-        for (var i = 0; i < max; i += 1)
+        for _ in 0 ..< max
         {
             a += "h"
         }
@@ -284,7 +284,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i += 1)
+        for i in 0 ..< limitLines.count
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartXAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRenderer.swift
@@ -38,7 +38,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         
         let max = Int(round(xValAverageLength + Double(xAxis.spaceBetweenLabels)))
         
-        for (var i = 0; i < max; i++)
+        for (var i = 0; i < max; i += 1)
         {
             a += "h"
         }
@@ -284,7 +284,7 @@ public class ChartXAxisRenderer: ChartAxisRendererBase
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i++)
+        for (var i = 0; i < limitLines.count; i += 1)
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
@@ -256,7 +256,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i += 1)
+        for i in 0 ..< limitLines.count
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
@@ -256,7 +256,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i++)
+        for (var i = 0; i < limitLines.count; i += 1)
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartXAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererRadarChart.swift
@@ -55,7 +55,8 @@ public class ChartXAxisRendererRadarChart: ChartXAxisRenderer
         let center = chart.centerOffsets
         
         let modulus = xAxis.axisLabelModulus
-        for var i = 0, count = xAxis.values.count; i < count; i += modulus
+        let count = xAxis.values.count
+        for i in 0.stride(to: count, by: modulus)
         {
             let label = xAxis.values[i]
             

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -114,7 +114,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             
             var v = yMin
             
-            for (var i = 0; i < labelCount; i++)
+            for (var i = 0; i < labelCount; i += 1)
             {
                 yAxis.entries.append(v)
                 v += step
@@ -140,7 +140,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
                 var n = 0
                 for (f = first; f <= last; f += interval)
                 {
-                    ++n
+                     n += 1
                 }
                 
                 if (yAxis.entries.count < n)
@@ -153,7 +153,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
                     yAxis.entries.removeRange(n..<yAxis.entries.count)
                 }
                 
-                for (f = first, i = 0; i < n; f += interval, ++i)
+                for (f = first, i = 0; i < n; f += interval, i += 1)
                 {
                     if (f == 0.0)
                     { // Fix for IEEE negative zero case (Where value == -0.0, and 0.0 == -0.0)
@@ -273,7 +273,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         
         var pt = CGPoint()
         
-        for (var i = 0; i < yAxis.entryCount; i++)
+        for (var i = 0; i < yAxis.entryCount; i += 1)
         {
             let text = yAxis.getFormattedLabel(i)
             
@@ -327,7 +327,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             var position = CGPoint(x: 0.0, y: 0.0)
             
             // draw the horizontal grid
-            for (var i = 0, count = yAxis.entryCount; i < count; i++)
+            for (var i = 0, count = yAxis.entryCount; i < count; i += 1)
             {
                 position.x = 0.0
                 position.y = CGFloat(yAxis.entries[i])
@@ -411,7 +411,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i++)
+        for (var i = 0; i < limitLines.count; i += 1)
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -31,8 +31,10 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
     }
     
     /// Computes the axis values.
-    public func computeAxis(var yMin yMin: Double, var yMax: Double)
+    public func computeAxis(yMin yMin: Double, yMax: Double)
     {
+        var yMinVar = yMin
+        var yMaxVar = yMax
         guard let yAxis = yAxis else { return }
         
         // calculate the starting and entry point of the y-labels (depending on
@@ -44,17 +46,17 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             
             if (!yAxis.isInverted)
             {
-                yMin = Double(p2.y)
-                yMax = Double(p1.y)
+                yMinVar = Double(p2.y)
+                yMaxVar = Double(p1.y)
             }
             else
             {
-                yMin = Double(p1.y)
-                yMax = Double(p2.y)
+                yMinVar = Double(p1.y)
+                yMaxVar = Double(p2.y)
             }
         }
         
-        computeAxisValues(min: yMin, max: yMax)
+        computeAxisValues(min: yMinVar, max: yMaxVar)
     }
     
     /// Sets up the y-axis labels. Computes the desired number of labels between

--- a/Charts/Classes/Renderers/ChartYAxisRenderer.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRenderer.swift
@@ -114,7 +114,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             
             var v = yMin
             
-            for (var i = 0; i < labelCount; i += 1)
+            for _ in 0 ..< labelCount
             {
                 yAxis.entries.append(v)
                 v += step
@@ -135,10 +135,8 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
                 let first = ceil(Double(yMin) / interval) * interval
                 let last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval)
                 
-                var f: Double
-                var i: Int
                 var n = 0
-                for (f = first; f <= last; f += interval)
+                for _ in first.stride(through: last, by: interval)
                 {
                      n += 1
                 }
@@ -153,7 +151,8 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
                     yAxis.entries.removeRange(n..<yAxis.entries.count)
                 }
                 
-                for (f = first, i = 0; i < n; f += interval, i += 1)
+                var f: Double = first
+                for i in 0 ..< n
                 {
                     if (f == 0.0)
                     { // Fix for IEEE negative zero case (Where value == -0.0, and 0.0 == -0.0)
@@ -161,6 +160,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
                     }
                     
                     yAxis.entries[i] = Double(f)
+                    f += interval
                 }
             }
         }
@@ -273,7 +273,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         
         var pt = CGPoint()
         
-        for (var i = 0; i < yAxis.entryCount; i += 1)
+        for i in 0 ..< yAxis.entryCount
         {
             let text = yAxis.getFormattedLabel(i)
             
@@ -327,7 +327,8 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
             var position = CGPoint(x: 0.0, y: 0.0)
             
             // draw the horizontal grid
-            for (var i = 0, count = yAxis.entryCount; i < count; i += 1)
+            let count = yAxis.entryCount
+            for i in 0 ..< count
             {
                 position.x = 0.0
                 position.y = CGFloat(yAxis.entries[i])
@@ -411,7 +412,7 @@ public class ChartYAxisRenderer: ChartAxisRendererBase
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i += 1)
+        for i in 0 ..< limitLines.count
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -65,7 +65,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         var positions = [CGPoint]()
         positions.reserveCapacity(yAxis.entries.count)
         
-        for (var i = 0; i < yAxis.entries.count; i++)
+        for (var i = 0; i < yAxis.entries.count; i += 1)
         {
             positions.append(CGPoint(x: CGFloat(yAxis.entries[i]), y: 0.0))
         }
@@ -162,7 +162,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         let labelFont = yAxis.labelFont
         let labelTextColor = yAxis.labelTextColor
         
-        for (var i = 0; i < yAxis.entryCount; i++)
+        for (var i = 0; i < yAxis.entryCount; i += 1)
         {
             let text = yAxis.getFormattedLabel(i)
             
@@ -206,7 +206,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
             }
             
             // draw the horizontal grid
-            for (var i = 0; i < yAxis.entryCount; i++)
+            for (var i = 0; i < yAxis.entryCount; i += 1)
             {
                 position.x = CGFloat(yAxis.entries[i])
                 position.y = 0.0
@@ -255,7 +255,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i++)
+        for (var i = 0; i < limitLines.count; i += 1)
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -27,8 +27,10 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// Computes the axis values.
-    public override func computeAxis(var yMin yMin: Double, var yMax: Double)
+    public override func computeAxis(yMin yMin: Double, yMax: Double)
     {
+        var yMinVar = yMin
+        var yMaxVar = yMax
         guard let yAxis = yAxis else { return }
         
         // calculate the starting and entry point of the y-labels (depending on zoom / contentrect bounds)
@@ -39,17 +41,17 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
             
             if (!yAxis.isInverted)
             {
-                yMin = Double(p1.x)
-                yMax = Double(p2.x)
+                yMinVar = Double(p1.x)
+                yMaxVar = Double(p2.x)
             }
             else
             {
-                yMin = Double(p2.x)
-                yMax = Double(p1.x)
+                yMinVar = Double(p2.x)
+                yMaxVar = Double(p1.x)
             }
         }
         
-        computeAxisValues(min: yMin, max: yMax)
+        computeAxisValues(min: yMinVar, max: yMaxVar)
     }
 
     /// draws the y-axis labels to the screen

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -65,7 +65,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         var positions = [CGPoint]()
         positions.reserveCapacity(yAxis.entries.count)
         
-        for (var i = 0; i < yAxis.entries.count; i += 1)
+        for i in 0 ..< yAxis.entries.count
         {
             positions.append(CGPoint(x: CGFloat(yAxis.entries[i]), y: 0.0))
         }
@@ -162,7 +162,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         let labelFont = yAxis.labelFont
         let labelTextColor = yAxis.labelTextColor
         
-        for (var i = 0; i < yAxis.entryCount; i += 1)
+        for i in 0 ..< yAxis.entryCount
         {
             let text = yAxis.getFormattedLabel(i)
             
@@ -206,7 +206,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
             }
             
             // draw the horizontal grid
-            for (var i = 0; i < yAxis.entryCount; i += 1)
+            for i in 0 ..< yAxis.entryCount
             {
                 position.x = CGFloat(yAxis.entries[i])
                 position.y = 0.0
@@ -255,7 +255,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         
         var position = CGPoint(x: 0.0, y: 0.0)
         
-        for (var i = 0; i < limitLines.count; i += 1)
+        for i in 0 ..< limitLines.count
         {
             let l = limitLines[i]
             

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -78,7 +78,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             var v = yMin
             
-            for (var i = 0; i < labelCount; i++)
+            for (var i = 0; i < labelCount; i += 1)
             {
                 yAxis.entries.append(v)
                 v += step
@@ -119,7 +119,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
                 var n = 0
                 for (f = first; f <= last; f += interval)
                 {
-                    ++n
+                     n += 1
                 }
                 
                 if (isnan(yAxis.customAxisMax))
@@ -133,7 +133,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
                     yAxis.entries = [Double](count: n, repeatedValue: 0.0)
                 }
                 
-                for (f = first, i = 0; i < n; f += interval, ++i)
+                for (f = first, i = 0; i < n; f += interval, i += 1)
                 {
                     yAxis.entries[i] = Double(f)
                 }
@@ -172,7 +172,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         
         let labelLineHeight = yAxis.labelFont.lineHeight
         
-        for (var j = 0; j < labelCount; j++)
+        for (var j = 0; j < labelCount; j += 1)
         {
             if (j == labelCount - 1 && yAxis.isDrawTopYLabelEntryEnabled == false)
             {
@@ -212,7 +212,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         
         let center = chart.centerOffsets
         
-        for (var i = 0; i < limitLines.count; i++)
+        for (var i = 0; i < limitLines.count; i += 1)
         {
             let l = limitLines[i]
             
@@ -236,7 +236,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             CGContextBeginPath(context)
             
-            for (var j = 0, count = chart.data!.xValCount; j < count; j++)
+            for (var j = 0, count = chart.data!.xValCount; j < count; j += 1)
             {
                 let p = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(j) + chart.rotationAngle)
                 

--- a/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererRadarChart.swift
@@ -78,7 +78,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             var v = yMin
             
-            for (var i = 0; i < labelCount; i += 1)
+            for _ in 0 ..< labelCount
             {
                 yAxis.entries.append(v)
                 v += step
@@ -114,10 +114,8 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
                 
                 let last = ChartUtils.nextUp(floor(Double(yMax) / interval) * interval)
                 
-                var f: Double
-                var i: Int
                 var n = 0
-                for (f = first; f <= last; f += interval)
+                for _ in first.stride(through: last, by: interval)
                 {
                      n += 1
                 }
@@ -133,9 +131,11 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
                     yAxis.entries = [Double](count: n, repeatedValue: 0.0)
                 }
                 
-                for (f = first, i = 0; i < n; f += interval, i += 1)
+                var f: Double = first
+                for i in 0 ..< n
                 {
                     yAxis.entries[i] = Double(f)
+                    f += interval
                 }
             }
         }
@@ -172,7 +172,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         
         let labelLineHeight = yAxis.labelFont.lineHeight
         
-        for (var j = 0; j < labelCount; j += 1)
+        for j in 0 ..< labelCount
         {
             if (j == labelCount - 1 && yAxis.isDrawTopYLabelEntryEnabled == false)
             {
@@ -212,7 +212,7 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
         
         let center = chart.centerOffsets
         
-        for (var i = 0; i < limitLines.count; i += 1)
+        for i in 0 ..< limitLines.count
         {
             let l = limitLines[i]
             
@@ -236,7 +236,8 @@ public class ChartYAxisRendererRadarChart: ChartYAxisRenderer
             
             CGContextBeginPath(context)
             
-            for (var j = 0, count = chart.data!.xValCount; j < count; j += 1)
+            let count = chart.data!.xValCount
+            for j in 0 ..< count
             {
                 let p = ChartUtils.getPosition(center: center, dist: r, angle: sliceangle * CGFloat(j) + chart.rotationAngle)
                 

--- a/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
+++ b/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
@@ -53,7 +53,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         var y: Double
         
         // do the drawing
-        for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j++)
+        for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
         {
             guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
             
@@ -158,7 +158,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 }
                 
                 // fill the stack
-                for (var k = 0; k < vals.count; k++)
+                for (var k = 0; k < vals.count; k += 1)
                 {
                     let value = vals[k]
                     
@@ -260,7 +260,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
             var posOffset: CGFloat
             var negOffset: CGFloat
             
-            for (var dataSetIndex = 0, count = barData.dataSetCount; dataSetIndex < count; dataSetIndex++)
+            for (var dataSetIndex = 0, count = barData.dataSetCount; dataSetIndex < count; dataSetIndex += 1)
             {
                 guard let dataSet = dataSets[dataSetIndex] as? IBarChartDataSet else { continue }
                 
@@ -285,7 +285,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 // if only single values are drawn (sum)
                 if (!dataSet.isStacked)
                 {
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j++)
+                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -334,7 +334,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 {
                     // if each value of a potential stack should be drawn
                     
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j++)
+                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -391,7 +391,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                             var posY = 0.0
                             var negY = -e.negativeSum
                             
-                            for (var k = 0; k < vals.count; k++)
+                            for (var k = 0; k < vals.count; k += 1)
                             {
                                 let value = vals[k]
                                 var y: Double
@@ -412,7 +412,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                             
                             trans.pointValuesToPixel(&transformed)
                             
-                            for (var k = 0; k < transformed.count; k++)
+                            for (var k = 0; k < transformed.count; k += 1)
                             {
                                 let val = vals[k]
                                 let valueText = formatter.stringFromNumber(val)!

--- a/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
+++ b/Charts/Classes/Renderers/HorizontalBarChartRenderer.swift
@@ -53,7 +53,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
         var y: Double
         
         // do the drawing
-        for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
+        let count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX))
+        for j in 0 ..< count
         {
             guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
             
@@ -158,7 +159,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 }
                 
                 // fill the stack
-                for (var k = 0; k < vals.count; k += 1)
+                for k in 0 ..< vals.count
                 {
                     let value = vals[k]
                     
@@ -260,7 +261,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
             var posOffset: CGFloat
             var negOffset: CGFloat
             
-            for (var dataSetIndex = 0, count = barData.dataSetCount; dataSetIndex < count; dataSetIndex += 1)
+            let count = barData.dataSetCount
+            for dataSetIndex in 0 ..< count
             {
                 guard let dataSet = dataSets[dataSetIndex] as? IBarChartDataSet else { continue }
                 
@@ -285,7 +287,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 // if only single values are drawn (sum)
                 if (!dataSet.isStacked)
                 {
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
+                    let count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX))
+                    for j in 0 ..< count
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -334,7 +337,8 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                 {
                     // if each value of a potential stack should be drawn
                     
-                    for (var j = 0, count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX)); j < count; j += 1)
+                    let count = Int(ceil(CGFloat(dataSet.entryCount) * animator.phaseX))
+                    for j in 0 ..< count
                     {
                         guard let e = dataSet.entryForIndex(j) as? BarChartDataEntry else { continue }
                         
@@ -391,7 +395,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                             var posY = 0.0
                             var negY = -e.negativeSum
                             
-                            for (var k = 0; k < vals.count; k += 1)
+                            for k in 0 ..< vals.count
                             {
                                 let value = vals[k]
                                 var y: Double
@@ -412,7 +416,7 @@ public class HorizontalBarChartRenderer: BarChartRenderer
                             
                             trans.pointValuesToPixel(&transformed)
                             
-                            for (var k = 0; k < transformed.count; k += 1)
+                            for k in 0 ..< transformed.count
                             {
                                 let val = vals[k]
                                 let valueText = formatter.stringFromNumber(val)!

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -34,7 +34,7 @@ public class LineChartRenderer: LineRadarChartRenderer
     {
         guard let lineData = dataProvider?.lineData else { return }
         
-        for (var i = 0; i < lineData.dataSetCount; i++)
+        for (var i = 0; i < lineData.dataSetCount; i += 1)
         {
             guard let set = lineData.getDataSetByIndex(i) else { continue }
             
@@ -134,7 +134,7 @@ public class LineChartRenderer: LineRadarChartRenderer
             // let the spline start
             CGPathMoveToPoint(cubicPath, &valueToPixelMatrix, CGFloat(cur.xIndex), CGFloat(cur.value) * phaseY)
             
-            for (var j = minx + 1, count = min(size, entryCount - 1); j < count; j++)
+            for (var j = minx + 1, count = min(size, entryCount - 1); j < count; j += 1)
             {
                 prevPrev = prev
                 prev = cur
@@ -267,7 +267,7 @@ public class LineChartRenderer: LineRadarChartRenderer
                 _lineSegments = [CGPoint](count: pointsPerEntryPair, repeatedValue: CGPoint())
             }
             
-            for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
+            for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
             {
                 if (count > 1 && j == count - 1)
                 { // Last point, we have already drawn a line to this point
@@ -343,38 +343,42 @@ public class LineChartRenderer: LineRadarChartRenderer
             {
                 let count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx)))
                 
-                for (var x = count > 1 ? minx + 1 : minx, j = 0; x < count; x++)
+                for (var x = count > 1 ? minx + 1 : minx, j = 0; x < count; x += 1)
                 {
                     e1 = dataSet.entryForIndex(x == 0 ? 0 : (x - 1))
                     e2 = dataSet.entryForIndex(x)
                     
                     if e1 == nil || e2 == nil { continue }
                     
-                    _lineSegments[j++] = CGPointApplyAffineTransform(
+                    _lineSegments[j] = CGPointApplyAffineTransform(
                         CGPoint(
                             x: CGFloat(e1.xIndex),
                             y: CGFloat(e1.value) * phaseY
                         ), valueToPixelMatrix)
+                    j += 1
                     
                     if isDrawSteppedEnabled
                     {
-                        _lineSegments[j++] = CGPointApplyAffineTransform(
+                        _lineSegments[j] = CGPointApplyAffineTransform(
                             CGPoint(
                                 x: CGFloat(e2.xIndex),
                                 y: CGFloat(e1.value) * phaseY
                             ), valueToPixelMatrix)
-                        _lineSegments[j++] = CGPointApplyAffineTransform(
+                        j += 1
+                        _lineSegments[j] = CGPointApplyAffineTransform(
                             CGPoint(
                                 x: CGFloat(e2.xIndex),
                                 y: CGFloat(e1.value) * phaseY
                             ), valueToPixelMatrix)
+                        j += 1
                     }
                     
-                    _lineSegments[j++] = CGPointApplyAffineTransform(
+                    _lineSegments[j] = CGPointApplyAffineTransform(
                         CGPoint(
                             x: CGFloat(e2.xIndex),
                             y: CGFloat(e2.value) * phaseY
                         ), valueToPixelMatrix)
+                    j += 1
                 }
                 
                 let size = max((count - minx - 1) * pointsPerEntryPair, pointsPerEntryPair)
@@ -432,7 +436,7 @@ public class LineChartRenderer: LineRadarChartRenderer
         }
         
         // create a new path
-        for (var x = from + 1, count = Int(ceil(CGFloat(to - from) * phaseX + CGFloat(from))); x < count; x++)
+        for (var x = from + 1, count = Int(ceil(CGFloat(to - from) * phaseX + CGFloat(from))); x < count; x += 1)
         {
             guard let e = dataSet.entryForIndex(x) else { continue }
             
@@ -473,7 +477,7 @@ public class LineChartRenderer: LineRadarChartRenderer
             
             var pt = CGPoint()
             
-            for (var i = 0; i < dataSets.count; i++)
+            for (var i = 0; i < dataSets.count; i += 1)
             {
                 guard let dataSet = dataSets[i] as? ILineChartDataSet else { continue }
                 
@@ -508,7 +512,7 @@ public class LineChartRenderer: LineRadarChartRenderer
                 let minx = max(dataSet.entryIndex(entry: entryFrom) - diff, 0)
                 let maxx = min(max(minx + 2, dataSet.entryIndex(entry: entryTo) + 1), entryCount)
                 
-                for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
+                for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
                 {
                     guard let e = dataSet.entryForIndex(j) else { break }
                     
@@ -561,7 +565,7 @@ public class LineChartRenderer: LineRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var i = 0, count = dataSets.count; i < count; i++)
+        for (var i = 0, count = dataSets.count; i < count; i += 1)
         {
             guard let dataSet = lineData.getDataSetByIndex(i) as? ILineChartDataSet else { continue }
             
@@ -590,7 +594,7 @@ public class LineChartRenderer: LineRadarChartRenderer
             let minx = max(dataSet.entryIndex(entry: entryFrom) - diff, 0)
             let maxx = min(max(minx + 2, dataSet.entryIndex(entry: entryTo) + 1), entryCount)
             
-            for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j++)
+            for (var j = minx, count = Int(ceil(CGFloat(maxx - minx) * phaseX + CGFloat(minx))); j < count; j += 1)
             {
                 guard let e = dataSet.entryForIndex(j) else { break }
 
@@ -645,7 +649,7 @@ public class LineChartRenderer: LineRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var i = 0; i < indices.count; i++)
+        for (var i = 0; i < indices.count; i += 1)
         {
             guard let set = lineData.getDataSetByIndex(indices[i].dataSetIndex) as? ILineChartDataSet else { continue }
             

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -428,8 +428,9 @@ public class LineChartRenderer: LineRadarChartRenderer
     }
     
     /// Generates the path that is used for filled drawing.
-    private func generateFilledPath(dataSet dataSet: ILineChartDataSet, fillMin: CGFloat, from: Int, to: Int, var matrix: CGAffineTransform) -> CGPath
+    private func generateFilledPath(dataSet dataSet: ILineChartDataSet, fillMin: CGFloat, from: Int, to: Int, matrix: CGAffineTransform) -> CGPath
     {
+        var matrixVar = matrix
         let phaseX = animator?.phaseX ?? 1.0
         let phaseY = animator?.phaseY ?? 1.0
         let isDrawSteppedEnabled = dataSet.isDrawSteppedEnabled
@@ -441,8 +442,8 @@ public class LineChartRenderer: LineRadarChartRenderer
         e = dataSet.entryForIndex(from)
         if e != nil
         {
-            CGPathMoveToPoint(filled, &matrix, CGFloat(e.xIndex), fillMin)
-            CGPathAddLineToPoint(filled, &matrix, CGFloat(e.xIndex), CGFloat(e.value) * phaseY)
+            CGPathMoveToPoint(filled, &matrixVar, CGFloat(e.xIndex), fillMin)
+            CGPathAddLineToPoint(filled, &matrixVar, CGFloat(e.xIndex), CGFloat(e.value) * phaseY)
         }
         
         // create a new path
@@ -455,10 +456,10 @@ public class LineChartRenderer: LineRadarChartRenderer
                 if isDrawSteppedEnabled
                 {
                     guard let ePrev = dataSet.entryForIndex(x-1) else { continue }
-                    CGPathAddLineToPoint(filled, &matrix, CGFloat(e.xIndex), CGFloat(ePrev.value) * phaseY)
+                    CGPathAddLineToPoint(filled, &matrixVar, CGFloat(e.xIndex), CGFloat(ePrev.value) * phaseY)
                 }
                 
-                CGPathAddLineToPoint(filled, &matrix, CGFloat(e.xIndex), CGFloat(e.value) * phaseY)
+                CGPathAddLineToPoint(filled, &matrixVar, CGFloat(e.xIndex), CGFloat(e.value) * phaseY)
             }
         }
         
@@ -466,7 +467,7 @@ public class LineChartRenderer: LineRadarChartRenderer
         e = dataSet.entryForIndex(max(min(Int(ceil(CGFloat(to - from) * phaseX + CGFloat(from))) - 1, dataSet.entryCount - 1), 0))
         if e != nil
         {
-            CGPathAddLineToPoint(filled, &matrix, CGFloat(e.xIndex), fillMin)
+            CGPathAddLineToPoint(filled, &matrixVar, CGFloat(e.xIndex), fillMin)
         }
         CGPathCloseSubpath(filled)
         

--- a/Charts/Classes/Renderers/PieChartRenderer.swift
+++ b/Charts/Classes/Renderers/PieChartRenderer.swift
@@ -111,12 +111,12 @@ public class PieChartRenderer: ChartDataRendererBase
         let userInnerRadius = drawInnerArc ? radius * chart.holeRadiusPercent : 0.0
         
         var visibleAngleCount = 0
-        for (var j = 0; j < entryCount; j++)
+        for (var j = 0; j < entryCount; j += 1)
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
             if ((abs(e.value) > 0.000001))
             {
-                visibleAngleCount++;
+                visibleAngleCount += 1;
             }
         }
         
@@ -124,7 +124,7 @@ public class PieChartRenderer: ChartDataRendererBase
 
         CGContextSaveGState(context)
         
-        for (var j = 0; j < entryCount; j++)
+        for (var j = 0; j < entryCount; j += 1)
         {
             let sliceAngle = drawAngles[j]
             var innerRadius = userInnerRadius
@@ -302,7 +302,7 @@ public class PieChartRenderer: ChartDataRendererBase
         var angle: CGFloat = 0.0
         var xIndex = 0
         
-        for (var i = 0; i < dataSets.count; i++)
+        for (var i = 0; i < dataSets.count; i += 1)
         {
             guard let dataSet = dataSets[i] as? IPieChartDataSet else { continue }
             
@@ -317,7 +317,7 @@ public class PieChartRenderer: ChartDataRendererBase
             
             guard let formatter = dataSet.valueFormatter else { continue }
             
-            for (var j = 0, entryCount = dataSet.entryCount; j < entryCount; j++)
+            for (var j = 0, entryCount = dataSet.entryCount; j < entryCount; j += 1)
             {
                 if (drawXVals && !drawYVals && (j >= data.xValCount || data.xVals[j] == nil))
                 {
@@ -402,7 +402,7 @@ public class PieChartRenderer: ChartDataRendererBase
                     )
                 }
                 
-                xIndex++
+                xIndex += 1
             }
         }
     }
@@ -535,7 +535,7 @@ public class PieChartRenderer: ChartDataRendererBase
         let drawInnerArc = chart.drawHoleEnabled && !chart.drawSlicesUnderHoleEnabled
         let userInnerRadius = drawInnerArc ? radius * chart.holeRadiusPercent : 0.0
         
-        for (var i = 0; i < indices.count; i++)
+        for (var i = 0; i < indices.count; i += 1)
         {
             // get the index to highlight
             let xIndex = indices[i].xIndex
@@ -553,12 +553,12 @@ public class PieChartRenderer: ChartDataRendererBase
             
             let entryCount = set.entryCount
             var visibleAngleCount = 0
-            for (var j = 0; j < entryCount; j++)
+            for (var j = 0; j < entryCount; j += 1)
             {
                 guard let e = set.entryForIndex(j) else { continue }
                 if ((abs(e.value) > 0.000001))
                 {
-                    visibleAngleCount++;
+                    visibleAngleCount += 1;
                 }
             }
             

--- a/Charts/Classes/Renderers/PieChartRenderer.swift
+++ b/Charts/Classes/Renderers/PieChartRenderer.swift
@@ -111,7 +111,7 @@ public class PieChartRenderer: ChartDataRendererBase
         let userInnerRadius = drawInnerArc ? radius * chart.holeRadiusPercent : 0.0
         
         var visibleAngleCount = 0
-        for (var j = 0; j < entryCount; j += 1)
+        for j in 0 ..< entryCount
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
             if ((abs(e.value) > 0.000001))
@@ -124,7 +124,7 @@ public class PieChartRenderer: ChartDataRendererBase
 
         CGContextSaveGState(context)
         
-        for (var j = 0; j < entryCount; j += 1)
+        for j in 0 ..< entryCount
         {
             let sliceAngle = drawAngles[j]
             var innerRadius = userInnerRadius
@@ -302,7 +302,7 @@ public class PieChartRenderer: ChartDataRendererBase
         var angle: CGFloat = 0.0
         var xIndex = 0
         
-        for (var i = 0; i < dataSets.count; i += 1)
+        for i in 0 ..< dataSets.count
         {
             guard let dataSet = dataSets[i] as? IPieChartDataSet else { continue }
             
@@ -317,7 +317,8 @@ public class PieChartRenderer: ChartDataRendererBase
             
             guard let formatter = dataSet.valueFormatter else { continue }
             
-            for (var j = 0, entryCount = dataSet.entryCount; j < entryCount; j += 1)
+            let entryCount = dataSet.entryCount
+            for j in 0 ..< entryCount
             {
                 if (drawXVals && !drawYVals && (j >= data.xValCount || data.xVals[j] == nil))
                 {
@@ -535,7 +536,7 @@ public class PieChartRenderer: ChartDataRendererBase
         let drawInnerArc = chart.drawHoleEnabled && !chart.drawSlicesUnderHoleEnabled
         let userInnerRadius = drawInnerArc ? radius * chart.holeRadiusPercent : 0.0
         
-        for (var i = 0; i < indices.count; i += 1)
+        for i in 0 ..< indices.count
         {
             // get the index to highlight
             let xIndex = indices[i].xIndex
@@ -553,7 +554,7 @@ public class PieChartRenderer: ChartDataRendererBase
             
             let entryCount = set.entryCount
             var visibleAngleCount = 0
-            for (var j = 0; j < entryCount; j += 1)
+            for j in 0 ..< entryCount
             {
                 guard let e = set.entryForIndex(j) else { continue }
                 if ((abs(e.value) > 0.000001))

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -85,7 +85,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
         let path = CGPathCreateMutable()
         var hasMovedToPoint = false
         
-        for (var j = 0; j < entryCount; j++)
+        for (var j = 0; j < entryCount; j += 1)
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
             
@@ -167,7 +167,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let yoffset = CGFloat(5.0)
         
-        for (var i = 0, count = data.dataSetCount; i < count; i++)
+        for (var i = 0, count = data.dataSetCount; i < count; i += 1)
         {
             let dataSet = data.getDataSetByIndex(i) as! IRadarChartDataSet
             
@@ -178,7 +178,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
             
             let entryCount = dataSet.entryCount
             
-            for (var j = 0; j < entryCount; j++)
+            for (var j = 0; j < entryCount; j += 1)
             {
                 guard let e = dataSet.entryForIndex(j) else { continue }
                 
@@ -257,9 +257,9 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let labelCount = chart.yAxis.entryCount
         
-        for (var j = 0; j < labelCount; j++)
+        for (var j = 0; j < labelCount; j += 1)
         {
-            for (var i = 0, xValCount = data.xValCount; i < xValCount; i++)
+            for (var i = 0, xValCount = data.xValCount; i < xValCount; i += 1)
             {
                 let r = CGFloat(chart.yAxis.entries[j] - chart.chartYMin) * factor
 
@@ -307,7 +307,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let center = chart.centerOffsets
         
-        for (var i = 0; i < indices.count; i++)
+        for (var i = 0; i < indices.count; i += 1)
         {
             guard let set = chart.data?.getDataSetByIndex(indices[i].dataSetIndex) as? IRadarChartDataSet else { continue }
             

--- a/Charts/Classes/Renderers/RadarChartRenderer.swift
+++ b/Charts/Classes/Renderers/RadarChartRenderer.swift
@@ -85,7 +85,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
         let path = CGPathCreateMutable()
         var hasMovedToPoint = false
         
-        for (var j = 0; j < entryCount; j += 1)
+        for j in 0 ..< entryCount
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
             
@@ -167,7 +167,8 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let yoffset = CGFloat(5.0)
         
-        for (var i = 0, count = data.dataSetCount; i < count; i += 1)
+        let count = data.dataSetCount
+        for i in 0 ..< count
         {
             let dataSet = data.getDataSetByIndex(i) as! IRadarChartDataSet
             
@@ -178,7 +179,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
             
             let entryCount = dataSet.entryCount
             
-            for (var j = 0; j < entryCount; j += 1)
+            for j in 0 ..< entryCount
             {
                 guard let e = dataSet.entryForIndex(j) else { continue }
                 
@@ -235,7 +236,8 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let xIncrements = 1 + chart.skipWebLineCount
         
-        for var i = 0, xValCount = data.xValCount; i < xValCount; i += xIncrements
+        let xValCount = data.xValCount
+        for i in 0.stride(to: xValCount, by: xIncrements)
         {
             let p = ChartUtils.getPosition(
                 center: center,
@@ -257,9 +259,10 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let labelCount = chart.yAxis.entryCount
         
-        for (var j = 0; j < labelCount; j += 1)
+        for j in 0 ..< labelCount
         {
-            for (var i = 0, xValCount = data.xValCount; i < xValCount; i += 1)
+            let xValCount = data.xValCount
+            for i in 0 ..< xValCount
             {
                 let r = CGFloat(chart.yAxis.entries[j] - chart.chartYMin) * factor
 
@@ -307,7 +310,7 @@ public class RadarChartRenderer: LineRadarChartRenderer
         
         let center = chart.centerOffsets
         
-        for (var i = 0; i < indices.count; i += 1)
+        for i in 0 ..< indices.count
         {
             guard let set = chart.data?.getDataSetByIndex(indices[i].dataSetIndex) as? IRadarChartDataSet else { continue }
             

--- a/Charts/Classes/Renderers/ScatterChartRenderer.swift
+++ b/Charts/Classes/Renderers/ScatterChartRenderer.swift
@@ -34,7 +34,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
     {
         guard let scatterData = dataProvider?.scatterData else { return }
         
-        for (var i = 0; i < scatterData.dataSetCount; i++)
+        for (var i = 0; i < scatterData.dataSetCount; i += 1)
         {
             guard let set = scatterData.getDataSetByIndex(i) else { continue }
             
@@ -81,7 +81,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var j = 0, count = Int(min(ceil(CGFloat(entryCount) * animator.phaseX), CGFloat(entryCount))); j < count; j++)
+        for (var j = 0, count = Int(min(ceil(CGFloat(entryCount) * animator.phaseX), CGFloat(entryCount))); j < count; j += 1)
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
             
@@ -279,7 +279,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
             
             var pt = CGPoint()
             
-            for (var i = 0; i < scatterData.dataSetCount; i++)
+            for (var i = 0; i < scatterData.dataSetCount; i += 1)
             {
                 let dataSet = dataSets[i]
                 
@@ -300,7 +300,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
                 let shapeSize = dataSet.scatterShapeSize
                 let lineHeight = valueFont.lineHeight
                 
-                for (var j = 0, count = Int(ceil(CGFloat(entryCount) * phaseX)); j < count; j++)
+                for (var j = 0, count = Int(ceil(CGFloat(entryCount) * phaseX)); j < count; j += 1)
                 {
                     guard let e = dataSet.entryForIndex(j) else { break }
                     
@@ -355,7 +355,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var i = 0; i < indices.count; i++)
+        for (var i = 0; i < indices.count; i += 1)
         {
             guard let set = scatterData.getDataSetByIndex(indices[i].dataSetIndex) as? IScatterChartDataSet else { continue }
             

--- a/Charts/Classes/Renderers/ScatterChartRenderer.swift
+++ b/Charts/Classes/Renderers/ScatterChartRenderer.swift
@@ -34,7 +34,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
     {
         guard let scatterData = dataProvider?.scatterData else { return }
         
-        for (var i = 0; i < scatterData.dataSetCount; i += 1)
+        for i in 0 ..< scatterData.dataSetCount
         {
             guard let set = scatterData.getDataSetByIndex(i) else { continue }
             
@@ -81,7 +81,8 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var j = 0, count = Int(min(ceil(CGFloat(entryCount) * animator.phaseX), CGFloat(entryCount))); j < count; j += 1)
+        let count = Int(min(ceil(CGFloat(entryCount) * animator.phaseX), CGFloat(entryCount)))
+        for j in 0 ..< count
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
             
@@ -279,7 +280,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
             
             var pt = CGPoint()
             
-            for (var i = 0; i < scatterData.dataSetCount; i += 1)
+            for i in 0 ..< scatterData.dataSetCount
             {
                 let dataSet = dataSets[i]
                 
@@ -300,7 +301,8 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
                 let shapeSize = dataSet.scatterShapeSize
                 let lineHeight = valueFont.lineHeight
                 
-                for (var j = 0, count = Int(ceil(CGFloat(entryCount) * phaseX)); j < count; j += 1)
+                let count = Int(ceil(CGFloat(entryCount) * phaseX))
+                for j in 0 ..< count
                 {
                     guard let e = dataSet.entryForIndex(j) else { break }
                     
@@ -355,7 +357,7 @@ public class ScatterChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        for (var i = 0; i < indices.count; i += 1)
+        for i in 0 ..< indices.count
         {
             guard let set = scatterData.getDataSetByIndex(indices[i].dataSetIndex) as? IScatterChartDataSet else { continue }
             

--- a/Charts/Classes/Utils/ChartTransformer.swift
+++ b/Charts/Classes/Utils/ChartTransformer.swift
@@ -104,7 +104,8 @@ public class ChartTransformer: NSObject
     public func pointValuesToPixel(inout pts: [CGPoint])
     {
         let trans = valueToPixelMatrix
-        for (var i = 0, count = pts.count; i < count; i += 1)
+        let count = pts.count
+        for i in 0 ..< count
         {
             pts[i] = CGPointApplyAffineTransform(pts[i], trans)
         }
@@ -158,7 +159,7 @@ public class ChartTransformer: NSObject
     {
         let trans = valueToPixelMatrix
         
-        for (var i = 0; i < rects.count; i += 1)
+        for i in 0 ..< rects.count
         {
             rects[i] = CGRectApplyAffineTransform(rects[i], trans)
         }
@@ -169,7 +170,7 @@ public class ChartTransformer: NSObject
     {
         let trans = pixelToValueMatrix
         
-        for (var i = 0; i < pixels.count; i += 1)
+        for i in 0 ..< pixels.count
         {
             pixels[i] = CGPointApplyAffineTransform(pixels[i], trans)
         }

--- a/Charts/Classes/Utils/ChartTransformer.swift
+++ b/Charts/Classes/Utils/ChartTransformer.swift
@@ -104,7 +104,7 @@ public class ChartTransformer: NSObject
     public func pointValuesToPixel(inout pts: [CGPoint])
     {
         let trans = valueToPixelMatrix
-        for (var i = 0, count = pts.count; i < count; i++)
+        for (var i = 0, count = pts.count; i < count; i += 1)
         {
             pts[i] = CGPointApplyAffineTransform(pts[i], trans)
         }
@@ -158,7 +158,7 @@ public class ChartTransformer: NSObject
     {
         let trans = valueToPixelMatrix
         
-        for (var i = 0; i < rects.count; i++)
+        for (var i = 0; i < rects.count; i += 1)
         {
             rects[i] = CGRectApplyAffineTransform(rects[i], trans)
         }
@@ -169,7 +169,7 @@ public class ChartTransformer: NSObject
     {
         let trans = pixelToValueMatrix
         
-        for (var i = 0; i < pixels.count; i++)
+        for (var i = 0; i < pixels.count; i += 1)
         {
             pixels[i] = CGPointApplyAffineTransform(pixels[i], trans)
         }

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -124,20 +124,21 @@ public class ChartUtils
         )
     }
     
-    public class func drawText(context context: CGContext, text: String, var point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
+    public class func drawText(context context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
     {
+        var pointVar = point
         if (align == .Center)
         {
-            point.x -= text.sizeWithAttributes(attributes).width / 2.0
+            pointVar.x -= text.sizeWithAttributes(attributes).width / 2.0
         }
         else if (align == .Right)
         {
-            point.x -= text.sizeWithAttributes(attributes).width
+            pointVar.x -= text.sizeWithAttributes(attributes).width
         }
         
         NSUIGraphicsPushContext(context)
         
-        (text as NSString).drawAtPoint(point, withAttributes: attributes)
+        (text as NSString).drawAtPoint(pointVar, withAttributes: attributes)
         
         NSUIGraphicsPopContext()
     }
@@ -249,14 +250,15 @@ public class ChartUtils
     }
     
     /// - returns: an angle between 0.0 < 360.0 (not less than zero, less than 360)
-    internal class func normalizedAngleFromAngle(var angle: CGFloat) -> CGFloat
+    internal class func normalizedAngleFromAngle(angle: CGFloat) -> CGFloat
     {
-        while (angle < 0.0)
+        var angleVar = angle
+        while (angleVar < 0.0)
         {
-            angle += 360.0
+            angleVar += 360.0
         }
         
-        return angle % 360.0
+        return angleVar % 360.0
     }
     
     private class func generateDefaultValueFormatter() -> NSNumberFormatter

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -74,7 +74,7 @@ public class ChartUtils
         var index = -Int.max
         var distance = DBL_MAX
         
-        for (var i = 0; i < valsAtIndex.count; i++)
+        for (var i = 0; i < valsAtIndex.count; i += 1)
         {
             let sel = valsAtIndex[i]
             
@@ -97,7 +97,7 @@ public class ChartUtils
     {
         var distance = DBL_MAX
         
-        for (var i = 0, count = valsAtIndex.count; i < count; i++)
+        for (var i = 0, count = valsAtIndex.count; i < count; i += 1)
         {
             let sel = valsAtIndex[i]
             

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -74,7 +74,7 @@ public class ChartUtils
         var index = -Int.max
         var distance = DBL_MAX
         
-        for (var i = 0; i < valsAtIndex.count; i += 1)
+        for i in 0 ..< valsAtIndex.count
         {
             let sel = valsAtIndex[i]
             
@@ -97,7 +97,8 @@ public class ChartUtils
     {
         var distance = DBL_MAX
         
-        for (var i = 0, count = valsAtIndex.count; i < count; i += 1)
+        let count = valsAtIndex.count
+        for i in 0 ..< count
         {
             let sel = valsAtIndex[i]
             


### PR DESCRIPTION
I went through the codebase and replaced all increment operators, decrement operators, and C-style for loops with their recommended replacements in Swift 2.2. Since the mechanics of for-in loops are slightly different than those of C-style for loops (as a range a ..< b cannot be created such that a > b), I added conditions for the for loops in which that appeared necessary. A double check on those edge cases would be appreciated.

I refrained from upgrading selectors, as this would break compatibility with previous versions of Swift. I can create a request for those changes too if backward compatibility is not necessary.