### PR TITLE
Make NSUIAccessibilityElement initializer public.

### DIFF
--- a/Source/Charts/Utils/Platform+Accessibility.swift
+++ b/Source/Charts/Utils/Platform+Accessibility.swift
@@ -33,7 +33,7 @@ open class NSUIAccessibilityElement: UIAccessibilityElement
         }
     }
 
-    override init(accessibilityContainer container: Any)
+    override public init(accessibilityContainer container: Any)
     {
         // We can force unwrap since all chart views are subclasses of UIView
         containerView = container as! UIView
@@ -164,7 +164,7 @@ open class NSUIAccessibilityElement: NSAccessibilityElement
         }
     }
 
-    init(accessibilityContainer container: Any)
+    public init(accessibilityContainer container: Any)
     {
         // We can force unwrap since all chart views are subclasses of NSView
         containerView = container as! NSView


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
When I create custom renderer with overriding LineChartRenderer, I can't create `NSUIAccessibilityElement` instance because its initializer is not public!
![image](https://user-images.githubusercontent.com/4150060/45736489-101e4b00-bc26-11e8-9bde-5426a408235e.png)

Furthermore, although `NSUIAccessibilityElement` is defined as open class, its subclass can create no instance.
![image](https://user-images.githubusercontent.com/4150060/45736795-f92c2880-bc26-11e8-87e1-ea185377aeed.png)

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
To be able to create `NSUIAccessibilityElement` instance outside Charts.framework.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
- Added `public` modifier to `NSUIAccessibilityElement.init(accessibilityContainer:)`.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
None, there are no specific tests.
This should not effect the snapshotting at all, and has no effect on the existing codebase.