### PR TITLE
Rounded bars in bar charts

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -148,7 +148,8 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
 
     /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     open var highlightAlpha = CGFloat(120.0 / 255.0)
-        
+    
+    /// The multiplier to generate a corner radius for the bar. 0.0 means no round radius.
     open var roundRadiusWidthMultiplier: CGFloat = 0.0
     
     // MARK: - NSCopying

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -148,6 +148,8 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
 
     /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     open var highlightAlpha = CGFloat(120.0 / 255.0)
+        
+    open var roundRadiusWidthMultiplier: CGFloat = 0.0
     
     // MARK: - NSCopying
     

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -528,6 +528,11 @@ extension ChartDataSet: RandomAccessCollection {
 
 // MARK: RangeReplaceableCollection
 extension ChartDataSet: RangeReplaceableCollection {
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Index>, with newElements: C) where C : Collection, Element == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
+        notifyDataSetChanged()
+    }
+    
     public func append(_ newElement: Element) {
         calcMinMax(entry: newElement)
         entries.append(newElement)

--- a/Source/Charts/Data/Interfaces/IBarChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IBarChartDataSet.swift
@@ -40,5 +40,6 @@ public protocol IBarChartDataSet: IBarLineScatterCandleBubbleChartDataSet
     /// array of labels used to describe the different values of the stacked bars
     var stackLabels: [String] { get set }
     
+    /// The multiplier to generate a corner radius for the bar. 0.0 means no round radius.
     var roundRadiusWidthMultiplier: CGFloat { get set }
 }

--- a/Source/Charts/Data/Interfaces/IBarChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IBarChartDataSet.swift
@@ -39,4 +39,6 @@ public protocol IBarChartDataSet: IBarLineScatterCandleBubbleChartDataSet
     
     /// array of labels used to describe the different values of the stacked bars
     var stackLabels: [String] { get set }
+    
+    var roundRadiusWidthMultiplier: CGFloat { get set }
 }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -431,7 +431,29 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            context.fill(barRect)
+            if dataSet.roundRadiusWidthMultiplier > 0.0, j % stackSize == stackSize - 1 {
+                var radius: CGFloat = barRect.width * dataSet.roundRadiusWidthMultiplier
+                if radius > barRect.height {
+                    radius = barRect.height * dataSet.roundRadiusWidthMultiplier
+                }
+                
+                let path = CGMutablePath()
+                path.move(to: CGPoint(x: barRect.minX, y: barRect.maxY))
+                path.addArc(tangent1End: CGPoint(x: barRect.minX, y: barRect.minY),
+                            tangent2End: CGPoint(x: barRect.maxX, y: barRect.minY),
+                            radius: radius)
+                path.addArc(tangent1End: CGPoint(x: barRect.maxX, y: barRect.minY),
+                            tangent2End: CGPoint(x: barRect.maxX, y: barRect.maxY),
+                            radius: radius)
+                path.addLine(to: CGPoint(x: barRect.maxX, y: barRect.maxY))
+                
+                context.addPath(path)
+                context.fillPath()
+            }
+            else {
+                context.fill(barRect)
+            }
+            
             
             if drawBorder
             {

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -411,6 +411,36 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         let isStacked = dataSet.isStacked
         let stackSize = isStacked ? dataSet.stackSize : 1
 
+        func getIndicesOfTopBar() -> Set<Int>
+        {
+            
+            if !(dataSet.roundRadiusWidthMultiplier > 0.0)
+            {
+                return Set()
+            }
+            
+            var indices = Set<Int>()
+            for i in stride(from: 0, to: buffer.rects.count, by: stackSize)
+            {
+                let rects = Array(buffer.rects[i...i+stackSize - 1])
+                
+                for index in (0..<rects.count).reversed()
+                {
+                    let rect = rects[index]
+                    
+                    if rect.height > 0 || index == 0
+                    {
+                        indices.insert(i + index)
+                        break
+                    }
+                }
+            }
+            
+            return indices
+        }
+        
+        let topRectIndices = Set(getIndicesOfTopBar())
+        
         for j in stride(from: 0, to: buffer.rects.count, by: 1)
         {
             let barRect = buffer.rects[j]
@@ -431,7 +461,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            if dataSet.roundRadiusWidthMultiplier > 0.0, j % stackSize == stackSize - 1 {
+            if topRectIndices.contains(j) {
                 var radius: CGFloat = barRect.width * dataSet.roundRadiusWidthMultiplier
                 if radius > barRect.height {
                     radius = barRect.height * dataSet.roundRadiusWidthMultiplier

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -869,7 +869,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 setHighlightDrawPos(highlight: high, barRect: barRect)
                 
-                if high.stackIndex == (e.yValues?.count ?? 0) - 1 {
+                if set.roundRadiusWidthMultiplier > 0.0 && (high.stackIndex == (e.yValues?.count ?? 0) - 1 || high.stackIndex == -1) {
                     drawRoundedBar(barRect: barRect, roundRadiusWidthMultiplier: set.roundRadiusWidthMultiplier, context: context)
                 }
                 else {

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -463,24 +463,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             
             if topRectIndices.contains(j)
             {
-                var radius: CGFloat = barRect.width * dataSet.roundRadiusWidthMultiplier
-                if radius > barRect.height, barRect.height > 0
-                {
-                    radius = barRect.height * 0.999
-                }
-                
-                let path = CGMutablePath()
-                path.move(to: CGPoint(x: barRect.minX, y: barRect.maxY))
-                path.addArc(tangent1End: CGPoint(x: barRect.minX, y: barRect.minY),
-                            tangent2End: CGPoint(x: barRect.maxX, y: barRect.minY),
-                            radius: radius)
-                path.addArc(tangent1End: CGPoint(x: barRect.maxX, y: barRect.minY),
-                            tangent2End: CGPoint(x: barRect.maxX, y: barRect.maxY),
-                            radius: radius)
-                path.addLine(to: CGPoint(x: barRect.maxX, y: barRect.maxY))
-                
-                context.addPath(path)
-                context.fillPath()
+                drawRoundedBar(barRect: barRect, roundRadiusWidthMultiplier: dataSet.roundRadiusWidthMultiplier, context: context)
             }
             else {
                 context.fill(barRect)
@@ -511,6 +494,27 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         }
         
         context.restoreGState()
+    }
+    
+    private func drawRoundedBar(barRect: CGRect, roundRadiusWidthMultiplier: CGFloat, context: CGContext) {
+        var radius: CGFloat = barRect.width * roundRadiusWidthMultiplier
+        if radius > barRect.height, barRect.height > 0
+        {
+            radius = barRect.height * 0.999
+        }
+
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: barRect.minX, y: barRect.maxY))
+        path.addArc(tangent1End: CGPoint(x: barRect.minX, y: barRect.minY),
+                    tangent2End: CGPoint(x: barRect.maxX, y: barRect.minY),
+                    radius: radius)
+        path.addArc(tangent1End: CGPoint(x: barRect.maxX, y: barRect.minY),
+                    tangent2End: CGPoint(x: barRect.maxX, y: barRect.maxY),
+                    radius: radius)
+        path.addLine(to: CGPoint(x: barRect.maxX, y: barRect.maxY))
+
+        context.addPath(path)
+        context.fillPath()
     }
     
     open func prepareBarHighlight(
@@ -865,7 +869,12 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 setHighlightDrawPos(highlight: high, barRect: barRect)
                 
-                context.fill(barRect)
+                if high.stackIndex == (e.yValues?.count ?? 0) - 1 {
+                    drawRoundedBar(barRect: barRect, roundRadiusWidthMultiplier: set.roundRadiusWidthMultiplier, context: context)
+                }
+                else {
+                    context.fill(barRect)
+                }
             }
         }
         

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -461,10 +461,12 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            if topRectIndices.contains(j) {
+            if topRectIndices.contains(j)
+            {
                 var radius: CGFloat = barRect.width * dataSet.roundRadiusWidthMultiplier
-                if radius > barRect.height {
-                    radius = barRect.height * dataSet.roundRadiusWidthMultiplier
+                if radius > barRect.height, barRect.height > 0
+                {
+                    radius = barRect.height * 0.999
                 }
                 
                 let path = CGMutablePath()


### PR DESCRIPTION
### Issue Link :link:

Other PR: https://github.com/danielgindi/Charts/pull/3754/

I understand that there are other attempts at this, but I am working on a project that requires this - so I forked this and gave it a shot with the latest master. 

### Goals :soccer:

Provide ability to round bar charts for charts that contain only positive values.

### Implementation Details :construction:

Pretty straightforward - provides a property to set the multiplier you wish to drive the corner radius - and the renderer searches for the correct bar segment to apply that to, and draws it with a path.
