### PR TITLE
#4968 - Added support for corner radius in bar chart

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -116,6 +116,9 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, BarChartData
     /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     open var highlightAlpha = CGFloat(120.0 / 255.0)
     
+    /// the value should create a radius in barchart. (0.0 no corner radius)
+    open var barCornerRadiusFactor: CGFloat = 0.0
+
     // MARK: - NSCopying
     
     open override func copy(with zone: NSZone? = nil) -> Any

--- a/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
@@ -33,6 +33,9 @@ public protocol BarChartDataSetProtocol: BarLineScatterCandleBubbleChartDataSetP
 
     /// the color drawing borders around the bars.
     var barBorderColor: NSUIColor { get set }
+  
+    /// the percentage of corner radius for each bar in chart
+    var barCornerRadiusFactor: CGFloat { get set }
 
     /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     var highlightAlpha: CGFloat { get set }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -349,9 +349,9 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             for barRect in buffer where viewPortHandler.isInBoundsLeft(barRect.origin.x + barRect.size.width)
             {
                 guard viewPortHandler.isInBoundsRight(barRect.origin.x) else { break }
-
-                context.setFillColor(dataSet.barShadowColor.cgColor)
-                context.fill(barRect)
+                let bezierPath = UIBezierPath(roundedRect: barRect, cornerRadius: barRect.width * dataSet.barCornerRadiusFactor)
+                context.addPath(bezierPath.cgPath)
+                context.drawPath(using: .fill)
             }
         }
         
@@ -379,7 +379,9 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            context.fill(barRect)
+            let bezierPath = UIBezierPath(roundedRect: barRect, cornerRadius: barRect.width * dataSet.barCornerRadiusFactor)
+            context.addPath(bezierPath.cgPath)
+            context.drawPath(using: .fill)
             
             if drawBorder
             {
@@ -743,8 +745,9 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 prepareBarHighlight(x: e.x, y1: y1, y2: y2, barWidthHalf: barData.barWidth / 2.0, trans: trans, rect: &barRect)
                 
                 setHighlightDrawPos(highlight: high, barRect: barRect)
-                
-                context.fill(barRect)
+                let bezierPath = UIBezierPath(roundedRect: barRect, cornerRadius: barRect.width * set.barCornerRadiusFactor)
+                context.addPath(bezierPath.cgPath)
+                context.drawPath(using: .fill)
             }
         }
     }


### PR DESCRIPTION
Added the barCornerRadiusFactor property in Dataset for barchat. If you set the value different from 0.0 the bars will have the round corners

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4968

### Goals :soccer:
Get the chance for drawing the corner in the bar when you use the Bar Chart

### Implementation Details :construction:
Create a property called `barCornerRadiusFactor`. We can set the factor for barWidth and create the appropriate corner in the bar

### Testing Details :mag:
for testing, you can set the value in the demo project and see the behavior