### PR TITLE
fix line chart renderer crash: can't form range when end < start

### DIFF
--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -440,7 +440,7 @@ public class LineChartRenderer: LineRadarChartRenderer
         }
         
         // create a new path
-        for x in from + 1 ..< Int(ceil(CGFloat(to - from) * phaseX + CGFloat(from)))
+        for x in (from + 1).stride(to: Int(ceil(CGFloat(to - from) * phaseX + CGFloat(from))), by: 1)
         {
             guard let e = dataSet.entryForIndex(x) else { continue }
             


### PR DESCRIPTION
ChartsDemo will crash all the time for the Line Chart1 Chart view controller,
This PR fix the line chart renderer crash: `can't form range when end < start` while phaseX is 0 (from + 1 ..< from + 0 is crashing); use `stride` instead, seems stride can gracefully fail the loop

@danielgindi I clicked the charts demo one by one, seems others are good, but I'm not sure if any of the rest for loops will have similar issue. Let's fix what we met first.


